### PR TITLE
fix for model button style broken

### DIFF
--- a/src/ModelButton/ModelButton.js
+++ b/src/ModelButton/ModelButton.js
@@ -60,8 +60,7 @@ export default function ModelButton({
             content: arrayChildren && arrayChildren.length > 0 ? '""' : "none",
             padding: "20px",
             position: "absolute",
-            right: "-18px",
-            width: "100%"
+            right: "-18px"
           },
           "&:hover": {
             "&::before": {
@@ -93,7 +92,8 @@ export default function ModelButton({
           position: "absolute",
           right: "0%",
           top: "0%",
-          transition: "all 0.2s ease-in-out"
+          transition: "all 0.2s ease-in-out",
+          width: "100%"
         }}
       >
         {icon
@@ -201,8 +201,7 @@ const ModelButtonPopup = ({ color, children, disabled, label }) => {
           bottom: "-74px",
           padding: "6px",
           position: "relative",
-          right: "-74px",
-          width: "100%"
+          right: "-74px"
         }}
       >
         <KeyboardArrowDownIcon


### PR DESCRIPTION
This is a fix for the ModelButton broken style in the storybook.

this
![screenshot-localhost_6006-2023 03 02-09_41_20](https://user-images.githubusercontent.com/56511816/222391364-77ce43f3-5abd-4727-a9a1-9459451484c6.png)

to this
![screenshot-localhost_6006-2023 03 02-09_41_57](https://user-images.githubusercontent.com/56511816/222391422-f46aa77e-3434-4d92-a2ab-da6e5942b7ca.png)
