### PR TITLE
Font style component

### DIFF
--- a/src/FontStyle/FontStyle.js
+++ b/src/FontStyle/FontStyle.js
@@ -1,0 +1,79 @@
+import * as React from "react";
+import {
+  FormatBold,
+  FormatItalic,
+  FormatUnderlined
+} from "@mui/icons-material";
+import { ToggleButton, ToggleButtonGroup } from "@mui/material";
+import PropTypes from "prop-types";
+
+/**
+ * Font style button group component to toggle between bold, italic and underline
+ */
+export default function FontStyle({
+  disabled = false,
+  onChange = () => {},
+  orientation = "horizontal",
+  size = "medium",
+  value = []
+}) {
+  // return components
+  return (
+    <ToggleButtonGroup
+      aria-label="font style"
+      disabled={disabled}
+      onChange={onChange}
+      orientation={orientation}
+      size={size}
+      value={value}
+    >
+      <ToggleButton aria-label="bold" data-testid="boldButton" value="bold">
+        <FormatBold />
+      </ToggleButton>
+      <ToggleButton
+        aria-label="italic"
+        data-testid="italicButton"
+        value="italic"
+      >
+        <FormatItalic />
+      </ToggleButton>
+      <ToggleButton
+        aria-label="underline"
+        data-testid="underlineButton"
+        value="underline"
+      >
+        <FormatUnderlined />
+      </ToggleButton>
+    </ToggleButtonGroup>
+  );
+}
+
+FontStyle.propTypes = {
+  /**
+   * If true, the component is disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Callback fired when the value changes.
+   *
+   * **Signature**
+   * ```
+   * function(event: React.MouseEvent<HTMLElement>, value: any) => void
+   * ```
+   * event: The event source of the callback.
+   * value: The value of the selected buttons.
+   */
+  onChange: PropTypes.func,
+  /**
+   * The orientation of the toggle button group.
+   */
+  orientation: PropTypes.oneOf(["horizontal", "vertical"]),
+  /**
+   * The size of the component.
+   */
+  size: PropTypes.oneOf(["small", "medium", "large"]),
+  /**
+   * The value of the selected button.
+   */
+  value: PropTypes.arrayOf(PropTypes.string)
+};

--- a/src/FontStyle/FontStyle.stories.js
+++ b/src/FontStyle/FontStyle.stories.js
@@ -1,0 +1,31 @@
+import FontStyle from "./FontStyle";
+import React from "react";
+import { action } from "@storybook/addon-actions";
+
+export default {
+  argTypes: {
+    value: { type: "array" }
+  },
+  component: FontStyle,
+  title: "Text/FontStyle"
+};
+
+const Template = args => {
+  const [value, setValue] = React.useState(args.value);
+  React.useEffect(() => {
+    setValue(args.value);
+  }, [args.value]);
+  const onChange = (event, value) => {
+    setValue(value);
+    action("onChange")(event, [...value]);
+  };
+  return <FontStyle {...args} onChange={onChange} value={value} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  disabled: false,
+  orientation: "horizontal",
+  size: "medium",
+  value: []
+};

--- a/src/FontStyle/FontStyle.test.js
+++ b/src/FontStyle/FontStyle.test.js
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import FontStyle from ".";
+import React from "react";
+
+/**
+ * Test wrapper for FontStyle
+ *
+ * Provides state for value to avoid errors changing from uncontrolled to controlled.
+ */
+const FontStyleWithState = ({ onChange, value: valueIn = "", ...rest }) => {
+  const [value, setValue] = React.useState(valueIn);
+  const handleChange = (event, value) => {
+    setValue(value);
+    onChange && onChange(event, value);
+  };
+  return <FontStyle {...rest} onChange={handleChange} value={value} />;
+};
+
+/**
+ * Tests
+ */
+describe("Select", () => {
+  test("can select bold", () => {
+    render(<FontStyleWithState value={["bold"]} />);
+    const boldButton = screen.getByTestId("boldButton");
+    const italicButton = screen.getByTestId("italicButton");
+    const underlineButton = screen.getByTestId("underlineButton");
+    expect(boldButton.getAttribute("aria-pressed")).toBe("true");
+    expect(italicButton.getAttribute("aria-pressed")).toBe("false");
+    expect(underlineButton.getAttribute("aria-pressed")).toBe("false");
+  });
+  test("can select italic", () => {
+    render(<FontStyleWithState value={["italic"]} />);
+    const boldButton = screen.getByTestId("boldButton");
+    const italicButton = screen.getByTestId("italicButton");
+    const underlineButton = screen.getByTestId("underlineButton");
+    expect(boldButton.getAttribute("aria-pressed")).toBe("false");
+    expect(italicButton.getAttribute("aria-pressed")).toBe("true");
+    expect(underlineButton.getAttribute("aria-pressed")).toBe("false");
+  });
+  test("can select underline", () => {
+    render(<FontStyleWithState value={["underline"]} />);
+    const boldButton = screen.getByTestId("boldButton");
+    const italicButton = screen.getByTestId("italicButton");
+    const underlineButton = screen.getByTestId("underlineButton");
+    expect(boldButton.getAttribute("aria-pressed")).toBe("false");
+    expect(italicButton.getAttribute("aria-pressed")).toBe("false");
+    expect(underlineButton.getAttribute("aria-pressed")).toBe("true");
+  });
+  test("can select multiple", () => {
+    render(<FontStyleWithState value={["bold", "italic"]} />);
+    const boldButton = screen.getByTestId("boldButton");
+    const italicButton = screen.getByTestId("italicButton");
+    const underlineButton = screen.getByTestId("underlineButton");
+    expect(boldButton.getAttribute("aria-pressed")).toBe("true");
+    expect(italicButton.getAttribute("aria-pressed")).toBe("true");
+    expect(underlineButton.getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/src/FontStyle/index.js
+++ b/src/FontStyle/index.js
@@ -1,0 +1,1 @@
+export { default } from "./FontStyle";

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export { default as Checkbox } from "./Checkbox";
 export { default as Copyright } from "./Copyright";
 export { default as Color } from "./Color";
 export { default as FontPicker } from "./FontPicker";
+export { default as FontStyle } from "./FontStyle";
 export { default as Loading } from "./Loading";
 export { default as LoginForm } from "./LoginForm";
 export { default as NoLicense } from "./NoLicense";


### PR DESCRIPTION
Contributes to https://github.com/IPG-Automotive-UK/instrument-designer/issues/14

New component added to toggle font style options (bold, italic, underline).

![image](https://user-images.githubusercontent.com/8976377/143304319-aa3e5d43-a1bc-401a-bd30-86323422d135.png)

Can be tested at https://deploy-preview-280--ipguk-react-ui.netlify.app/?path=/story/text-fontstyle--default