### PR TITLE
Fix dark mode primary color

### DIFF
--- a/src/AppHeader/AppHeader.js
+++ b/src/AppHeader/AppHeader.js
@@ -31,10 +31,7 @@ function Header({
   return (
     <AppBar
       sx={theme => ({
-        backgroundColor:
-          theme.palette.mode === "light"
-            ? theme.palette.primary.main
-            : "#87A5D2"
+        backgroundColor: theme.palette.primary.main
       })}
     >
       <Toolbar style={{ justifyContent: "space-between" }}>

--- a/src/ThemeProvider/ThemeProvider.js
+++ b/src/ThemeProvider/ThemeProvider.js
@@ -128,7 +128,7 @@ const darkTheme = createTheme(
         default: "#121212"
       },
       mode: "dark",
-      primary: { main: "#42a5f5" }
+      primary: { main: "#87A5D2" }
     },
     typography: {
       allVariants: {


### PR DESCRIPTION
As I was reviewing the new app layout component integration with our apps I noticed that dark mode primary color was wrong. You can see sidebar items were wrong color compared to Figma and so was anything in our apps that was using primary color, e.g. the plots in results app.

Before:
![image](https://user-images.githubusercontent.com/8976377/222258549-3d722b71-ebe0-4ce6-be9c-5f6185613f4c.png)

Now:
![image](https://user-images.githubusercontent.com/8976377/222258513-500eb51e-c4a4-433d-9c84-ef5219edbb7e.png)
