### PR TITLE
Model button grouping

### DIFF
--- a/src/ModelButton/ModelButton.js
+++ b/src/ModelButton/ModelButton.js
@@ -1,14 +1,16 @@
 import * as React from "react";
 
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box, IconButton, Popover, Stack, Typography } from "@mui/material";
 
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import PropTypes from "prop-types";
 import { useTheme } from "@mui/material/styles";
 
 /**
- * Model button component to display a button with an icon, label and border color based on the model status
+ * Model button component to display a button with an icon, label and border color based on the model status. ModelButton components can be nested to create a button group. Nested children are displayed in a popup dialog.
  */
 export default function ModelButton({
+  children,
   disabled = false,
   icon = null,
   label = "",
@@ -48,13 +50,26 @@ export default function ModelButton({
         disableRipple
         onClick={onClick}
         sx={{
+          "&::before": {
+            border: `2px solid ${borderColor}`,
+            borderRadius: "50%",
+            bottom: "-18px",
+            content: children && children.length > 0 ? '""' : "none",
+            padding: "20px",
+            position: "absolute",
+            right: "-18px"
+          },
           "&:hover": {
+            "&::before": {
+              border: theme => `2px solid ${theme.palette.primary.main}`
+            },
             background: theme =>
               theme.palette.mode === "light"
                 ? "rgba(0, 48, 99, 0.04)"
                 : "rgba(2, 136, 209, 0.12)",
             border: theme => `2px solid ${theme.palette.primary.main}`,
-            color: theme => theme.palette.primary.main
+            color: theme => theme.palette.primary.main,
+            cursor: "pointer"
           },
           alignItems: "center",
           border: `2px solid ${borderColor}`,
@@ -69,6 +84,7 @@ export default function ModelButton({
           flexDirection: "row",
           fontSize: "40px",
           left: "0%",
+          overflow: "hidden",
           padding: "16px",
           position: "absolute",
           right: "0%",
@@ -85,6 +101,11 @@ export default function ModelButton({
             })
           : null}
       </IconButton>
+      {children && children.length > 0 ? (
+        <ModelButtonPopup color={borderColor} disabled={disabled} label={label}>
+          {children}
+        </ModelButtonPopup>
+      ) : null}
       <Typography
         sx={{
           alignItems: "center",
@@ -141,4 +162,82 @@ ModelButton.propTypes = {
    * The status string that determines the border color of the button. Default is `none`.
    */
   status: PropTypes.oneOf(["none", "error", "warning", "success"])
+};
+
+// component to display children in a popup dialog
+const ModelButtonPopup = ({ color, children, disabled, label }) => {
+  // state for popover
+  const [popperOpen, setPopperOpen] = React.useState(false);
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  // handle button click to open popper
+  const handleClick = event => {
+    setAnchorEl(event.currentTarget);
+    setPopperOpen(true);
+  };
+
+  // create button and popper elements
+  return (
+    <>
+      <IconButton
+        disabled={disabled}
+        onClick={handleClick}
+        sx={{
+          "&:disabled": {
+            backgroundColor: theme =>
+              theme.palette.mode === "light" ? "#fff" : "#333"
+          },
+          "&:hover": {
+            backgroundColor: theme =>
+              theme.palette.mode === "light" ? "#fff" : "#333"
+          },
+          backgroundColor: theme =>
+            theme.palette.mode === "light" ? "#fff" : "#333",
+          bottom: "-74px",
+          padding: "6px",
+          position: "relative",
+          right: "-74px"
+        }}
+      >
+        <KeyboardArrowDownIcon
+          sx={{
+            "&:hover": {
+              backgroundColor: theme => theme.palette.primary.main
+            },
+            background: color,
+            borderRadius: "50%",
+            color: theme =>
+              theme.palette.mode === "light"
+                ? disabled
+                  ? "rgba(0, 0, 0, 0.38)"
+                  : "#fff"
+                : disabled
+                ? "rgba(255, 255, 255, 0.5)"
+                : "#000",
+            height: "24px",
+            width: "24px"
+          }}
+        />
+      </IconButton>
+      <Popover
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          horizontal: "left",
+          vertical: "bottom"
+        }}
+        onClose={() => setPopperOpen(false)}
+        open={popperOpen}
+        PaperProps={{
+          sx: { borderRadius: 2, padding: 2 }
+        }}
+      >
+        <Typography sx={{ fontSize: "14px", pb: 2 }}>{label}</Typography>
+        <Stack direction="row" spacing={3}>
+          {React.Children.map(children, child => (
+            <Box sx={{ height: "144px", width: "100px" }}>{child}</Box>
+          ))}
+        </Stack>
+      </Popover>
+    </>
+  );
 };

--- a/src/ModelButton/ModelButton.js
+++ b/src/ModelButton/ModelButton.js
@@ -180,6 +180,7 @@ const ModelButtonPopup = ({ color, children, disabled, label }) => {
   return (
     <>
       <IconButton
+        data-testid="popup-button"
         disabled={disabled}
         onClick={handleClick}
         sx={{
@@ -233,8 +234,10 @@ const ModelButtonPopup = ({ color, children, disabled, label }) => {
       >
         <Typography sx={{ fontSize: "14px", pb: 2 }}>{label}</Typography>
         <Stack direction="row" spacing={3}>
-          {React.Children.map(children, child => (
-            <Box sx={{ height: "144px", width: "100px" }}>{child}</Box>
+          {children.map((child, index) => (
+            <Box key={index} sx={{ height: "144px", width: "100px" }}>
+              {child}
+            </Box>
           ))}
         </Stack>
       </Popover>

--- a/src/ModelButton/ModelButton.stories.js
+++ b/src/ModelButton/ModelButton.stories.js
@@ -20,17 +20,53 @@ export default {
   title: "General/ModelButton"
 };
 
-// create instance of component
-const Template = args => {
+// default component with no children
+const DefaultTemplate = args => {
   return <ModelButton {...args} onClick={event => action("onClick")(event)} />;
 };
 
+// component with children
+const ChildrenTemplate = args => {
+  return (
+    <ModelButton {...args} onClick={event => action("onClick")(event)}>
+      <ModelButton
+        icon={<DirectionsCarIcon />}
+        label="Child Model 1"
+        onClick={event => action("onClick")(event)}
+        status="error"
+      />
+      <ModelButton
+        icon={<DirectionsCarIcon />}
+        label="Child Model 2"
+        onClick={event => action("onClick")(event)}
+        status="warning"
+      />
+      <ModelButton
+        icon={<DirectionsCarIcon />}
+        label="Child Model 3"
+        onClick={event => action("onClick")(event)}
+        status="success"
+      />
+    </ModelButton>
+  );
+};
+
 // default story props
-export const Default = Template.bind({});
+export const Default = DefaultTemplate.bind({});
 Default.args = {
   disabled: false,
   icon: <DirectionsCarIcon />,
   label: "My Model",
   onClick: () => {},
   status: "none"
+};
+
+// with children story props
+export const WithChildren = ChildrenTemplate.bind({});
+WithChildren.args = {
+  disabled: false,
+  icon: <DirectionsCarIcon />,
+  label: "Parent Model",
+  onClick: () => {},
+  status: "warning"
 };


### PR DESCRIPTION
Contributes to https://sce.myjetbrains.com/youtrack/issue/TD-1273/Create-new-model-class-button-component

Updated the ModelButton component to allow children to be nested to achieve this design shown below. Figma design can be found at https://www.figma.com/file/B75H0DFTEiUFjJtehIKa8M/Model-Manager?node-id=1027%3A61058&t=fJAD4DsnYV3fwNKM-1

https://user-images.githubusercontent.com/8976377/216949709-c342b98e-18b7-49ad-9c69-bf8268906687.mov

When @mattcorner and I originally discussed the design we were thinking of this syntax with a new ModelButtonGroup parent.

```
<ModelButtonGroup>
   <ModelButton />
   <ModelButton />
   <ModelButton />
</ModelButtonGroup>
```

But when I got into the dev it made more sense to allow ModelButton to have ModelButton children as the styling for the notch and popup button is directly linked to ModelButton.

```
<ModelButton>
   <ModelButton />
   <ModelButton />
   <ModelButton />
</ModelButton>
```

If there are no children then the default existing behaviour remains as so:
![image](https://user-images.githubusercontent.com/8976377/216950375-e8a731e9-16ee-43d9-81c1-9177cdf65230.png)

I'm having some issues with the tests for the new popup button which I'll need to debug with another developer separately. For now, please test the functionality in Storybook and review the code. I'll push the tests once debugged (maybe with @mattcorner tomorrow).