### PR TITLE
Bugfix/numberfield

### DIFF
--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -31,7 +31,7 @@ export default function NumberField({
     setNumber(value);
   }, [value]);
 
-  // validate the number field when number, min or max changes
+  // validate the number field when, number, min or max changes
   useEffect(() => {
     if (min && number < min) {
       setValueError(true);
@@ -55,8 +55,20 @@ export default function NumberField({
     // set the number
     setNumber(event.target.value);
 
+    // is min satisfied
+    let minSatisfied = true;
+    if (min && newValue < min) {
+      minSatisfied = false;
+    }
+
+    // is max satisfied
+    let maxSatisfied = true;
+    if (max && newValue > max) {
+      maxSatisfied = false;
+    }
+
     // // if the value is valid, set error to false
-    if (newValue >= min && newValue <= max && event.target.value !== "") {
+    if (minSatisfied && maxSatisfied && event.target.value !== "") {
       setValueError(false);
       setErrorMessage("");
       onChange(updatedEvent);

--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -1,6 +1,6 @@
 import { TextField as MuiTextField } from "@mui/material";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect } from "react";
 
 /**
  * NumberField components are used for collecting user provided information as a Number.
@@ -26,6 +26,11 @@ export default function NumberField({
   const [errorMessage, setErrorMessage] = React.useState("");
   const [number, setNumber] = React.useState(value);
 
+  // update the value of the number field
+  useEffect(() => {
+    setNumber(value);
+  }, [value]);
+
   // handleChange
   const handleChange = event => {
     // update event.target.value so that it is a number
@@ -35,6 +40,15 @@ export default function NumberField({
 
     // set the number
     setNumber(event.target.value);
+
+    // if the value is an empty string, don't update the value and show error if min is set
+    if (event.target.value === "") {
+      if (min !== undefined) {
+        setValueError(true);
+        setErrorMessage(`Value must be greater than or equal to ${min}`);
+      }
+      return;
+    }
 
     // if the value is less than minimum, set error
     if (newValue < min && min !== undefined) {

--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -67,7 +67,7 @@ export default function NumberField({
       maxSatisfied = false;
     }
 
-    // // if the value is valid, set error to false
+    // if the value is valid, set error to false
     if (minSatisfied && maxSatisfied && event.target.value !== "") {
       setValueError(false);
       setErrorMessage("");

--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -1,6 +1,6 @@
+import React, { useEffect } from "react";
 import { TextField as MuiTextField } from "@mui/material";
 import PropTypes from "prop-types";
-import React, { useEffect } from "react";
 
 /**
  * NumberField components are used for collecting user provided information as a Number.
@@ -31,6 +31,20 @@ export default function NumberField({
     setNumber(value);
   }, [value]);
 
+  // validate the number field when number, min or max changes
+  useEffect(() => {
+    if (min && number < min) {
+      setValueError(true);
+      setErrorMessage(`Must be greater than ${min}`);
+    } else if (max && number > max) {
+      setValueError(true);
+      setErrorMessage(`Must be less than ${max}`);
+    } else {
+      setValueError(false);
+      setErrorMessage("");
+    }
+  }, [max, min, number]);
+
   // handleChange
   const handleChange = event => {
     // update event.target.value so that it is a number
@@ -41,34 +55,19 @@ export default function NumberField({
     // set the number
     setNumber(event.target.value);
 
-    // if the value is an empty string, don't update the value and show error if min is set
-    if (event.target.value === "") {
-      if (min !== undefined) {
-        setValueError(true);
-        setErrorMessage(`Value must be greater than or equal to ${min}`);
-      }
-      return;
+    // // if the value is valid, set error to false
+    if (newValue >= min && newValue <= max && event.target.value !== "") {
+      setValueError(false);
+      setErrorMessage("");
+      onChange(updatedEvent);
     }
-
-    // if the value is less than minimum, set error
-    if (newValue < min && min !== undefined) {
-      setValueError(true);
-      setErrorMessage(`Value must be greater than or equal to ${min}`);
-      return;
-    }
-
-    // if the value is greater than maximum, set error
-    if (newValue > max && max !== undefined) {
-      setValueError(true);
-      setErrorMessage(`Value must be less than or equal to ${max}`);
-      return;
-    }
-
-    // set error to false and fire onChange
-    setValueError(false);
-    setErrorMessage("");
-    onChange(updatedEvent);
   };
+
+  // set number to the last value, when the user clicks away from the field
+  const handleBlur = () => {
+    setNumber(value);
+  };
+
   // return components
   return (
     <MuiTextField
@@ -80,6 +79,7 @@ export default function NumberField({
       label={label}
       margin={margin}
       onChange={handleChange}
+      onBlur={handleBlur}
       placeholder={placeholder}
       required={required}
       size={size}

--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -33,10 +33,10 @@ export default function NumberField({
 
   // validate the number field when, number, min or max changes
   useEffect(() => {
-    if (min && number < min) {
+    if (min !== undefined && number < min) {
       setValueError(true);
       setErrorMessage(`Must be greater than ${min}`);
-    } else if (max && number > max) {
+    } else if (max !== undefined && number > max) {
       setValueError(true);
       setErrorMessage(`Must be less than ${max}`);
     } else {
@@ -57,13 +57,13 @@ export default function NumberField({
 
     // is min satisfied
     let minSatisfied = true;
-    if (min && newValue < min) {
+    if (min !== undefined && newValue < min) {
       minSatisfied = false;
     }
 
     // is max satisfied
     let maxSatisfied = true;
-    if (max && newValue > max) {
+    if (max !== undefined && newValue > max) {
       maxSatisfied = false;
     }
 
@@ -73,11 +73,6 @@ export default function NumberField({
       setErrorMessage("");
       onChange(updatedEvent);
     }
-  };
-
-  // set number to the last value, when the user clicks away from the field
-  const handleBlur = () => {
-    setNumber(value);
   };
 
   // return components
@@ -91,7 +86,6 @@ export default function NumberField({
       label={label}
       margin={margin}
       onChange={handleChange}
-      onBlur={handleBlur}
       placeholder={placeholder}
       required={required}
       size={size}

--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -24,6 +24,7 @@ export default function NumberField({
 }) {
   const [valueError, setValueError] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState("");
+  const [number, setNumber] = React.useState(value);
 
   // handleChange
   const handleChange = event => {
@@ -31,6 +32,9 @@ export default function NumberField({
     const newValue = Number(event.target.value);
     const newEventValue = { target: { value: newValue } };
     const updatedEvent = { ...event, ...newEventValue };
+
+    // set the number
+    setNumber(event.target.value);
 
     // if the value is less than minimum, set error
     if (newValue < min && min !== undefined) {
@@ -66,7 +70,7 @@ export default function NumberField({
       required={required}
       size={size}
       type="Number"
-      value={value}
+      value={number}
       variant={variant}
       inputProps={{ max: max, min: min, step: step }}
       sx={

--- a/src/NumberField/NumberField.stories.js
+++ b/src/NumberField/NumberField.stories.js
@@ -58,3 +58,18 @@ CustomMinMaxAndStep.args = {
   step: 0.1,
   variant: "outlined"
 };
+
+export const InitialError = Template.bind({});
+InitialError.args = {
+  disabled: false,
+  error: false,
+  label: "Enter a Number",
+  margin: "normal",
+  max: 1,
+  min: 0,
+  required: false,
+  size: "medium",
+  step: 0.1,
+  value: 2,
+  variant: "outlined"
+};

--- a/src/NumberField/NumberField.test.js
+++ b/src/NumberField/NumberField.test.js
@@ -73,7 +73,7 @@ describe("NumberField", () => {
     userEvent.type(inputBase, "{backspace}{backspace}{backspace}");
     userEvent.type(inputBase, "1234");
     fireEvent.blur(inputBase);
-    expect(inputBase.value).toBe("100");
+    expect(inputBase.value).toBe("123");
     const errorBase = container.querySelector(".MuiInputBase-root");
     expect(errorBase).not.toHaveClass("Mui-error");
   });

--- a/src/NumberField/NumberField.test.js
+++ b/src/NumberField/NumberField.test.js
@@ -67,14 +67,4 @@ describe("NumberField", () => {
     const errorBase = container.querySelector(".MuiInputBase-root");
     expect(errorBase).not.toHaveClass("Mui-error");
   });
-  test("on Blur return to previous valid value", () => {
-    const { container } = render(<NumberFieldWithState max={123} />);
-    const inputBase = container.querySelector(".MuiInputBase-input");
-    userEvent.type(inputBase, "{backspace}{backspace}{backspace}");
-    userEvent.type(inputBase, "1234");
-    fireEvent.blur(inputBase);
-    expect(inputBase.value).toBe("123");
-    const errorBase = container.querySelector(".MuiInputBase-root");
-    expect(errorBase).not.toHaveClass("Mui-error");
-  });
 });

--- a/src/NumberField/NumberField.test.js
+++ b/src/NumberField/NumberField.test.js
@@ -1,6 +1,6 @@
-import { fireEvent, render } from "@testing-library/react";
 import NumberField from ".";
 import React from "react";
+import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 /**

--- a/src/NumberField/NumberField.test.js
+++ b/src/NumberField/NumberField.test.js
@@ -1,27 +1,80 @@
+import { fireEvent, render } from "@testing-library/react";
 import NumberField from ".";
 import React from "react";
-import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
+/**
+ * Test wrapper for Numberfield
+ *
+ * Provides state for value to avoid errors changing from uncontrolled to controlled
+ */
+const NumberFieldWithState = ({ onChange, valueIn = 100, ...rest }) => {
+  const [value, setValue] = React.useState(valueIn);
+  const handleChange = event => {
+    setValue(event.target.value);
+    onChange && onChange(event);
+  };
+  return <NumberField {...rest} onChange={handleChange} value={value} />;
+};
 
 /**
  * Tests
  */
 describe("NumberField", () => {
   test("can type value in Numberfield", () => {
-    const { container } = render(<NumberField />);
+    const { container } = render(<NumberFieldWithState />);
     const inputBase = container.querySelector(".MuiInputBase-input");
+    userEvent.type(inputBase, "{backspace}{backspace}{backspace}");
     userEvent.type(inputBase, "123");
     expect(inputBase.value).toBe("123");
   });
   test("Numberfield does not allow typing of letters", () => {
-    const { container } = render(<NumberField />);
+    const { container } = render(<NumberFieldWithState />);
     const inputBase = container.querySelector(".MuiInputBase-input");
+    userEvent.type(inputBase, "{backspace}{backspace}{backspace}");
     userEvent.type(inputBase, "abc");
     expect(inputBase.value).toBe("");
   });
   test("shows error state", () => {
-    const { container } = render(<NumberField error />);
+    const { container } = render(<NumberFieldWithState error />);
     const inputBase = container.querySelector(".MuiInputBase-root");
     expect(inputBase).toHaveClass("Mui-error");
+  });
+  test("shows error when value exceeds max", () => {
+    const { container } = render(<NumberFieldWithState max={123} />);
+    const inputBase = container.querySelector(".MuiInputBase-input");
+    userEvent.type(inputBase, "{backspace}{backspace}{backspace}");
+    userEvent.type(inputBase, "1234");
+    expect(inputBase.value).toBe("1234");
+    const errorBase = container.querySelector(".MuiInputBase-root");
+    expect(errorBase).toHaveClass("Mui-error");
+  });
+  test("shows error when value is less than min", () => {
+    const { container } = render(<NumberFieldWithState min={1234} />);
+    const inputBase = container.querySelector(".MuiInputBase-input");
+    userEvent.type(inputBase, "{backspace}{backspace}{backspace}");
+    userEvent.type(inputBase, "123");
+    expect(inputBase.value).toBe("123");
+    const errorBase = container.querySelector(".MuiInputBase-root");
+    expect(errorBase).toHaveClass("Mui-error");
+  });
+  test("does not show error when value is valid", () => {
+    const { container } = render(<NumberFieldWithState min={123} max={1234} />);
+    const inputBase = container.querySelector(".MuiInputBase-input");
+    userEvent.type(inputBase, "{backspace}{backspace}{backspace}");
+    userEvent.type(inputBase, "124");
+    expect(inputBase.value).toBe("124");
+    const errorBase = container.querySelector(".MuiInputBase-root");
+    expect(errorBase).not.toHaveClass("Mui-error");
+  });
+  test("on Blur return to previous valid value", () => {
+    const { container } = render(<NumberFieldWithState max={123} />);
+    const inputBase = container.querySelector(".MuiInputBase-input");
+    userEvent.type(inputBase, "{backspace}{backspace}{backspace}");
+    userEvent.type(inputBase, "1234");
+    fireEvent.blur(inputBase);
+    expect(inputBase.value).toBe("100");
+    const errorBase = container.querySelector(".MuiInputBase-root");
+    expect(errorBase).not.toHaveClass("Mui-error");
   });
 });


### PR DESCRIPTION
closes: IPG-Automotive-UK/instrument-designer/issues/84
closes: IPG-Automotive-UK/instrument-designer/issues/87 found in this PR: IPG-Automotive-UK/instrument-designer/pull/81

This fix introduces new internal state for the value of the NumberField, this enables the NumberField to display  what the user has typed without updating the 'external' controlling state. If a value is entered by the user that is outside the defined bounds the onChange event is not fired.  The error states are now managed by a useEffect, which means an error will be rendered if the initial value is outside the defined bounds. 


