### PR TITLE
Remove popover from color component

### DIFF
--- a/src/Color/Color.js
+++ b/src/Color/Color.js
@@ -129,123 +129,117 @@ export default function Color({
 
   // define components
   return (
-    <Box>
-      <Box sx={{ display: "flex", flexDirection: "column" }}>
-        <Box>
-          {showPicker && (
-            <Box>
-              <Box sx={sx.colorPicker}>
-                {noColorChecked ? (
-                  <Box
-                    sx={{
-                      border: "1px solid #bdbdbd",
-                      borderRadius: "4px",
-                      height: "238px"
-                    }}
-                  />
-                ) : (
-                  <RgbaColorPicker
-                    color={rgbaObj}
-                    onChange={handleColorPickerChange}
-                    id="colorPicker"
-                  />
-                )}
-              </Box>
-            </Box>
-          )}
-          {showControls && (
-            <div>
-              <Checkbox
-                checked={noColorChecked}
-                id="NoColorCheckbox"
-                label="No Color"
-                onChange={handleNoColor}
-                size="small"
-              />
-              <Box sx={{ display: "flex", flexDirection: "row" }}>
-                <TextField
-                  data-testid="redTextField"
-                  disabled={noColorChecked}
-                  id="red"
-                  type="number"
-                  size="small"
-                  margin="dense"
-                  max="255"
-                  label="Red"
-                  error={rgbaObj.r > 255}
-                  value={noColorChecked ? "" : rgbaObj.r}
-                  sx={{
-                    marginRight: theme => theme.spacing(1),
-                    width: "33%"
-                  }}
-                  InputLabelProps={{
-                    shrink: true
-                  }}
-                  onChange={handleRedChange}
-                  inputProps={{ max: 255, min: 0 }}
-                />
-                <TextField
-                  data-testid="greenTextField"
-                  disabled={noColorChecked}
-                  id="green"
-                  type="number"
-                  size="small"
-                  margin="dense"
-                  max="255"
-                  label="Green"
-                  error={rgbaObj.g > 255}
-                  value={noColorChecked ? "" : rgbaObj.g}
-                  sx={{
-                    marginRight: theme => theme.spacing(1),
-                    width: "33%"
-                  }}
-                  InputLabelProps={{
-                    shrink: true
-                  }}
-                  onChange={handleGreenChange}
-                  inputProps={{ max: 255, min: 0 }}
-                />
-                <TextField
-                  data-testid="blueTextField"
-                  disabled={noColorChecked}
-                  id="blue"
-                  type="number"
-                  size="small"
-                  margin="dense"
-                  max="255"
-                  label="Blue"
-                  error={rgbaObj.b > 255}
-                  value={noColorChecked ? "" : rgbaObj.b}
-                  sx={{ width: "33%" }}
-                  InputLabelProps={{
-                    shrink: true
-                  }}
-                  onChange={handleBlueChange}
-                  inputProps={{ max: 255, min: 0 }}
-                />
-              </Box>
-              <TextField
-                data-testid="alphaTextField"
-                disabled={noColorChecked}
-                id="alpha"
-                type="number"
-                size="small"
-                margin="dense"
-                max="1"
-                label="Transparency"
-                error={rgbaObj.a > 1}
-                value={noColorChecked ? "" : rgbaObj.a}
-                fullWidth
-                InputLabelProps={{
-                  shrink: true
-                }}
-                onChange={handleAlphaChange}
-                inputProps={{ max: 1, min: 0, step: 0.1 }}
-              />
-            </div>
+    <Box sx={{ display: "flex", flexDirection: "column" }}>
+      {showPicker && (
+        <Box sx={sx.colorPicker}>
+          {noColorChecked ? (
+            <Box
+              sx={{
+                border: "1px solid #bdbdbd",
+                borderRadius: "4px",
+                height: "238px"
+              }}
+            />
+          ) : (
+            <RgbaColorPicker
+              color={rgbaObj}
+              onChange={handleColorPickerChange}
+              id="colorPicker"
+            />
           )}
         </Box>
-      </Box>
+      )}
+      {showControls && (
+        <div>
+          <Checkbox
+            checked={noColorChecked}
+            id="NoColorCheckbox"
+            label="No Color"
+            onChange={handleNoColor}
+            size="small"
+          />
+          <Box sx={{ display: "flex", flexDirection: "row" }}>
+            <TextField
+              data-testid="redTextField"
+              disabled={noColorChecked}
+              id="red"
+              type="number"
+              size="small"
+              margin="dense"
+              max="255"
+              label="Red"
+              error={rgbaObj.r > 255}
+              value={noColorChecked ? "" : rgbaObj.r}
+              sx={{
+                marginRight: theme => theme.spacing(1),
+                width: "33%"
+              }}
+              InputLabelProps={{
+                shrink: true
+              }}
+              onChange={handleRedChange}
+              inputProps={{ max: 255, min: 0 }}
+            />
+            <TextField
+              data-testid="greenTextField"
+              disabled={noColorChecked}
+              id="green"
+              type="number"
+              size="small"
+              margin="dense"
+              max="255"
+              label="Green"
+              error={rgbaObj.g > 255}
+              value={noColorChecked ? "" : rgbaObj.g}
+              sx={{
+                marginRight: theme => theme.spacing(1),
+                width: "33%"
+              }}
+              InputLabelProps={{
+                shrink: true
+              }}
+              onChange={handleGreenChange}
+              inputProps={{ max: 255, min: 0 }}
+            />
+            <TextField
+              data-testid="blueTextField"
+              disabled={noColorChecked}
+              id="blue"
+              type="number"
+              size="small"
+              margin="dense"
+              max="255"
+              label="Blue"
+              error={rgbaObj.b > 255}
+              value={noColorChecked ? "" : rgbaObj.b}
+              sx={{ width: "33%" }}
+              InputLabelProps={{
+                shrink: true
+              }}
+              onChange={handleBlueChange}
+              inputProps={{ max: 255, min: 0 }}
+            />
+          </Box>
+          <TextField
+            data-testid="alphaTextField"
+            disabled={noColorChecked}
+            id="alpha"
+            type="number"
+            size="small"
+            margin="dense"
+            max="1"
+            label="Transparency"
+            error={rgbaObj.a > 1}
+            value={noColorChecked ? "" : rgbaObj.a}
+            fullWidth
+            InputLabelProps={{
+              shrink: true
+            }}
+            onChange={handleAlphaChange}
+            inputProps={{ max: 1, min: 0, step: 0.1 }}
+          />
+        </div>
+      )}
     </Box>
   );
 }
@@ -262,7 +256,7 @@ Color.propTypes = {
    */
   onChange: PropTypes.func,
   /**
-   * This determines if the RGB and HEX controls are shown.
+   * This determines if the rgba controls are shown.
    * @default true
    */
   showControls: PropTypes.bool,

--- a/src/Color/Color.js
+++ b/src/Color/Color.js
@@ -1,5 +1,6 @@
-import { Box, Button, Popover, TextField } from "@mui/material";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Box, TextField } from "@mui/material";
+import React, { useEffect, useMemo, useState } from "react";
+
 import Checkbox from "../Checkbox/Checkbox";
 import PropTypes from "prop-types";
 import { RgbaColorPicker } from "react-colorful";
@@ -42,21 +43,11 @@ const sx = {
 
 // component to select a color
 export default function Color({
-  disabled = false,
-  popoverWidth = "250px",
+  onChange = () => {},
   showControls = true,
   showPicker = true,
-  swatchSize = "small",
-  value = "rgba(255,0,0,1)",
-  anchorType = "anchorEl",
-  onChange = () => {},
-  onClose = () => {},
-  ...props
+  value = "rgba(255,0,0,1)"
 }) {
-  // create popover states
-  const buttonRef = useRef(null);
-  const [open, setOpen] = useState(props.open || false);
-
   // color state
   const [color, setColor] = useState(value);
 
@@ -82,27 +73,6 @@ export default function Color({
   const noColorChecked = useMemo(() => {
     return color.length === 0;
   }, [color]);
-
-  // convert rgba string to swatch background color
-  const swatchBackground = useMemo(() => {
-    return color === ""
-      ? "linear-gradient(to top left, rgba(255,0,0,0) 0%, rgba(255,0,0,0) calc(50% - 0.8px),rgba(255,0,0,1) 50%,rgba(255,0,0,0) calc(50% + 0.8px),rgba(0,0,0,0) 100% )"
-      : color;
-  }, [color]);
-
-  // handle button / swatch size
-  const swatchDimensions = useMemo(() => {
-    switch (swatchSize) {
-      case "small":
-        return "15";
-      case "medium":
-        return "20";
-      case "large":
-        return "30";
-      default:
-        return "15";
-    }
-  }, [swatchSize]);
 
   // debounce color picker change
   const handleColorPickerChange = useDebouncyFn(newRbgaObj => {
@@ -157,222 +127,130 @@ export default function Color({
     setColor(newColor);
   };
 
-  // handle popover open
-  const handleClick = () => {
-    setOpen(true);
-  };
-
-  // handle popover close
-  const handleClose = () => {
-    onClose(color);
-    setOpen(false);
-  };
-
   // define components
   return (
     <Box>
-      <Button
-        sx={
-          (sx.swatch,
-          {
-            "&:hover": {
-              backgroundColor: color !== "" ? color : "transparent"
-            },
-            background: swatchBackground,
-            height: `${swatchDimensions}px`,
-            minHeight: `${swatchDimensions}px`,
-            minWidth: `${swatchDimensions}px`,
-            padding: "0",
-            width: `${swatchDimensions}px`
-          })
-        }
-        onClick={handleClick}
-        id="swatch"
-        data-testid="swatch"
-        ref={buttonRef}
-        variant="contained"
-        disabled={disabled}
-      />
-      <Popover
-        data-testid="popover"
-        open={open}
-        anchorEl={buttonRef.current}
-        onClose={handleClose}
-        anchorOrigin={{
-          horizontal: props.anchorOriginHorizontal || "right",
-          vertical: props.anchorOriginVertical || "bottom"
-        }}
-        transformOrigin={{
-          horizontal: props.transformOriginHorizontal || "right",
-          vertical: props.transformOriginVertical || "top"
-        }}
-        anchorPosition={{
-          left: props.popoverPositionLeft || 0,
-          top: props.popoverPositionTop || 0
-        }}
-        anchorReference={
-          anchorType === "anchorEl" && !buttonRef.current ? "none" : anchorType
-        }
-      >
-        <Box sx={{ display: "flex", flexDirection: "column" }}>
-          <Box sx={{ m: 1, width: popoverWidth }}>
-            {showPicker && (
-              <Box sx={{ width: popoverWidth }}>
-                <Box sx={sx.colorPicker}>
-                  {noColorChecked ? (
-                    <Box
-                      sx={{
-                        border: "1px solid #bdbdbd",
-                        borderRadius: "4px",
-                        height: "238px"
-                      }}
-                    />
-                  ) : (
-                    <RgbaColorPicker
-                      color={rgbaObj}
-                      onChange={handleColorPickerChange}
-                      id="colorPicker"
-                    />
-                  )}
-                </Box>
+      <Box sx={{ display: "flex", flexDirection: "column" }}>
+        <Box>
+          {showPicker && (
+            <Box>
+              <Box sx={sx.colorPicker}>
+                {noColorChecked ? (
+                  <Box
+                    sx={{
+                      border: "1px solid #bdbdbd",
+                      borderRadius: "4px",
+                      height: "238px"
+                    }}
+                  />
+                ) : (
+                  <RgbaColorPicker
+                    color={rgbaObj}
+                    onChange={handleColorPickerChange}
+                    id="colorPicker"
+                  />
+                )}
               </Box>
-            )}
-            <Checkbox
-              checked={noColorChecked}
-              id="NoColorCheckbox"
-              label="No Color"
-              onChange={handleNoColor}
-              size="small"
-            />
-            {showControls && (
-              <div>
-                <Box sx={{ display: "flex", flexDirection: "row" }}>
-                  <TextField
-                    data-testid="redTextField"
-                    disabled={noColorChecked}
-                    id="red"
-                    type="number"
-                    size="small"
-                    margin="dense"
-                    max="255"
-                    label="Red"
-                    error={rgbaObj.r > 255}
-                    value={noColorChecked ? "" : rgbaObj.r}
-                    sx={{
-                      marginRight: theme => theme.spacing(1),
-                      width: "33%"
-                    }}
-                    InputLabelProps={{
-                      shrink: true
-                    }}
-                    onChange={handleRedChange}
-                    inputProps={{ max: 255, min: 0 }}
-                  />
-                  <TextField
-                    data-testid="greenTextField"
-                    disabled={noColorChecked}
-                    id="green"
-                    type="number"
-                    size="small"
-                    margin="dense"
-                    max="255"
-                    label="Green"
-                    error={rgbaObj.g > 255}
-                    value={noColorChecked ? "" : rgbaObj.g}
-                    sx={{
-                      marginRight: theme => theme.spacing(1),
-                      width: "33%"
-                    }}
-                    InputLabelProps={{
-                      shrink: true
-                    }}
-                    onChange={handleGreenChange}
-                    inputProps={{ max: 255, min: 0 }}
-                  />
-                  <TextField
-                    data-testid="blueTextField"
-                    disabled={noColorChecked}
-                    id="blue"
-                    type="number"
-                    size="small"
-                    margin="dense"
-                    max="255"
-                    label="Blue"
-                    error={rgbaObj.b > 255}
-                    value={noColorChecked ? "" : rgbaObj.b}
-                    sx={{ width: "33%" }}
-                    InputLabelProps={{
-                      shrink: true
-                    }}
-                    onChange={handleBlueChange}
-                    inputProps={{ max: 255, min: 0 }}
-                  />
-                </Box>
+            </Box>
+          )}
+          {showControls && (
+            <div>
+              <Checkbox
+                checked={noColorChecked}
+                id="NoColorCheckbox"
+                label="No Color"
+                onChange={handleNoColor}
+                size="small"
+              />
+              <Box sx={{ display: "flex", flexDirection: "row" }}>
                 <TextField
-                  data-testid="alphaTextField"
+                  data-testid="redTextField"
                   disabled={noColorChecked}
-                  id="alpha"
+                  id="red"
                   type="number"
                   size="small"
                   margin="dense"
-                  max="1"
-                  label="Transparency"
-                  error={rgbaObj.a > 1}
-                  value={noColorChecked ? "" : rgbaObj.a}
-                  fullWidth
+                  max="255"
+                  label="Red"
+                  error={rgbaObj.r > 255}
+                  value={noColorChecked ? "" : rgbaObj.r}
+                  sx={{
+                    marginRight: theme => theme.spacing(1),
+                    width: "33%"
+                  }}
                   InputLabelProps={{
                     shrink: true
                   }}
-                  onChange={handleAlphaChange}
-                  inputProps={{ max: 1, min: 0, step: 0.1 }}
+                  onChange={handleRedChange}
+                  inputProps={{ max: 255, min: 0 }}
                 />
-              </div>
-            )}
-          </Box>
+                <TextField
+                  data-testid="greenTextField"
+                  disabled={noColorChecked}
+                  id="green"
+                  type="number"
+                  size="small"
+                  margin="dense"
+                  max="255"
+                  label="Green"
+                  error={rgbaObj.g > 255}
+                  value={noColorChecked ? "" : rgbaObj.g}
+                  sx={{
+                    marginRight: theme => theme.spacing(1),
+                    width: "33%"
+                  }}
+                  InputLabelProps={{
+                    shrink: true
+                  }}
+                  onChange={handleGreenChange}
+                  inputProps={{ max: 255, min: 0 }}
+                />
+                <TextField
+                  data-testid="blueTextField"
+                  disabled={noColorChecked}
+                  id="blue"
+                  type="number"
+                  size="small"
+                  margin="dense"
+                  max="255"
+                  label="Blue"
+                  error={rgbaObj.b > 255}
+                  value={noColorChecked ? "" : rgbaObj.b}
+                  sx={{ width: "33%" }}
+                  InputLabelProps={{
+                    shrink: true
+                  }}
+                  onChange={handleBlueChange}
+                  inputProps={{ max: 255, min: 0 }}
+                />
+              </Box>
+              <TextField
+                data-testid="alphaTextField"
+                disabled={noColorChecked}
+                id="alpha"
+                type="number"
+                size="small"
+                margin="dense"
+                max="1"
+                label="Transparency"
+                error={rgbaObj.a > 1}
+                value={noColorChecked ? "" : rgbaObj.a}
+                fullWidth
+                InputLabelProps={{
+                  shrink: true
+                }}
+                onChange={handleAlphaChange}
+                inputProps={{ max: 1, min: 0, step: 0.1 }}
+              />
+            </div>
+          )}
         </Box>
-      </Popover>
+      </Box>
     </Box>
   );
 }
 
 Color.propTypes = {
-  /**
-   * This is the point on the anchor where the popover's
-   * `anchorEl` will attach to. This is not used when the
-   * anchorReference is 'anchorPosition'.
-   *
-   * Options:
-   * left, center, right.
-   * @default : 'right'
-   */
-  anchorOriginHorizontal: PropTypes.oneOfType([
-    PropTypes.oneOf(["center", "left", "right"]),
-    PropTypes.number
-  ]),
-  /**
-   * This is the point on the anchor where the popover's
-   * `anchorEl` will attach to. This is not used when the
-   * anchorReference is 'anchorPosition'.
-   *
-   * Options:
-   * top, center, bottom
-   * @default 'bottom'
-   */
-  anchorOriginVertical: PropTypes.oneOfType([
-    PropTypes.oneOf(["bottom", "center", "top"]),
-    PropTypes.number
-  ]),
-  /**
-   * This determines which anchor prop to refer to when
-   * setting the position of the popover.
-   * @default 'anchorEl'
-   */
-  anchorType: PropTypes.oneOf(["anchorEl", "anchorPosition", "none"]),
-  /**
-   * This determines if the color picker is enabled or disabled.
-   * @default 'false'
-   */
-  disabled: PropTypes.bool,
   /**
    * Callback fired when the value is changed.
    *
@@ -384,40 +262,6 @@ Color.propTypes = {
    */
   onChange: PropTypes.func,
   /**
-   * Callback fired when the popover is closed.
-   *
-   * **Signature**
-   * ```
-   * function(color: string) => void
-   * ```
-   * color: This is the selected colour in a rgba string e.g "rgba(255,0,0,1)".
-   */
-  onClose: PropTypes.func,
-  /**
-   * This determines if the popover is open on the intial
-   * render.
-   * @default false
-   */
-  open: PropTypes.bool,
-  /**
-   * This is the left positon of the popover when the anchor
-   * type is anchorPosition.
-   * @default 0
-   */
-  popoverPositionLeft: PropTypes.number,
-  /**
-   * This is the top positon of the popover when the anchor
-   * type is anchorPosition.
-   * @default 0
-   */
-  popoverPositionTop: PropTypes.number,
-  /**
-   * This is the width of the popover, this also effects the
-   * popover's children the colorpicker and controls.
-   * @default 250px
-   */
-  popoverWidth: PropTypes.string,
-  /**
    * This determines if the RGB and HEX controls are shown.
    * @default true
    */
@@ -427,37 +271,6 @@ Color.propTypes = {
    * @default true
    */
   showPicker: PropTypes.bool,
-  /**
-   * This determines the size of the swatch
-   * Options:
-   * small, medium, large
-   * @default 'small'
-   */
-  swatchSize: PropTypes.oneOf(["small", "medium", "large"]),
-  /**
-   * This is the point on the popover which
-   * will attach to the anchor's origin.
-   *
-   * Options:
-   * left, center, right, x(px).
-   * @default 'right'
-   */
-  transformOriginHorizontal: PropTypes.oneOfType([
-    PropTypes.oneOf(["center", "left", "right"]),
-    PropTypes.number
-  ]),
-  /**
-   * This is the point on the popover which
-   * will attach to the anchor's origin.
-   *
-   * Options:
-   * top, center, bottom, x(px);
-   * @default "top"
-   */
-  transformOriginVertical: PropTypes.oneOfType([
-    PropTypes.oneOf(["bottom", "center", "top"]),
-    PropTypes.number
-  ]),
   /**
    * This is the rgba color string that is used to
    * set the inital value

--- a/src/Color/Color.stories.js
+++ b/src/Color/Color.stories.js
@@ -4,6 +4,16 @@ import { action } from "@storybook/addon-actions";
 
 export default {
   argTypes: {
+    showControls: {
+      control: {
+        type: "boolean"
+      }
+    },
+    showPicker: {
+      control: {
+        type: "boolean"
+      }
+    },
     value: {
       control: { type: "color" }
     }
@@ -21,83 +31,42 @@ const Template = args => {
     setValue(color);
     action("onChange")(color);
   };
-  const onClose = color => {
-    action("onClose")(color);
-  };
 
   return (
     <Color
       {...args}
-      value={value}
       onChange={onChange}
-      onClose={onClose}
-      swatchSize={args.swatchSize}
-      popoverWidth={args.popoverWidth}
       showControls={args.showControls}
-      anchorType={args.anchorType}
       showPicker={args.showPicker}
+      value={value}
     />
   );
 };
 
 export const Default = Template.bind({});
 Default.args = {
-  anchorOriginHorizontal: "right",
-  anchorOriginVertical: "bottom",
-  anchorType: "anchorEl",
-  open: false,
-  popoverWidth: "250px",
   showControls: true,
   showPicker: true,
-  swatchSize: "small",
-  transformOriginHorizontal: "right",
-  transformOriginVertical: "top",
   value: "rgba(255,0,0,1)"
 };
 
-export const SwatchMedium = Template.bind({});
-SwatchMedium.args = {
-  swatchSize: "medium"
-};
-
-export const SwatchLarge = Template.bind({});
-SwatchLarge.args = {
-  swatchSize: "large"
-};
-
-export const NoPicker = Template.bind({});
-NoPicker.args = {
-  showPicker: false
+export const NoColor = Template.bind({});
+NoColor.args = {
+  showControls: true,
+  showPicker: true,
+  value: ""
 };
 
 export const NoControls = Template.bind({});
 NoControls.args = {
-  showControls: false
+  showControls: false,
+  showPicker: true,
+  value: "rgba(255,0,0,1)"
 };
 
-export const ModifiedPopoverWidth = Template.bind({});
-ModifiedPopoverWidth.args = {
-  popoverWidth: "600px"
-};
-
-export const PopoverIntiallyOpen = Template.bind({});
-PopoverIntiallyOpen.args = {
-  open: true
-};
-
-export const PopoverWithPosition = Template.bind({});
-PopoverWithPosition.args = {
-  anchorType: "anchorPosition",
-  popoverPositionLeft: 300,
-  popoverPositionTop: 100
-};
-
-export const disabled = Template.bind({});
-disabled.args = {
-  disabled: true
-};
-
-export const InitiallyNoColor = Template.bind({});
-InitiallyNoColor.args = {
-  value: ""
+export const NoPicker = Template.bind({});
+NoPicker.args = {
+  showControls: true,
+  showPicker: false,
+  value: "rgba(255,0,0,1)"
 };

--- a/src/Color/Color.test.js
+++ b/src/Color/Color.test.js
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+
 import Color from ".";
 import React from "react";
 import userEvent from "@testing-library/user-event";
@@ -93,14 +94,6 @@ describe("Color", () => {
     await user.type(elements.inputs.alpha, "0.5");
     expect(document.querySelector("[id=alpha]").value).toBe("0.5");
   });
-  test("Click swatch opens popover", async () => {
-    const user = userEvent.setup();
-    const value = "rgba(255,55,100,1)";
-    render(<ColorWithState value={value} />);
-    const swatch = screen.getByTestId("swatch");
-    await user.click(swatch);
-    expect(document.querySelector("[id=red]").value).toBe("255");
-  });
   test("No initial color", () => {
     const value = "";
     render(<ColorWithState open value={value} />);
@@ -115,10 +108,6 @@ describe("Color", () => {
     const user = userEvent.setup();
     const value = "rgba(255,55,100,1)";
     render(<ColorWithState value={value} />);
-
-    // get swatch and click swatch
-    const swatch = screen.getByTestId("swatch");
-    await user.click(swatch);
 
     // click no color checkbox
     const noColor = document.querySelector("[type=checkbox]");

--- a/src/MultiColor/MultiColor.js
+++ b/src/MultiColor/MultiColor.js
@@ -50,18 +50,12 @@ export default function MultiColor({ onChange = () => {}, rows = [] }) {
         />
       ),
       renderEditCell: params => (
-        <Popover
-          anchorEl={popperRef.current}
-          onClose={newColor => handleOnColorClose(newColor, params)}
-          open
-        >
-          <Paper sx={{ height: 380, padding: 1, width: 300 }} elevation={3}>
-            <Color
-              value={params.value}
-              onChange={newColor => handleOnColorChange(newColor, params)}
-            />
-          </Paper>
-        </Popover>
+        <EditCell
+          ref={popperRef}
+          params={params}
+          handleOnColorChange={handleOnColorChange}
+          handleOnColorClose={handleOnColorClose}
+        />
       ),
       sortable: false,
       type: "string",
@@ -151,6 +145,29 @@ export default function MultiColor({ onChange = () => {}, rows = [] }) {
     </Box>
   );
 }
+
+const EditCell = React.forwardRef(
+  ({ params, handleOnColorChange, handleOnColorClose }, ref) => {
+    return (
+      <>
+        <div ref={ref}></div>
+        <Popover
+          anchorEl={ref.current}
+          onClose={newColor => handleOnColorClose(newColor, params)}
+          open
+        >
+          <Paper sx={{ height: 380, padding: 1, width: 300 }} elevation={3}>
+            <Color
+              value={params.value}
+              onChange={newColor => handleOnColorChange(newColor, params)}
+            />
+          </Paper>
+        </Popover>
+      </>
+    );
+  }
+);
+EditCell.displayName = "EditCell";
 
 MultiColor.propTypes = {
   /**

--- a/src/MultiColor/MultiColor.js
+++ b/src/MultiColor/MultiColor.js
@@ -1,10 +1,11 @@
-import { Box, IconButton } from "@mui/material";
+import { Box, IconButton, Paper, Popover } from "@mui/material";
+import React, { useRef } from "react";
+
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import Color from "../Color";
 import { DataGrid } from "@mui/x-data-grid";
 import DeleteIcon from "@mui/icons-material/Delete";
 import PropTypes from "prop-types";
-import React from "react";
 
 /**
  * Multi color component is used to manage a table for value-color pair
@@ -12,6 +13,9 @@ import React from "react";
 export default function MultiColor({ onChange = () => {}, rows = [] }) {
   // add an id for each color/value
   const rowsWithID = rows.map((item, index) => ({ ...item, id: index }));
+
+  // ref for the popover
+  const popperRef = useRef();
 
   // set column definition
   const columns = [
@@ -46,12 +50,18 @@ export default function MultiColor({ onChange = () => {}, rows = [] }) {
         />
       ),
       renderEditCell: params => (
-        <Color
-          value={params.value}
-          onChange={newColor => handleOnColorChange(newColor, params)}
+        <Popover
+          anchorEl={popperRef.current}
           onClose={newColor => handleOnColorClose(newColor, params)}
           open
-        />
+        >
+          <Paper sx={{ height: 380, padding: 1, width: 300 }} elevation={3}>
+            <Color
+              value={params.value}
+              onChange={newColor => handleOnColorChange(newColor, params)}
+            />
+          </Paper>
+        </Popover>
       ),
       sortable: false,
       type: "string",
@@ -117,6 +127,7 @@ export default function MultiColor({ onChange = () => {}, rows = [] }) {
       display="flex"
       flexDirection="column"
       key={rows.length}
+      ref={popperRef}
       sx={{ height: "100%", width: "100%" }}
     >
       <DataGrid


### PR DESCRIPTION
Removed the popover dialog and swatch from the color component. Color component is now just a standalone color selector component that can be parented wherever required. If a particular app requires it in a popover it can parent it so. We have a usecase in ID that doesn't require the color component with swatch and popover and instead we just want the core color selector parts. This has also significantly simplified the component with less props and less code to deal with popover related stuff.

Multi-color also required updating as it uses the color component internally.

![image](https://user-images.githubusercontent.com/8976377/194082441-215b841e-5302-4858-bd48-a7fa08896ba8.png)
