### PR TITLE
Font picker

### DIFF
--- a/src/Autocomplete/Autocomplete.stories.js
+++ b/src/Autocomplete/Autocomplete.stories.js
@@ -32,5 +32,6 @@ Default.args = {
   options: ["Apple", "Apricot", "Pear"],
   required: true,
   size: "medium",
+  value: "Apple",
   variant: "outlined"
 };

--- a/src/FontPicker/FontPicker.js
+++ b/src/FontPicker/FontPicker.js
@@ -196,7 +196,7 @@ export default function FontPicker({
   );
 }
 
-Autocomplete.propTypes = {
+FontPicker.propTypes = {
   /**
    * If true, the label, input and helper text should be displayed in a disabled state.
    */

--- a/src/FontPicker/FontPicker.js
+++ b/src/FontPicker/FontPicker.js
@@ -1,0 +1,246 @@
+import { Autocomplete, Box, TextField, Typography } from "@mui/material";
+import PropTypes from "prop-types";
+import React from "react";
+
+// default font options list
+const defaultFonts = new Set(
+  [
+    // Windows 10
+    "Arial",
+    "Arial Black",
+    "Bahnschrift",
+    "Calibri",
+    "Cambria",
+    "Cambria Math",
+    "Candara",
+    "Comic Sans MS",
+    "Consolas",
+    "Constantia",
+    "Corbel",
+    "Courier New",
+    "Ebrima",
+    "Franklin Gothic Medium",
+    "Gabriola",
+    "Gadugi",
+    "Georgia",
+    "HoloLens MDL2 Assets",
+    "Impact",
+    "Ink Free",
+    "Javanese Text",
+    "Leelawadee UI",
+    "Lucida Console",
+    "Lucida Sans Unicode",
+    "Malgun Gothic",
+    "Marlett",
+    "Microsoft Himalaya",
+    "Microsoft JhengHei",
+    "Microsoft New Tai Lue",
+    "Microsoft PhagsPa",
+    "Microsoft Sans Serif",
+    "Microsoft Tai Le",
+    "Microsoft YaHei",
+    "Microsoft Yi Baiti",
+    "MingLiU-ExtB",
+    "Mongolian Baiti",
+    "MS Gothic",
+    "MV Boli",
+    "Myanmar Text",
+    "Nirmala UI",
+    "Palatino Linotype",
+    "Segoe MDL2 Assets",
+    "Segoe Print",
+    "Segoe Script",
+    "Segoe UI",
+    "Segoe UI Historic",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "SimSun",
+    "Sitka",
+    "Sylfaen",
+    "Symbol",
+    "Tahoma",
+    "Times New Roman",
+    "Trebuchet MS",
+    "Verdana",
+    "Webdings",
+    "Wingdings",
+    "Yu Gothic",
+
+    // macOS
+    "American Typewriter",
+    "Andale Mono",
+    "Arial",
+    "Arial Black",
+    "Arial Narrow",
+    "Arial Rounded MT Bold",
+    "Arial Unicode MS",
+    "Avenir",
+    "Avenir Next",
+    "Avenir Next Condensed",
+    "Baskerville",
+    "Big Caslon",
+    "Bodoni 72",
+    "Bodoni 72 Oldstyle",
+    "Bodoni 72 Smallcaps",
+    "Bradley Hand",
+    "Brush Script MT",
+    "Chalkboard",
+    "Chalkboard SE",
+    "Chalkduster",
+    "Charter",
+    "Cochin",
+    "Comic Sans MS",
+    "Copperplate",
+    "Courier",
+    "Courier New",
+    "Didot",
+    "DIN Alternate",
+    "DIN Condensed",
+    "Futura",
+    "Geneva",
+    "Georgia",
+    "Gill Sans",
+    "Helvetica",
+    "Helvetica Neue",
+    "Herculanum",
+    "Hoefler Text",
+    "Impact",
+    "Lucida Grande",
+    "Luminari",
+    "Marker Felt",
+    "Menlo",
+    "Microsoft Sans Serif",
+    "Monaco",
+    "Noteworthy",
+    "Optima",
+    "Palatino",
+    "Papyrus",
+    "Phosphate",
+    "Rockwell",
+    "Savoye LET",
+    "SignPainter",
+    "Skia",
+    "Snell Roundhand",
+    "Tahoma",
+    "Times",
+    "Times New Roman",
+    "Trattatello",
+    "Trebuchet MS",
+    "Verdana",
+    "Zapfino"
+  ].sort()
+);
+
+/**
+ * FontPicker component is used to allow user to select a font from a list of available fonts.
+ */
+export default function FontPicker({
+  error = false,
+  disabled = false,
+  label = "Font",
+  margin = "normal",
+  onChange = () => {},
+  required = false,
+  size = "medium",
+  value,
+  variant = "outlined",
+  ...other
+}) {
+  // get available default font options
+  const getAvailableDefaultFonts = () => {
+    const fontAvailable = new Set();
+    for (const font of defaultFonts.values()) {
+      if (document.fonts.check(`12px "${font}"`)) {
+        fontAvailable.add(font);
+      }
+    }
+    return [...fontAvailable.values()];
+  };
+
+  // get options
+  const options = other.options || getAvailableDefaultFonts();
+
+  // return components
+  return (
+    <Autocomplete
+      disableClearable
+      disabled={disabled}
+      onChange={onChange}
+      options={options}
+      size={size}
+      value={value}
+      renderInput={params => (
+        <TextField
+          {...params}
+          error={error}
+          inputProps={{
+            ...params.inputProps,
+            sx: {
+              fontFamily: `${value}, Arial, sans-serif`
+            }
+          }}
+          label={label}
+          margin={margin}
+          required={required}
+          variant={variant}
+        />
+      )}
+      renderOption={(props, option) => (
+        <Box {...props}>
+          <Typography sx={{ fontFamily: `${option}, Arial, sans-serif` }}>
+            {option}
+          </Typography>
+        </Box>
+      )}
+    />
+  );
+}
+
+Autocomplete.propTypes = {
+  /**
+   * If true, the label, input and helper text should be displayed in a disabled state.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If true, the component will display an error state.
+   */
+  error: PropTypes.bool,
+  /**
+   * Label to display above input.
+   */
+  label: PropTypes.string,
+  /**
+   * If dense or normal, will adjust vertical spacing of this and contained components.
+   */
+  margin: PropTypes.oneOf(["none", "dense", "normal"]),
+  /**
+   * Callback fired when the value is changed.
+   *
+   * **Signature**
+   * ```
+   * function(event: object) => void
+   * ```
+   * _event_: The event source of the callback. You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange: PropTypes.func,
+  /**
+   * Array of options to display.
+   */
+  options: PropTypes.arrayOf(PropTypes.string),
+  /**
+   * If true, the label will indicate that the input is required.
+   */
+  required: PropTypes.bool,
+  /**
+   * The size of the select field.
+   */
+  size: PropTypes.oneOf(["medium", "small"]),
+  /**
+   * The input value
+   */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * The variant to use.
+   */
+  variant: PropTypes.oneOf(["standard", "outlined", "filled"])
+};

--- a/src/FontPicker/FontPicker.js
+++ b/src/FontPicker/FontPicker.js
@@ -161,7 +161,7 @@ export default function FontPicker({
         fontAvailable.add(font);
       }
     }
-    return [...fontAvailable.values()];
+    return Array.from(fontAvailable.values());
   };
 
   // fetch default available options on load

--- a/src/FontPicker/FontPicker.js
+++ b/src/FontPicker/FontPicker.js
@@ -1,6 +1,6 @@
 import { Autocomplete, Box, TextField, Typography } from "@mui/material";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import React from "react";
 
 // default font options list
 const defaultFonts = new Set(
@@ -127,7 +127,10 @@ const defaultFonts = new Set(
     "Trattatello",
     "Trebuchet MS",
     "Verdana",
-    "Zapfino"
+    "Zapfino",
+
+    // Google
+    "Roboto"
   ].sort()
 );
 
@@ -144,10 +147,14 @@ export default function FontPicker({
   size = "medium",
   value,
   variant = "outlined",
-  ...other
+  ...props
 }) {
+  // state for available options
+  const [defaultOptions, setDefaultOptions] = useState([]);
+
   // get available default font options
-  const getAvailableDefaultFonts = () => {
+  const getAvailableDefaultFonts = async () => {
+    await document.fonts.ready;
     const fontAvailable = new Set();
     for (const font of defaultFonts.values()) {
       if (document.fonts.check(`12px "${font}"`)) {
@@ -157,8 +164,13 @@ export default function FontPicker({
     return [...fontAvailable.values()];
   };
 
-  // get options
-  const options = other.options || getAvailableDefaultFonts();
+  // fetch default available options on load
+  useEffect(async () => {
+    try {
+      const theseOptions = await getAvailableDefaultFonts();
+      setDefaultOptions(theseOptions);
+    } catch (e) {}
+  }, []);
 
   // return components
   return (
@@ -166,7 +178,7 @@ export default function FontPicker({
       disableClearable
       disabled={disabled}
       onChange={onChange}
-      options={options}
+      options={props.options ? props.options : defaultOptions}
       size={size}
       value={value}
       renderInput={params => (

--- a/src/FontPicker/FontPicker.stories.js
+++ b/src/FontPicker/FontPicker.stories.js
@@ -1,0 +1,48 @@
+import FontPicker from "./FontPicker";
+import React from "react";
+import { action } from "@storybook/addon-actions";
+
+export default {
+  argTypes: {
+    value: { type: "string" }
+  },
+  component: FontPicker,
+  title: "General/FontPicker"
+};
+
+const Template = args => {
+  const [value, setValue] = React.useState(args.value);
+  React.useEffect(() => {
+    setValue(args.value);
+  }, [args.value]);
+  const onChange = (event, value, reason) => {
+    setValue(value);
+    action("onChange")(event, value, reason);
+  };
+  return <FontPicker {...args} onChange={onChange} value={value} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  disabled: false,
+  error: false,
+  label: "Font",
+  margin: "normal",
+  required: false,
+  size: "medium",
+  value: "Arial",
+  variant: "outlined"
+};
+
+export const CustomOptions = Template.bind({});
+CustomOptions.args = {
+  disabled: false,
+  error: false,
+  label: "Font",
+  margin: "normal",
+  options: ["Arial", "Helvetica", "Times New Roman"],
+  required: false,
+  size: "medium",
+  value: "Arial",
+  variant: "outlined"
+};

--- a/src/FontPicker/FontPicker.test.js
+++ b/src/FontPicker/FontPicker.test.js
@@ -22,7 +22,7 @@ const FontPickerWithState = ({ onChange, value: valueIn = "", ...rest }) => {
 /**
  * Tests
  */
-describe("Select", () => {
+describe("FontPicker", () => {
   test("can select an item", () => {
     const { container } = render(
       <FontPickerWithState options={options} value="Arial" />

--- a/src/FontPicker/FontPicker.test.js
+++ b/src/FontPicker/FontPicker.test.js
@@ -1,0 +1,43 @@
+import FontPicker from ".";
+import React from "react";
+import { render } from "@testing-library/react";
+
+// list of options to display
+const options = ["Arial", "Helvetica", "Times New Roman"];
+
+/**
+ * Test wrapper for FontPicker
+ *
+ * Provides state for value to avoid errors changing from uncontrolled to controlled.
+ */
+const FontPickerWithState = ({ onChange, value: valueIn = "", ...rest }) => {
+  const [value, setValue] = React.useState(valueIn);
+  const handleChange = (event, value, reason) => {
+    setValue(value);
+    onChange && onChange(event, value, reason);
+  };
+  return <FontPicker {...rest} onChange={handleChange} value={value} />;
+};
+
+/**
+ * Tests
+ */
+describe("Select", () => {
+  test("can select an item", () => {
+    const { container } = render(
+      <FontPickerWithState options={options} value="Arial" />
+    );
+    const inputBase = container.querySelector(".MuiInputBase-input");
+    expect(inputBase.value).toBe("Arial");
+  });
+  test("is item shown in its own font", () => {
+    const { container } = render(
+      <FontPickerWithState options={options} value="Arial" />
+    );
+    const inputBase = container.querySelector(".MuiInputBase-input");
+    const actualFont = window
+      .getComputedStyle(inputBase, null)
+      .getPropertyValue("font-family");
+    expect(actualFont).toBe("Arial,Arial,sans-serif");
+  });
+});

--- a/src/FontPicker/index.js
+++ b/src/FontPicker/index.js
@@ -1,0 +1,1 @@
+export { default } from "./FontPicker";

--- a/src/Sidebar/Sidebar.stories.js
+++ b/src/Sidebar/Sidebar.stories.js
@@ -110,10 +110,10 @@ export const IconsOnly = Template.bind({});
 IconsOnly.args = {
   children: (
     <>
-      <SidebarItem icon={<Home />} />
-      <SidebarItem icon={<Mail />} selected />
-      <SidebarItem icon={<Person />} />
-      <SidebarItem icon={<Settings />} />
+      <SidebarItem icon={<Home />} name="" />
+      <SidebarItem icon={<Mail />} name="" selected />
+      <SidebarItem icon={<Person />} name="" />
+      <SidebarItem icon={<Settings />} name="" />
     </>
   ),
   showLogo: false,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export { default as Autocomplete } from "./Autocomplete";
 export { default as Copyright } from "./Copyright";
 export { default as Color } from "./Color";
+export { default as FontPicker } from "./FontPicker";
 export { default as Loading } from "./Loading";
 export { default as LoginForm } from "./LoginForm";
 export { default as NoLicense } from "./NoLicense";


### PR DESCRIPTION
Contributes to https://github.com/IPG-Automotive-UK/instrument-designer/issues/59

New font picker component. Allows selection of a font family from an autocomplete dropdown. A set of default font options are provided but a custom font options list can also be provided. The dropdown options and the currently selected item are displayed in the corresponding font.

Also fixed a couple of storybook warnings with the Autocomplete and Sidebar components along the way.

![image](https://user-images.githubusercontent.com/8976377/143048411-f946d139-0e98-429d-ae66-4bf1532d5cf2.png)

![image](https://user-images.githubusercontent.com/8976377/143048569-380d8d3e-104a-4f38-96be-bdde7180211b.png)

Can be tested at https://deploy-preview-274--ipguk-react-ui.netlify.app/?path=/story/general-fontpicker--default