### PR TITLE
Password manager integration

### DIFF
--- a/src/LoginForm/LoginForm.js
+++ b/src/LoginForm/LoginForm.js
@@ -27,7 +27,7 @@ export default function LoginForm({ loading = false, onLogin = () => {} }) {
             fullWidth
             label="Email Address"
             name="email"
-            autoComplete="email"
+            autoComplete="username"
             autoFocus={!loading}
             inputProps={{ "aria-label": "email" }}
             inputRef={register({

--- a/src/RegistrationForm/RegistrationForm.js
+++ b/src/RegistrationForm/RegistrationForm.js
@@ -83,7 +83,7 @@ export default function RegistrationForm({
             fullWidth
             label="Email Address"
             name="email"
-            autoComplete="email"
+            autoComplete="username"
             inputProps={{ "aria-label": "email" }}
             inputRef={register({
               pattern: {


### PR DESCRIPTION
Fixes issue with password manager not always recognising username field when registering a new account, changing password when logged in or resetting password. Fix was actually a simple one in the end and just required autocomplete on the email fields to be set to username. Have tested all password components using Chrome & Edge password managers and now username (email address in our case) is correctly picked up.

Closes https://github.com/IPG-Automotive-UK/react-ui/issues/98