### PR TITLE
Bugfix/numberfield does not allow 0

### DIFF
--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -20,7 +20,7 @@ export default function NumberField({
   showMinMaxErrorMessage = true,
   size = "medium",
   startAdornment = null,
-  step = 1,
+  step,
   stepper = true,
   value,
   variant = "outlined"
@@ -62,6 +62,7 @@ export default function NumberField({
       }
     } else if (
       number !== undefined &&
+      step !== undefined &&
       ((number * 100) % (step * 100)) / 100 !== 0
     ) {
       // value is not a multiple of step

--- a/src/NumberField/NumberField.js
+++ b/src/NumberField/NumberField.js
@@ -163,7 +163,7 @@ export default function NumberField({
       required={required}
       size={size}
       type="Number"
-      value={number || ""}
+      value={number}
       variant={variant}
       InputProps={{
         ...endAdornmentInputProperty,

--- a/src/NumberField/NumberField.test.js
+++ b/src/NumberField/NumberField.test.js
@@ -111,4 +111,19 @@ describe("NumberField", () => {
     expect(inputBase.value).toBe("10");
     expect(onChange).toHaveBeenCalled();
   });
+  test("can create component with an initial value of 0", async () => {
+    const { container } = render(
+      <NumberField min={0} max={100} step={10} value={0} />
+    );
+    const inputBase = container.querySelector(".MuiInputBase-input");
+    expect(inputBase.value).toBe("0");
+  });
+  test("does not show error when value is not an integer and no step has been provided", async () => {
+    const { container } = render(
+      <NumberFieldWithState min={0} max={100} value={0.2} />
+    );
+
+    const errorBase = container.querySelector(".MuiFormHelperText-root");
+    expect(errorBase).toBe(null);
+  });
 });

--- a/src/NumberField/NumberField.test.js
+++ b/src/NumberField/NumberField.test.js
@@ -115,6 +115,8 @@ describe("NumberField", () => {
     const { container } = render(
       <NumberField min={0} max={100} step={10} value={0} />
     );
+
+    // the value should be 0
     const inputBase = container.querySelector(".MuiInputBase-input");
     expect(inputBase.value).toBe("0");
   });
@@ -123,6 +125,7 @@ describe("NumberField", () => {
       <NumberFieldWithState min={0} max={100} value={0.2} />
     );
 
+    // there should be no helper text (which parents the error message)
     const errorBase = container.querySelector(".MuiFormHelperText-root");
     expect(errorBase).toBe(null);
   });

--- a/src/NumberField/NumberField.test.js
+++ b/src/NumberField/NumberField.test.js
@@ -111,7 +111,7 @@ describe("NumberField", () => {
     expect(inputBase.value).toBe("10");
     expect(onChange).toHaveBeenCalled();
   });
-  test("can create component with an initial value of 0", async () => {
+  test("can create component with an initial value of 0", () => {
     const { container } = render(
       <NumberField min={0} max={100} step={10} value={0} />
     );
@@ -120,7 +120,7 @@ describe("NumberField", () => {
     const inputBase = container.querySelector(".MuiInputBase-input");
     expect(inputBase.value).toBe("0");
   });
-  test("does not show error when value is not an integer and no step has been provided", async () => {
+  test("does not show error when value is not an integer and no step has been provided", () => {
     const { container } = render(
       <NumberFieldWithState min={0} max={100} value={0.2} />
     );


### PR DESCRIPTION
Summary:
- updated the NumberField component to allow an initial value of 0 
- updated the NumberField component to ignore step logic when no step is passed into the component 
- added tests for the above two cases. 