### PR TITLE
Feature/wizard max width

### DIFF
--- a/src/Wizard/Wizard.js
+++ b/src/Wizard/Wizard.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Box, Typography } from "@mui/material";
+import { Box, ThemeProvider, Typography } from "@mui/material";
 
 import PropTypes from "prop-types";
 
@@ -8,34 +8,58 @@ import PropTypes from "prop-types";
  * The Wizard component allows you to create a multi-step form.
  * It handles title and layout.
  */
-export default function Wizard({ title, children }) {
+export default function Wizard({ title, children, maxWidth }) {
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        height: "100%",
-        px: 2
-      }}
+    <ThemeOverride maxWidth={maxWidth}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          px: 2
+        }}
+      >
+        {title ? (
+          <Typography
+            variant="h5"
+            color="textPrimary"
+            sx={{
+              fontWeight: 500,
+              maxWidth: theme => theme?.layout?.content?.maxWidth,
+              mb: 3,
+              mt: 1,
+              mx: "auto",
+              width: "100%"
+            }}
+          >
+            {title}
+          </Typography>
+        ) : null}
+        {children}
+      </Box>
+    </ThemeOverride>
+  );
+}
+
+/**
+ * Internal wrapper for ThemeProvider that overrides the layout.content.maxWidth if maxWidth is provided.
+ */
+function ThemeOverride({ children, maxWidth }) {
+  return maxWidth ? (
+    <ThemeProvider
+      theme={baseTheme => ({
+        ...baseTheme,
+        layout: {
+          content: {
+            maxWidth
+          }
+        }
+      })}
     >
-      {title ? (
-        <Typography
-          variant="h5"
-          color="textPrimary"
-          sx={{
-            fontWeight: 500,
-            maxWidth: theme => theme?.layout?.content?.maxWidth,
-            mb: 3,
-            mt: 1,
-            mx: "auto",
-            width: "100%"
-          }}
-        >
-          {title}
-        </Typography>
-      ) : null}
       {children}
-    </Box>
+    </ThemeProvider>
+  ) : (
+    children
   );
 }
 
@@ -46,7 +70,22 @@ Wizard.propTypes = {
    */
   children: PropTypes.node,
   /**
+   * Maximum width of the content. This includes the title, steps, and content, but not the actions.
+   */
+  maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
    * Wizard title
    */
   title: PropTypes.string
+};
+
+ThemeOverride.propTypes = {
+  /**
+   * Children.
+   */
+  children: PropTypes.node,
+  /**
+   * Maximum width to override in the theme.
+   */
+  maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };

--- a/src/Wizard/Wizard.js
+++ b/src/Wizard/Wizard.js
@@ -70,7 +70,7 @@ Wizard.propTypes = {
    */
   children: PropTypes.node,
   /**
-   * Maximum width of the content. This includes the title, steps, and content, but not the actions.
+   * Maximum width of the content. This includes the title, steps, and content, but not the actions. Default is taken from the parent theme (layout.content.maxWidth).
    */
   maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**

--- a/src/Wizard/Wizard.stories.js
+++ b/src/Wizard/Wizard.stories.js
@@ -32,11 +32,13 @@ const Template = args => {
 // default story
 export const Default = Template.bind({});
 Default.args = {
-  title: "Wizard Title"
+  maxWidth: 1152,
+  title: ""
 };
 
-// no title story
-export const NoTitle = Template.bind({});
-NoTitle.args = {
-  title: ""
+// with title story
+export const WithTitle = Template.bind({});
+WithTitle.args = {
+  ...Default.args,
+  title: "Wizard Title"
 };

--- a/src/Wizard/Wizard.stories.js
+++ b/src/Wizard/Wizard.stories.js
@@ -8,6 +8,11 @@ export default {
   argTypes: {
     children: {
       control: false
+    },
+    maxWidth: {
+      control: {
+        type: "number"
+      }
     }
   },
   component: Wizard,

--- a/src/Wizard/Wizard.test.js
+++ b/src/Wizard/Wizard.test.js
@@ -19,6 +19,14 @@ describe("Wizard", () => {
     expect(screen.getByTestId("child1")).toBeInTheDocument();
     expect(screen.getByTestId("child2")).toBeInTheDocument();
   });
+  it("has a default max width", () => {
+    render(
+      <ThemeProvider>
+        <Wizard title="Wizard Title" />
+      </ThemeProvider>
+    );
+    expect(screen.getByText("Wizard Title")).toHaveStyle("max-width: 1152px");
+  });
   it("can set max width", () => {
     render(
       <ThemeProvider>

--- a/src/Wizard/Wizard.test.js
+++ b/src/Wizard/Wizard.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 
 import React from "react";
+import ThemeProvider from "../ThemeProvider/ThemeProvider";
 import Wizard from "./Wizard";
 
 describe("Wizard", () => {
@@ -17,5 +18,13 @@ describe("Wizard", () => {
     );
     expect(screen.getByTestId("child1")).toBeInTheDocument();
     expect(screen.getByTestId("child2")).toBeInTheDocument();
+  });
+  it("can set max width", () => {
+    render(
+      <ThemeProvider>
+        <Wizard maxWidth={100} title="Wizard Title" />
+      </ThemeProvider>
+    );
+    expect(screen.getByText("Wizard Title")).toHaveStyle("max-width: 100px");
   });
 });


### PR DESCRIPTION
Release notes:
* New `maxWidth` property on the `<Wizard />` component which allows overriding the default maximum content width of 1152px.

New api looks as follows, where maxWidth can be a string or a number. Behind the scenes it employs the same ThemeProvider override that we are using in place of this fix in some apps.

```
<Wizard maxWidth="1000px" />
<Wizard maxWidth={1000} />
```