### PR TITLE
Color controlled state

### DIFF
--- a/src/Color/Color.js
+++ b/src/Color/Color.js
@@ -1,5 +1,5 @@
 import { Box, TextField } from "@mui/material";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import Checkbox from "../Checkbox/Checkbox";
 import PropTypes from "prop-types";
@@ -48,37 +48,30 @@ export default function Color({
   showPicker = true,
   value = "rgba(255,0,0,1)"
 }) {
-  // color state
-  const [color, setColor] = useState(value);
-
   // store last value to return back to it when toggling no color
   const [lastColor, setLastColor] = useState(value);
   useEffect(() => {
-    if (color.length !== 0) {
-      setLastColor(color);
+    if (value.length !== 0) {
+      setLastColor(value);
     }
-  }, [color]);
-
-  // call on change when color changes
-  useEffect(() => {
-    onChange(color);
-  }, [color]);
+  }, [value]);
 
   // convert rgba string to rgba object
-  const rgbaObj = useMemo(() => {
-    return colord(color).toRgb();
-  }, [color]);
+  const rgbaObj = colord(value).toRgb();
 
   // check if no color is selected
-  const noColorChecked = useMemo(() => {
-    return color.length === 0;
-  }, [color]);
+  const noColorChecked = value.length === 0;
 
   // debounce color picker change
   const handleColorPickerChange = useDebouncyFn(newRbgaObj => {
     const newColor = colord(newRbgaObj).toRgbString();
     setColor(newColor);
   }, 200);
+
+  // handle color change
+  const setColor = newColor => {
+    onChange(newColor);
+  };
 
   // handle no color button click
   const handleNoColor = event => {

--- a/src/Color/Color.js
+++ b/src/Color/Color.js
@@ -88,7 +88,7 @@ export default function Color({
   const handleRedChange = event => {
     const newColor = colord({
       ...rgbaObj,
-      r: event.target.value
+      r: event.target.value.length === 0 ? 0 : event.target.value
     }).toRgbString();
     setColor(newColor);
   };
@@ -97,7 +97,7 @@ export default function Color({
   const handleGreenChange = event => {
     const newColor = colord({
       ...rgbaObj,
-      g: event.target.value
+      g: event.target.value.length === 0 ? 0 : event.target.value
     }).toRgbString();
     setColor(newColor);
   };
@@ -106,7 +106,7 @@ export default function Color({
   const handleBlueChange = event => {
     const newColor = colord({
       ...rgbaObj,
-      b: event.target.value
+      b: event.target.value.length === 0 ? 0 : event.target.value
     }).toRgbString();
     setColor(newColor);
   };
@@ -115,7 +115,7 @@ export default function Color({
   const handleAlphaChange = event => {
     const newColor = colord({
       ...rgbaObj,
-      a: event.target.value
+      a: event.target.value.length === 0 ? 0 : event.target.value
     }).toRgbString();
     setColor(newColor);
   };


### PR DESCRIPTION
Fixes two issues with color component we spotted in one of our apps.

## Value prop
Value prop was not being kept in sync with internal state. I've removed the internal state now as there was no need for it and we can just use the value prop directly. I also removed useMemo which wasn't necessary where it was being used. You could see the behaviour in storybook where you could change the value using the color picker in storybook prop but the color component wasn't actually updated.

### Before

https://user-images.githubusercontent.com/8976377/195438434-2dd7ca46-d983-4fec-a23f-97473fccdbb5.mov



### After

https://user-images.githubusercontent.com/8976377/195438124-12b5f529-8aba-4b4b-b2bb-a29709f0a71c.mov


## Deleting number field contents
If you pressed delete on one of the input number fields, e.g. the red field, then all color fields had got set to 0. Pressing delete actually results in an empty string which then gets converted to (0,0,0). If you press delete on one of the numberfields now then that particular field will go to 0 but all other fields will remain. It's now technically impossible to have an 'empty' field.

### Before

https://user-images.githubusercontent.com/8976377/195438374-36fdeebe-0bb4-4bb5-9c3c-50718a65a7b4.mov


### After

https://user-images.githubusercontent.com/8976377/195438275-0195750f-05b9-4861-ba3b-8c1e04a289ff.mov
