### PR TITLE
Feature/numberfield error message prop

### DIFF
--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -16,6 +16,7 @@ export default function NumberField({
   onChange = () => {},
   placeholder,
   required = false,
+  showMinMaxErrorMessage = true,
   size = "medium",
   step = 1,
   stepper = true,
@@ -35,10 +36,14 @@ export default function NumberField({
   useEffect(() => {
     if (min !== undefined && number < min) {
       setValueError(true);
-      setErrorMessage(`Must be greater than or equal to ${min}`);
+      if (showMinMaxErrorMessage) {
+        setErrorMessage(`Must be greater than or equal to ${min}`);
+      }
     } else if (max !== undefined && number > max) {
       setValueError(true);
-      setErrorMessage(`Must be less than or equal to ${max}`);
+      if (showMinMaxErrorMessage) {
+        setErrorMessage(`Must be less than or equal to ${max}`);
+      }
     } else {
       setValueError(false);
       setErrorMessage("");
@@ -160,6 +165,11 @@ NumberField.propTypes = {
    * @default false
    */
   required: PropTypes.bool,
+  /**
+   * If true, the component will display an error message if the value is outside of the allowable min or max values, providing a min or max value is set.
+   * @default "true"
+   */
+  showMinMaxErrorMessage: PropTypes.bool,
   /**
    * The size of the select field.
    * @default "medium"

--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -1,5 +1,5 @@
+import { InputAdornment, TextField as MuiTextField } from "@mui/material";
 import React, { useEffect } from "react";
-import { TextField as MuiTextField, InputAdornment } from "@mui/material";
 import PropTypes from "prop-types";
 
 /**

--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { TextField as MuiTextField } from "@mui/material";
+import { TextField as MuiTextField, InputAdornment } from "@mui/material";
 import PropTypes from "prop-types";
 
 /**
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
  */
 export default function NumberField({
   disabled = false,
+  endAdornment = "",
   error = false,
   helperText,
   label,
@@ -18,6 +19,7 @@ export default function NumberField({
   required = false,
   showMinMaxErrorMessage = true,
   size = "medium",
+  startAdornment = "",
   step = 1,
   stepper = true,
   value,
@@ -97,7 +99,19 @@ export default function NumberField({
       type="Number"
       value={number}
       variant={variant}
-      inputProps={{ max: max, min: min, step: step }}
+      InputProps={{
+        endAdornment: (
+          <InputAdornment position="end">{endAdornment}</InputAdornment>
+        ),
+        startAdornment: (
+          <InputAdornment position="start">{startAdornment}</InputAdornment>
+        )
+      }}
+      inputProps={{
+        max: max,
+        min: min,
+        step: step
+      }}
       sx={
         !stepper
           ? {

--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -133,6 +133,11 @@ NumberField.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
+   * When set this string will appear as a suffix to the input, this does not effect the value of the output.
+   * @default ""
+   */
+  endAdornment: PropTypes.string,
+  /**
    * If true, the component will display an error state.
    * @default false
    */
@@ -189,6 +194,11 @@ NumberField.propTypes = {
    * @default "medium"
    */
   size: PropTypes.oneOf(["medium", "small"]),
+  /**
+   * When set this string will appear as a prefix to the input, this does not effect the value of the output.
+   * @default ""
+   */
+  startAdornment: PropTypes.string,
   /**
    * If the stepper in enabled, this is the step increment
    * @default 1

--- a/src/NumberField/NumberField.stories.js
+++ b/src/NumberField/NumberField.stories.js
@@ -33,6 +33,36 @@ Default.args = {
   variant: "outlined"
 };
 
+export const StartAdornment = Template.bind({});
+StartAdornment.args = {
+  disabled: false,
+  error: false,
+  helperText: "What Number are you going to type?",
+  label: "Enter a Number",
+  margin: "normal",
+  required: false,
+  showMinMaxErrorMessage: true,
+  size: "medium",
+  startAdornment: "$",
+  stepper: true,
+  variant: "outlined"
+};
+
+export const EndAdornment = Template.bind({});
+EndAdornment.args = {
+  disabled: false,
+  endAdornment: "px",
+  error: false,
+  helperText: "What Number are you going to type?",
+  label: "Enter a Number",
+  margin: "normal",
+  required: false,
+  showMinMaxErrorMessage: true,
+  size: "medium",
+  stepper: true,
+  variant: "outlined"
+};
+
 export const SmallAndDense = Template.bind({});
 SmallAndDense.args = {
   disabled: false,

--- a/src/NumberField/NumberField.stories.js
+++ b/src/NumberField/NumberField.stories.js
@@ -27,8 +27,23 @@ Default.args = {
   label: "Enter a Number",
   margin: "normal",
   required: false,
+  showMinMaxErrorMessage: true,
   size: "medium",
   stepper: true,
+  variant: "outlined"
+};
+
+export const SmallAndDense = Template.bind({});
+SmallAndDense.args = {
+  disabled: false,
+  error: false,
+  helperText: "What Number are you going to type?",
+  label: "Enter a Number",
+  margin: "dense",
+  required: false,
+  showMinMaxErrorMessage: true,
+  size: "small",
+  stepper: false,
   variant: "outlined"
 };
 
@@ -40,6 +55,7 @@ NoStepper.args = {
   label: "Enter a Number",
   margin: "normal",
   required: false,
+  showMinMaxErrorMessage: true,
   size: "medium",
   stepper: false,
   variant: "outlined"
@@ -54,6 +70,7 @@ CustomMinMaxAndStep.args = {
   max: 1,
   min: 0,
   required: false,
+  showMinMaxErrorMessage: true,
   size: "medium",
   step: 0.1,
   variant: "outlined"
@@ -68,6 +85,23 @@ InitialError.args = {
   max: 1,
   min: 0,
   required: false,
+  showMinMaxErrorMessage: true,
+  size: "medium",
+  step: 0.1,
+  value: 2,
+  variant: "outlined"
+};
+
+export const NoMinMaxErrorMessage = Template.bind({});
+NoMinMaxErrorMessage.args = {
+  disabled: false,
+  error: false,
+  label: "Enter a Number",
+  margin: "normal",
+  max: 1,
+  min: 0,
+  required: false,
+  showMinMaxErrorMessage: false,
   size: "medium",
   step: 0.1,
   value: 2,


### PR DESCRIPTION
Added a new props: 
- showMinMaxErrorMessage (default: true) 
False set here:
![image](https://user-images.githubusercontent.com/75164177/145674232-c70b747c-fff0-42b8-a9a5-bb4e224edab2.png)

- startAdornment (default: empty string)
$ set here:
![image](https://user-images.githubusercontent.com/75164177/145674248-dc15ae1c-44af-4373-8e1f-70840e9cdcbe.png)

- endAdornment (default: empty string) 
px set here
![image](https://user-images.githubusercontent.com/75164177/145674264-e639e2b0-d8e5-4499-a0b1-40152067aa8b.png)


