### PR TITLE
add negative margin when accordion summary is expanded

### DIFF
--- a/src/ThemeProvider/ThemeProvider.js
+++ b/src/ThemeProvider/ThemeProvider.js
@@ -5,6 +5,11 @@ import React from "react";
 // custom material-ui theme
 const theme = createTheme({
   overrides: {
+    MuiAccordionSummary: {
+      root: {
+        "&$expanded": { marginBottom: -20 }
+      }
+    },
     MuiIconButton: { root: { color: "#9e9e9e" } },
     MuiTableRow: {
       root: {


### PR DESCRIPTION
Added some negative margin to reduce the whitespace when an accordion is expanded as noticed in https://github.com/IPG-Automotive-UK/ngd/pull/560

Before
![image](https://user-images.githubusercontent.com/8976377/130090743-704315b7-8414-4962-992d-e10d877cc5fc.png)

After
![image](https://user-images.githubusercontent.com/8976377/130090804-d855a851-38ee-49a3-9771-ed0b414303a2.png)
