### PR TITLE
Add error prop to Select component

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -6,6 +6,7 @@ import React from "react";
  * Select components are used for collecting user provided information from a list of options.
  */
 export default function Select({
+  error = false,
   disabled = false,
   helperText,
   label,
@@ -23,7 +24,7 @@ export default function Select({
       select
       required={required}
       variant={variant}
-      error={required && !value}
+      error={error}
       margin={margin}
       fullWidth
       label={label}
@@ -48,6 +49,10 @@ Select.propTypes = {
    * If true, the label, input and helper text should be displayed in a disabled state.
    */
   disabled: PropTypes.bool,
+  /**
+   * If true, the component will display an error state.
+   */
+  error: PropTypes.bool,
   /**
    * Helper text to display below input.
    */

--- a/src/Select/Select.stories.js
+++ b/src/Select/Select.stories.js
@@ -21,6 +21,7 @@ const Template = args => {
 
 export const Default = Template.bind({});
 Default.args = {
+  error: false,
   helperText: "What is your selection going to be?",
   label: "Select an option",
   options: ["Option A", "Option B", "Option C"],

--- a/src/Select/Select.test.js
+++ b/src/Select/Select.test.js
@@ -42,10 +42,8 @@ describe("Select", () => {
     await selectMaterialUiSelectOption(container, value);
     expect(onChange).toHaveReturnedWith(value);
   });
-  test("shows error if no selection", () => {
-    const { container } = render(
-      <SelectWithState options={options} value="" required />
-    );
+  test("shows error state", () => {
+    const { container } = render(<SelectWithState error options={options} />);
     const inputBase = container.querySelector(".MuiInputBase-root");
     expect(inputBase).toHaveClass("Mui-error");
   });


### PR DESCRIPTION
Added new error prop to the Select componet so it can be controlled outside the component. Prior to this the component itself had some built-in logic to decide when to show the error state. This obviously isn't that useful if you want to control the error state yourself in an app (as I do).