### PR TITLE
Feature/expose colour in switchfield

### DIFF
--- a/src/SwitchField/SwitchField.js
+++ b/src/SwitchField/SwitchField.js
@@ -19,9 +19,21 @@ export default function FormSwitch({
   helperText,
   label,
   onChange,
-  options
+  options,
+  switchStyle,
+  thumbColor,
+  trackColor
 }) {
   // return components
+
+  // color styling
+  const colorStyling = {
+    "& .MuiSwitch-thumb": { color: thumbColor },
+    ".Mui-checked": {
+      "& + .MuiSwitch-track": { backgroundColor: trackColor }
+    }
+  };
+
   return (
     <FormControl disabled={disabled}>
       {label && <FormLabel style={{ fontSize: "0.75rem" }}>{label}</FormLabel>}
@@ -29,14 +41,19 @@ export default function FormSwitch({
         <Typography
           component="div"
           color={disabled ? "textSecondary" : "textPrimary"}
-          style={{ cursor: disabled ? "default" : "pointer" }}
         >
           <Grid component="label" container alignItems="center" spacing={1}>
             <Grid item>
               <SwitchOptionLabel disabled={disabled} label={options[0]} />
             </Grid>
             <Grid item>
-              <Switch checked={checked} onChange={onChange} />
+              <FormControl disabled={disabled}>
+                <Switch
+                  checked={checked}
+                  onChange={onChange}
+                  sx={{ ...colorStyling, ...style }}
+                />
+              </FormControl>
             </Grid>
             <Grid item>
               <SwitchOptionLabel disabled={disabled} label={options[1]} />
@@ -54,10 +71,7 @@ export default function FormSwitch({
  */
 function SwitchOptionLabel({ disabled, label }) {
   return (
-    <Typography
-      color={disabled ? "textSecondary" : "textPrimary"}
-      style={{ cursor: disabled ? "default" : "pointer" }}
-    >
+    <Typography color={disabled ? "textSecondary" : "textPrimary"}>
       {label}
     </Typography>
   );
@@ -105,5 +119,17 @@ FormSwitch.propTypes = {
         `Invalid prop ${propName} supplied to ${componentName}. Expected a string array of length 2.`
       );
     }
-  }
+  },
+  /**
+   * Custom styling for the MUI Switch component.
+   */
+  switchStyle: PropTypes.string,
+  /**
+   * The thumb color
+   */
+  thumbColor: PropTypes.string,
+  /**
+   * The track color.
+   */
+  trackColor: PropTypes.string
 };

--- a/src/SwitchField/SwitchField.js
+++ b/src/SwitchField/SwitchField.js
@@ -41,6 +41,7 @@ export default function FormSwitch({
         <Typography
           component="div"
           color={disabled ? "textSecondary" : "textPrimary"}
+          style={{ cursor: disabled ? "default" : "pointer" }}
         >
           <Grid component="label" container alignItems="center" spacing={1}>
             <Grid item>
@@ -71,7 +72,10 @@ export default function FormSwitch({
  */
 function SwitchOptionLabel({ disabled, label }) {
   return (
-    <Typography color={disabled ? "textSecondary" : "textPrimary"}>
+    <Typography
+      color={disabled ? "textSecondary" : "textPrimary"}
+      style={{ cursor: disabled ? "default" : "pointer" }}
+    >
       {label}
     </Typography>
   );

--- a/src/SwitchField/SwitchField.js
+++ b/src/SwitchField/SwitchField.js
@@ -26,7 +26,7 @@ export default function FormSwitch({
 }) {
   // return components
 
-  // color styling
+  // thumb and track color styling
   const colorStyling = {
     "& .MuiSwitch-thumb": { color: thumbColor },
     ".Mui-checked": {

--- a/src/SwitchField/SwitchField.js
+++ b/src/SwitchField/SwitchField.js
@@ -51,7 +51,7 @@ export default function FormSwitch({
                 <Switch
                   checked={checked}
                   onChange={onChange}
-                  sx={{ ...colorStyling, ...style }}
+                  sx={{ ...colorStyling, ...switchStyle }}
                 />
               </FormControl>
             </Grid>

--- a/src/SwitchField/SwitchField.stories.js
+++ b/src/SwitchField/SwitchField.stories.js
@@ -40,3 +40,13 @@ Disabled.args = {
   label: "Make a choice",
   options: ["Choice A", "Choice B"]
 };
+
+export const RgbaColor = Template.bind({});
+RgbaColor.args = {
+  checked: true,
+  helperText: "Maybe you need some help?",
+  label: "Make a choice",
+  options: ["Choice A", "Choice B"],
+  thumbColor: "rgba(241, 255, 0, 1)",
+  trackColor: "rgba(2, 0, 235, 0.8)"
+};


### PR DESCRIPTION
contributes to: IPG-Automotive-UK/instrument-designer/issues/121

This pull request: 
- adds new thumbColor and trackColor property to easily change the color properties of the MUI switchField 
- adds new switchStyle property to make it easier to customise the MUI switchField
- conditionally renders the FormHelperText only when the helperText prop is set. 

![image](https://user-images.githubusercontent.com/75164177/146184838-9d6c45ff-f686-42f0-8923-507ed6334f79.png)
