### PR TITLE
Storybook dark/light mode

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,8 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
-    "@storybook/preset-create-react-app"
+    "@storybook/preset-create-react-app",
+    "storybook-dark-mode"
   ],
   framework: "@storybook/react",
   core: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,8 +1,26 @@
+import { DARK_MODE_EVENT_NAME } from "storybook-dark-mode";
 import React from "react";
-import { addDecorator } from "@storybook/react";
 import ThemeProvider from "../src/ThemeProvider/ThemeProvider";
+import { addDecorator } from "@storybook/react";
+import addons from "@storybook/addons";
 
-addDecorator(story => <ThemeProvider>{story()}</ThemeProvider>);
+// get channel to listen to event emitter
+const channel = addons.getChannel();
+
+addDecorator(story => {
+  // this example uses hook but you can also use class component as well
+  const [isDark, setDark] = React.useState(false);
+
+  React.useEffect(() => {
+    // listen to DARK_MODE event
+    channel.on(DARK_MODE_EVENT_NAME, setDark);
+    return () => channel.off(DARK_MODE_EVENT_NAME, setDark);
+  }, [channel, setDark]);
+
+  return (
+    <ThemeProvider theme={isDark ? "dark" : "light"}>{story()}</ThemeProvider>
+  );
+});
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "mutationobserver-shim": "^0.3.7",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.6.2",
+        "storybook-dark-mode": "^1.1.2",
         "webpack": "^5.72.0"
       },
       "engines": {
@@ -36706,6 +36707,34 @@
       "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==",
       "dev": true
     },
+    "node_modules/storybook-dark-mode": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-1.1.2.tgz",
+      "integrity": "sha512-L5QjJN49bl+ktprM6faMkTeW+LCvuMYWQaRo8/JGSMmzomIjLT7Yo20UiTsnMgMYyYWYF5O4EK/F3OvjDNp8tQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.0.0",
+        "@storybook/api": "^6.0.0",
+        "@storybook/components": "^6.0.0",
+        "@storybook/core-events": "^6.0.0",
+        "@storybook/theming": "^6.0.0",
+        "fast-deep-equal": "^3.0.0",
+        "global": "^4.4.0",
+        "memoizerific": "^1.11.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -68439,6 +68468,22 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.2.tgz",
       "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==",
       "dev": true
+    },
+    "storybook-dark-mode": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-1.1.2.tgz",
+      "integrity": "sha512-L5QjJN49bl+ktprM6faMkTeW+LCvuMYWQaRo8/JGSMmzomIjLT7Yo20UiTsnMgMYyYWYF5O4EK/F3OvjDNp8tQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.0.0",
+        "@storybook/api": "^6.0.0",
+        "@storybook/components": "^6.0.0",
+        "@storybook/core-events": "^6.0.0",
+        "@storybook/theming": "^6.0.0",
+        "fast-deep-equal": "^3.0.0",
+        "global": "^4.4.0",
+        "memoizerific": "^1.11.3"
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mutationobserver-shim": "^0.3.7",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",
+    "storybook-dark-mode": "^1.1.2",
     "webpack": "^5.72.0"
   },
   "files": [

--- a/src/ThemeProvider/ThemeProvider.js
+++ b/src/ThemeProvider/ThemeProvider.js
@@ -4,6 +4,7 @@ import {
   createTheme
 } from "@mui/material/styles";
 import React, { useEffect } from "react";
+
 import PropTypes from "prop-types";
 import ThemeContext from "./ThemeContext";
 import darkScrollbar from "@mui/material/darkScrollbar";
@@ -89,9 +90,12 @@ const darkTheme = createTheme({
 /**
  * IPG Material-ui theme provider and hook.
  */
-export default function ThemeProvider({ children }) {
+export default function ThemeProvider({
+  children,
+  theme: controlledTheme = "light"
+}) {
   // theme state
-  const [theme, setTheme] = React.useState("light");
+  const [theme, setTheme] = React.useState(controlledTheme);
 
   // on first render get theme from local storage or set default to light if not set
   useEffect(() => {
@@ -99,10 +103,16 @@ export default function ThemeProvider({ children }) {
     if (storedThemeMode) {
       setTheme(storedThemeMode);
     } else {
-      setTheme("light");
-      localStorage.setItem("theme", "light");
+      setTheme(controlledTheme);
+      localStorage.setItem("theme", controlledTheme);
     }
   }, []);
+
+  useEffect(() => {
+    if (theme !== controlledTheme) {
+      setTheme(controlledTheme);
+    }
+  }, [controlledTheme]);
 
   // on theme change update local storage
   useEffect(() => {


### PR DESCRIPTION
Added storybook dark mode controls, and synced our ThemeProvider with it. This allows us to test what our components look like in dark mode via storybook.

<img width="386" alt="image" src="https://user-images.githubusercontent.com/27866636/196937480-03eebff6-0d91-4581-8cba-611c37f81b02.png">
<img width="386" alt="image" src="https://user-images.githubusercontent.com/27866636/196937495-56d54633-ab3a-4744-8664-8f4943075363.png">

Idea from: https://github.com/IPG-Automotive-UK/react-ui/pull/467#issuecomment-1285082876

