### PR TITLE
fixed helper text  error message to be reflective of actual conditions.

### DIFF
--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -35,10 +35,10 @@ export default function NumberField({
   useEffect(() => {
     if (min !== undefined && number < min) {
       setValueError(true);
-      setErrorMessage(`Must be greater than ${min}`);
+      setErrorMessage(`Must be greater than or equal to ${min}`);
     } else if (max !== undefined && number > max) {
       setValueError(true);
-      setErrorMessage(`Must be less than ${max}`);
+      setErrorMessage(`Must be less than or equal to ${max}`);
     } else {
       setValueError(false);
       setErrorMessage("");


### PR DESCRIPTION
fixed helper message. Previously the message would say value has to be greater than "min" or less than "max" when in fact the value could be greater than or equal to min or less than equal to max. 