### PR TITLE
Change Failed to Errored for in StatusLabel/StatusMessage

### DIFF
--- a/src/Status/statuses.js
+++ b/src/Status/statuses.js
@@ -40,7 +40,7 @@ const statuses = {
     },
     label: {
       color: red[700],
-      text: "Failed"
+      text: "Errored"
     }
   },
   "not-ready": {


### PR DESCRIPTION
Changes:
* Change Failed to Errored for in StatusLabel/StatusMessage to avoid mixing up with the "Failed" status of a metric.

Old:
![image](https://user-images.githubusercontent.com/27866636/220945221-bc8f47eb-85f1-4ea3-ba6d-300dfd80a932.png)

New:
![image](https://user-images.githubusercontent.com/27866636/220945284-ee2260ef-a81a-4bfd-a52a-001eff46d799.png)
