### PR TITLE
Fix close button size

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -22,6 +22,9 @@ const sx = {
   action: {
     color: "#fff"
   },
+  close: {
+    fontSize: 15
+  },
   error: {
     backgroundColor: theme => theme.palette.error.dark,
     color: "#fff"
@@ -110,7 +113,7 @@ export default function Snackbar({
             size="large"
             sx={sx.action}
           >
-            <Close sx={sx.icon} />
+            <Close sx={sx.close} />
           </IconButton>
         ]}
       />


### PR DESCRIPTION
Closes https://github.com/IPG-Automotive-UK/instrument-designer/issues/133

Fixed issue with the close button in snackbar showing as an elipse rather than circle when hovering over it. This was introduced during the recent migration to MUI 5 with updated styling. As well as make it circular again I have also knocked down the size a little bit as it was overwhelming the snackbar a bit too much.