### PR TITLE
Bug/color swatch border

### DIFF
--- a/src/Color/Color.js
+++ b/src/Color/Color.js
@@ -247,7 +247,6 @@ export default function Color({
         data-testid="swatch"
         ref={buttonRef}
         variant="contained"
-        disableElevation
       />
       <Popover
         data-testid="popover"

--- a/src/Color/Color.js
+++ b/src/Color/Color.js
@@ -231,8 +231,7 @@ export default function Color({
           (sx.swatch,
           {
             "&:hover": {
-              backgroundColor: value,
-              opacity: 0.5
+              backgroundColor: value
             },
             background: value,
             height: swatchDimensions,


### PR DESCRIPTION
Closes https://github.com/IPG-Automotive-UK/react-ui/issues/276

The fix was simple in the end and didn't require additional border. The default button behaviour provides some box shadow elevation effect but this had been disabled. Enabling it again allows the button to stil be visible even when the colour matches the parent background.

Can be tested at https://deploy-preview-278--ipguk-react-ui.netlify.app/

Before:
![image](https://user-images.githubusercontent.com/8976377/143249973-f3999c15-0567-4c78-9739-89921d0e8559.png)

After:
![image](https://user-images.githubusercontent.com/8976377/143250174-c3940775-0218-4b4b-8d31-49d761e44a87.png)
