### PR TITLE
Removed bottom border for last table row

### DIFF
--- a/src/MultiText/MultiText.js
+++ b/src/MultiText/MultiText.js
@@ -11,7 +11,7 @@ import React from "react";
 export default function LabelSetter({
   onChange = () => {},
   rows = [],
-  style = { height: 250, width: "100%" }
+  style = { height: 254, width: "100%" }
 }) {
   // add an id for each label/value
   const rowsWithID = rows.map((item, index) => ({ ...item, id: index }));
@@ -81,6 +81,12 @@ export default function LabelSetter({
   return (
     <Box sx={style} display="flex" flexDirection="column" key={rows.length}>
       <DataGrid
+        sx={{
+          "& .MuiDataGrid-cell": {
+            borderBottom: 0,
+            borderTop: "1px solid rgb(224,224,224)"
+          }
+        }}
         data-testid="dataGrid"
         disableColumnMenu
         disableColumnSelector


### PR DESCRIPTION
Removed bottom border for the last table row; it has a bit of shadow effect.
![image](https://user-images.githubusercontent.com/89025096/146188115-d3f65615-edfb-4c6a-b47d-f7e3dc511862.png)
Updated table:
![image](https://user-images.githubusercontent.com/89025096/146188271-f269b2b0-a90a-46e1-941c-f2a06f8b72fa.png)

