### PR TITLE
Bugfix/model button inset icon radius

### DIFF
--- a/src/ModelButton/ModelButton.js
+++ b/src/ModelButton/ModelButton.js
@@ -60,7 +60,8 @@ export default function ModelButton({
             content: arrayChildren && arrayChildren.length > 0 ? '""' : "none",
             padding: "20px",
             position: "absolute",
-            right: "-18px"
+            right: "-18px",
+            transition: "all 0.2s ease-in-out"
           },
           "&:hover": {
             "&::before": {

--- a/src/ModelButton/ModelButton.js
+++ b/src/ModelButton/ModelButton.js
@@ -55,7 +55,7 @@ export default function ModelButton({
         sx={{
           "&::before": {
             border: `2px solid ${borderColor}`,
-            borderRadius: "50%",
+            borderRadius: "20px 0 0 0",
             bottom: "-18px",
             content: arrayChildren && arrayChildren.length > 0 ? '""' : "none",
             padding: "20px",
@@ -198,6 +198,7 @@ const ModelButtonPopup = ({ color, children, disabled, label }) => {
           },
           backgroundColor: theme =>
             theme.palette.mode === "light" ? "#fff" : "#333",
+          borderRadius: "20px 0 0 0",
           bottom: "-74px",
           padding: "6px",
           position: "relative",


### PR DESCRIPTION
Contributes to [TD-1441](https://sce.myjetbrains.com/youtrack/issue/TD-1441/Drop-down-arrow-overlaps-green-box-in-Chrome)

Please just approve, I'll take care over merge/release notes/ release.

Main change is that the inset radius now behaves correctly.

Before:
<img width="224" alt="image" src="https://user-images.githubusercontent.com/27866636/223134574-1cf0d1df-3d97-4d16-bbd8-1cbb40603c6d.png">

After:
<img width="214" alt="image" src="https://user-images.githubusercontent.com/27866636/223135420-0443ee58-cdf9-4419-a277-f7bbdafb93e0.png">

Secondary fix is that the inset radius now animates correctly on hover. Previous is changed colour instantly, while the outer border eased in. 

Before:

https://user-images.githubusercontent.com/27866636/223135215-36ab6566-b70d-47fc-94cb-8997c1d2387e.mov

After:

https://user-images.githubusercontent.com/27866636/223135630-7a1ac888-8439-4e96-b537-955036bd07b0.mov


