### PR TITLE
SidebarItem styling props

### DIFF
--- a/src/Sidebar/SidebarItem/SidebarItem.js
+++ b/src/Sidebar/SidebarItem/SidebarItem.js
@@ -19,10 +19,12 @@ export default function SidebarItem({
   count,
   disabled = false,
   icon,
+  iconStyle = {},
   initialOpen = false,
   name,
   onClick,
-  selected = false
+  selected = false,
+  textStyle = {}
 }) {
   // use styles
   const color = selected ? "primary" : "inherit";
@@ -53,10 +55,13 @@ export default function SidebarItem({
         disabled={disabled}
         className={className}
       >
-        <ListItemIcon>{React.cloneElement(icon, { color })}</ListItemIcon>
+        <ListItemIcon sx={iconStyle}>
+          {React.cloneElement(icon, { color })}
+        </ListItemIcon>
         <ListItemText
           primary={name}
           primaryTypographyProps={primaryTypographyProps}
+          sx={textStyle}
         />
         {count ? (
           <Badge
@@ -102,6 +107,10 @@ SidebarItem.propTypes = {
    */
   icon: PropTypes.element.isRequired,
   /**
+   * Custom style to apply to the icon
+   */
+  iconStyle: PropTypes.object,
+  /**
    * Initial open state of sidebar item with children
    */
   initialOpen: PropTypes.bool,
@@ -122,5 +131,9 @@ SidebarItem.propTypes = {
   /**
    * Use to apply selected styling.
    */
-  selected: PropTypes.bool
+  selected: PropTypes.bool,
+  /**
+   * Custom style to apply to the text
+   */
+  textStyle: PropTypes.object
 };

--- a/src/Sidebar/SidebarItem/SidebarItem.stories.js
+++ b/src/Sidebar/SidebarItem/SidebarItem.stories.js
@@ -19,6 +19,20 @@ const Template = args => <SidebarItem {...args} onClick={action("onClick")} />;
 export const Default = Template.bind({});
 Default.args = { icon: <Home />, name: "Home" };
 
+export const IconStyle = Template.bind({});
+IconStyle.args = {
+  icon: <Home />,
+  iconStyle: { border: "1px solid blue", minWidth: 20 },
+  name: "Home"
+};
+
+export const TextStyle = Template.bind({});
+TextStyle.args = {
+  icon: <Home />,
+  name: "Home",
+  textStyle: { border: "1px solid blue" }
+};
+
 export const Selected = Template.bind({});
 Selected.args = { icon: <Person />, name: "Profile", selected: true };
 


### PR DESCRIPTION
Added two new props to SidebarItem to allow custom styling to be passed in to the icon and text components. There are two new stories to show how to use them.