### PR TITLE
Feature/hide sidebar logo version

### DIFF
--- a/src/Sidebar/Sidebar.js
+++ b/src/Sidebar/Sidebar.js
@@ -3,35 +3,45 @@ import PropTypes from "prop-types";
 import React from "react";
 
 // sidebar component for app which displays logo, list of items and app version
-function Sidebar({ logoSrc, children, appVersion }) {
+function Sidebar({
+  appVersion,
+  children,
+  logoSrc,
+  showLogo = true,
+  showVersion = true
+}) {
   // define components
   return (
     <>
-      <Box
-        sx={{
-          alignItems: "center",
-          color: theme => theme.palette.text.secondary,
-          display: "flex",
-          padding: theme => theme.spacing(2)
-        }}
-      >
-        {logoSrc && (
+      {showLogo ? (
+        <>
           <Box
             sx={{
-              height: 24,
-              marginRight: theme => theme.spacing(3),
-              width: 30
+              alignItems: "center",
+              color: theme => theme.palette.text.secondary,
+              display: "flex",
+              padding: theme => theme.spacing(2)
             }}
           >
-            <img src={logoSrc} />
+            {logoSrc && (
+              <Box
+                sx={{
+                  height: 24,
+                  marginRight: theme => theme.spacing(3),
+                  width: 30
+                }}
+              >
+                <img src={logoSrc} />
+              </Box>
+            )}
+            <Typography>IPG Automotive</Typography>
           </Box>
-        )}
-        <Typography>IPG Automotive</Typography>
-      </Box>
-      <Divider sx={{ margin: theme => theme.spacing(0, 0, 1, 0) }} />
+          <Divider sx={{ margin: theme => theme.spacing(0, 0, 1, 0) }} />
+        </>
+      ) : null}
       {children}
       <Box flexGrow={1} />
-      {appVersion && (
+      {showVersion ? (
         <Typography
           sx={{
             color: theme => theme.palette.text.secondary,
@@ -40,7 +50,7 @@ function Sidebar({ logoSrc, children, appVersion }) {
         >
           {appVersion}
         </Typography>
-      )}
+      ) : null}
     </>
   );
 }
@@ -57,7 +67,15 @@ Sidebar.propTypes = {
   /**
    * Image source for logo displayed at top of sidebar
    */
-  logoSrc: PropTypes.string
+  logoSrc: PropTypes.string,
+  /**
+   * Boolean to determine if logo should be displayed at the top of the sidebar
+   */
+  showLogo: PropTypes.bool,
+  /**
+   * Boolean to determine if version should be displayed at the bottom of the sidebar
+   */
+  showVersion: PropTypes.bool
 };
 
 export default Sidebar;

--- a/src/Sidebar/Sidebar.stories.js
+++ b/src/Sidebar/Sidebar.stories.js
@@ -1,3 +1,4 @@
+import { Home, Mail, Person, Settings } from "@mui/icons-material";
 import {
   Default as SidebarItemDefault,
   Disabled as SidebarItemDisabled,
@@ -23,15 +24,34 @@ const Template = args => (
       display: "flex",
       flexDirection: "column",
       minHeight: 500,
-      width: 240
+      width: args.width || 240
     }}
   >
     <Sidebar {...args} />
   </div>
 );
 
+// default story
 export const Default = Template.bind({});
 Default.args = {
+  appVersion: `v${version}`,
+  children: (
+    <>
+      <SidebarItem {...SidebarItemDefault.args} />
+      <SidebarItem {...SidebarItemSelected.args} />
+      <SidebarDivider />
+      <SidebarItem {...SidebarItemDisabled.args} />
+      <SidebarItem {...SidebarItemWithCount.args} />
+    </>
+  ),
+  logoSrc: "/ipgLogoNoText.png",
+  showLogo: true,
+  showVersion: true
+};
+
+// hidden logo story
+export const HiddenLogo = Template.bind({});
+HiddenLogo.args = {
   appVersion: `v${version}`,
   children: (
     <>
@@ -44,5 +64,59 @@ Default.args = {
       <SidebarItem {...SidebarItemNested.args} />
     </>
   ),
-  logoSrc: "/ipgLogoNoText.png"
+  showLogo: false,
+  showVersion: true
+};
+
+// hidden version story
+export const HiddenVersion = Template.bind({});
+HiddenVersion.args = {
+  children: (
+    <>
+      <SidebarItem {...SidebarItemDefault.args} />
+      <SidebarItem {...SidebarItemSelected.args} />
+      <SidebarDivider />
+      <SidebarItem {...SidebarItemDisabled.args} />
+      <SidebarItem {...SidebarItemWithCount.args} />
+      <SidebarDivider />
+      <SidebarItem {...SidebarItemNested.args} />
+    </>
+  ),
+  logoSrc: "/ipgLogoNoText.png",
+  showLogo: true,
+  showVersion: false
+};
+
+// items only story
+export const ItemsOnly = Template.bind({});
+ItemsOnly.args = {
+  children: (
+    <>
+      <SidebarItem {...SidebarItemDefault.args} />
+      <SidebarItem {...SidebarItemSelected.args} />
+      <SidebarDivider />
+      <SidebarItem {...SidebarItemDisabled.args} />
+      <SidebarItem {...SidebarItemWithCount.args} />
+      <SidebarDivider />
+      <SidebarItem {...SidebarItemNested.args} />
+    </>
+  ),
+  showLogo: false,
+  showVersion: false
+};
+
+// icons only story
+export const IconsOnly = Template.bind({});
+IconsOnly.args = {
+  children: (
+    <>
+      <SidebarItem icon={<Home />} />
+      <SidebarItem icon={<Mail />} selected />
+      <SidebarItem icon={<Person />} />
+      <SidebarItem icon={<Settings />} />
+    </>
+  ),
+  showLogo: false,
+  showVersion: false,
+  width: 60
 };

--- a/src/Sidebar/Sidebar.test.js
+++ b/src/Sidebar/Sidebar.test.js
@@ -7,14 +7,26 @@ describe("Sidebar", () => {
     render(<Sidebar>Child</Sidebar>);
     expect(screen.queryByText("Child")).toBeInTheDocument();
   });
-  it("renders app version", () => {
+  it("renders app version by default", () => {
     render(<Sidebar appVersion="v1.2.3" />);
     expect(screen.queryByText("v1.2.3")).toBeInTheDocument();
   });
-  it("renders icon", () => {
+  it("can hide app version", () => {
+    render(<Sidebar appVersion="v1.2.3" showVersion={false} />);
+    expect(screen.queryByText("v1.2.3")).not.toBeInTheDocument();
+  });
+  it("renders icon by default", () => {
     const { container } = render(<Sidebar logoSrc="/path/img.png" />);
     expect(
       container.querySelector("img[src='/path/img.png']")
     ).toBeInTheDocument();
+  });
+  it("can hide icon", () => {
+    const { container } = render(
+      <Sidebar logoSrc="/path/img.png" showLogo={false} />
+    );
+    expect(
+      container.querySelector("img[src='/path/img.png']")
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Added two new props to Sidebar component to allow the top logo and bottom version sections to be hidden. Existing default behaviour remains with them both shown.

Latest build can be tested here https://deploy-preview-256--ipguk-react-ui.netlify.app/?path=/story/layout-sidebar--default

![image](https://user-images.githubusercontent.com/8976377/140763905-ac91f314-125c-4e96-a433-375b67191c4b.png)

I've also added some new stories to show the different states sidebar can be in.

Should be reviewed after https://github.com/IPG-Automotive-UK/react-ui/pull/255 as it builds on it.