### PR TITLE
Model button component

### DIFF
--- a/src/ModelButton/ModelButton.js
+++ b/src/ModelButton/ModelButton.js
@@ -1,0 +1,129 @@
+import * as React from "react";
+
+import { Box, IconButton, Typography } from "@mui/material";
+
+import PropTypes from "prop-types";
+import { useTheme } from "@mui/material/styles";
+
+/**
+ * Model button component to display a button with an icon, label and border color based on the model status
+ */
+export default function ModelButton({
+  disabled = false,
+  icon = null,
+  label = "",
+  onClick = () => {},
+  status = "none"
+}) {
+  // use theme hook
+  const theme = useTheme();
+
+  // set border color based on status
+  let borderColor = theme.palette.text.secondary;
+  if (status === "error") {
+    borderColor = theme.palette.error.main;
+  } else if (status === "warning") {
+    borderColor = theme.palette.warning.main;
+  } else if (status === "success") {
+    borderColor = theme.palette.success.main;
+  }
+
+  // render component
+  return (
+    <Box
+      sx={{
+        height: "144px",
+        position: "absolute",
+        width: "100px"
+      }}
+    >
+      <IconButton
+        data-testid="model-button"
+        disabled={disabled}
+        disableRipple
+        onClick={onClick}
+        sx={{
+          "&:hover": {
+            border: theme => `2px solid ${theme.palette.primary.main}`,
+            color: theme => theme.palette.primary.main
+          },
+          alignItems: "center",
+          border: `2px solid ${borderColor}`,
+          borderRadius: "20px",
+          bottom: "30.56%",
+          boxSizing: "border-box",
+          color: theme =>
+            theme.palette.mode === "light"
+              ? theme.palette.common.black
+              : theme.palette.common.white,
+          display: "flex",
+          flexDirection: "row",
+          fontSize: "40px",
+          left: "0%",
+          padding: "16px",
+          position: "absolute",
+          right: "0%",
+          top: "0%",
+          transition: "all 0.2s ease-in-out"
+        }}
+      >
+        {icon
+          ? React.cloneElement(icon, {
+              sx: {
+                height: "60px",
+                width: "60px"
+              }
+            })
+          : null}
+      </IconButton>
+      <Typography
+        sx={{
+          alignItems: "center",
+          bottom: "0%",
+          display: "flex",
+          flexDirection: "row",
+          gap: "10px",
+          justifyContent: "center",
+          left: "0%",
+          position: "absolute",
+          right: "0%",
+          textAlign: "center",
+          top: "69.44%"
+        }}
+        color="textSecondary"
+        variant="body2"
+      >
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+ModelButton.propTypes = {
+  /**
+   * If `true`, the button will be disabled. Default is `false`.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * The icon component to render inside the button. Can be set to `null` to not display an icon. MUI SVG icons are recommended.
+   */
+  icon: PropTypes.node,
+  /**
+   * The label text to display. Default is an empty string.
+   */
+  label: PropTypes.string,
+  /**
+   * Callback fired when the button is clicked.
+   *
+   * **Signature**
+   * ```
+   * function(event: React.MouseEvent<HTMLElement>) => void
+   * ```
+   * event: The event source of the callback.
+   */
+  onClick: PropTypes.func,
+  /**
+   * The status string that determines the border color of the button. Default is `none`.
+   */
+  status: PropTypes.oneOf(["none", "error", "warning", "success"])
+};

--- a/src/ModelButton/ModelButton.js
+++ b/src/ModelButton/ModelButton.js
@@ -20,7 +20,12 @@ export default function ModelButton({
 
   // set border color based on status
   let borderColor = theme.palette.text.secondary;
-  if (status === "error") {
+  if (disabled) {
+    borderColor =
+      theme.palette.mode === "light"
+        ? "rgba(0, 0, 0, 0.38)"
+        : "rgba(255, 255, 255, 0.5)";
+  } else if (status === "error") {
     borderColor = theme.palette.error.main;
   } else if (status === "warning") {
     borderColor = theme.palette.warning.main;
@@ -44,6 +49,10 @@ export default function ModelButton({
         onClick={onClick}
         sx={{
           "&:hover": {
+            background: theme =>
+              theme.palette.mode === "light"
+                ? "rgba(0, 48, 99, 0.04)"
+                : "rgba(2, 136, 209, 0.12)",
             border: theme => `2px solid ${theme.palette.primary.main}`,
             color: theme => theme.palette.primary.main
           },
@@ -82,6 +91,7 @@ export default function ModelButton({
           bottom: "0%",
           display: "flex",
           flexDirection: "row",
+          fontSize: "13px",
           gap: "10px",
           justifyContent: "center",
           left: "0%",

--- a/src/ModelButton/ModelButton.js
+++ b/src/ModelButton/ModelButton.js
@@ -89,6 +89,11 @@ export default function ModelButton({
         sx={{
           alignItems: "center",
           bottom: "0%",
+          color: disabled
+            ? theme.palette.mode === "light"
+              ? "rgba(0, 0, 0, 0.38)"
+              : "rgba(255, 255, 255, 0.5)"
+            : theme => theme.palette.text.secondary,
           display: "flex",
           flexDirection: "row",
           fontSize: "13px",

--- a/src/ModelButton/ModelButton.stories.js
+++ b/src/ModelButton/ModelButton.stories.js
@@ -1,0 +1,36 @@
+import DirectionsCarIcon from "@mui/icons-material/DirectionsCar";
+import ModelButton from "./ModelButton";
+import React from "react";
+import { action } from "@storybook/addon-actions";
+
+// define story metadata
+export default {
+  argTypes: {
+    disabled: {
+      control: "boolean"
+    },
+    icon: {
+      control: false
+    },
+    onClick: {
+      control: false
+    }
+  },
+  component: ModelButton,
+  title: "General/ModelButton"
+};
+
+// create instance of component
+const Template = args => {
+  return <ModelButton {...args} onClick={event => action("onClick")(event)} />;
+};
+
+// default story props
+export const Default = Template.bind({});
+Default.args = {
+  disabled: false,
+  icon: <DirectionsCarIcon />,
+  label: "My Model",
+  onClick: () => {},
+  status: "none"
+};

--- a/src/ModelButton/ModelButton.test.js
+++ b/src/ModelButton/ModelButton.test.js
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+
+import ModelButton from "./ModelButton";
+import React from "react";
+
+/**
+ * Tests for model button component
+ */
+describe("ModelButton", () => {
+  // test label is correctly shown
+  test("shows label", () => {
+    render(<ModelButton label="Test label" />);
+    expect(screen.getByText("Test label")).toBeInTheDocument();
+  });
+
+  // test onClick is called when button is clicked
+  test("calls onClick when clicked", () => {
+    const onClick = jest.fn();
+    render(<ModelButton onClick={onClick} />);
+    const button = screen.getByRole("button");
+    button.click();
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  // test icon is correctly shown
+  test("shows icon", () => {
+    render(<ModelButton icon={<div data-testid="test-icon" />} />);
+    expect(screen.getByTestId("test-icon")).toBeInTheDocument();
+  });
+
+  // test disabled is correctly set
+  test("sets disabled", () => {
+    render(<ModelButton disabled={true} />);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  // test status none is correctly set
+  test("sets status none", () => {
+    render(<ModelButton status="none" />);
+    const button = screen.getByTestId("model-button");
+    const styles = window.getComputedStyle(button);
+    expect(styles.border).toBe("2px solid rgba(0, 0, 0, 0.6)");
+  });
+
+  // test status error is correctly set
+  test("sets status error", () => {
+    render(<ModelButton status="error" />);
+    const button = screen.getByTestId("model-button");
+    const styles = window.getComputedStyle(button);
+    expect(styles.border).toBe("2px solid #d32f2f");
+  });
+
+  // test status warning is correctly set
+  test("sets status warning", () => {
+    render(<ModelButton status="warning" />);
+    const button = screen.getByTestId("model-button");
+    const styles = window.getComputedStyle(button);
+    expect(styles.border).toBe("2px solid #ed6c02");
+  });
+
+  // test status success is correctly set
+  test("sets status success", () => {
+    render(<ModelButton status="success" />);
+    const button = screen.getByTestId("model-button");
+    const styles = window.getComputedStyle(button);
+    expect(styles.border).toBe("2px solid #2e7d32");
+  });
+});

--- a/src/ModelButton/index.js
+++ b/src/ModelButton/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ModelButton";

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export { default as FontStyle } from "./FontStyle";
 export { default as Loading } from "./Loading";
 export { default as LoginForm } from "./LoginForm";
 export { default as NoLicense } from "./NoLicense";
+export { default as ModelButton } from "./ModelButton";
 export { default as MultiColor } from "./MultiColor";
 export { default as MultiText } from "./MultiText";
 export { default as NumberField } from "./NumberField";


### PR DESCRIPTION
Contributes to TD-1273.

Added a new model button component as per https://www.figma.com/file/B75H0DFTEiUFjJtehIKa8M/Model-Manager?node-id=1451%3A53435&t=WpgDwwhWuRpQtzje-1

![image](https://user-images.githubusercontent.com/8976377/214877130-15258aba-5595-4c95-a3b2-e299045a273c.png)

Component accepts props for disabled, icon, label, onClick and status. Styled as per Figma. Border color is set based on the status prop (none, error, warning or success). Hover effect changes border and icon to blue. Supports dark and light mode.

There will be a separate PR for the ModelButtonGroup component which will accept this ModelButton as children.