### PR TITLE
font-weight updated

### DIFF
--- a/src/Wizard/Wizard.js
+++ b/src/Wizard/Wizard.js
@@ -24,7 +24,7 @@ export default function Wizard({ title, children, maxWidth }) {
             variant="h5"
             color="textPrimary"
             sx={{
-              fontWeight: 500,
+              fontWeight: 700,
               maxWidth: theme => theme?.layout?.content?.maxWidth,
               mb: 3,
               mt: 1,


### PR DESCRIPTION
- A small update to the Wizard title font weight to match the new Figma

Figma
![screenshot-www figma com-2023 03 16-14_59_06](https://user-images.githubusercontent.com/56511816/225659383-81a56612-d014-42a1-8a08-430637d37115.png)

this
![screenshot-localhost_6006-2023 03 16-14_58_31](https://user-images.githubusercontent.com/56511816/225659679-e67cdd79-cf95-467b-8b64-3a8b3bbd68d9.png)

to this
![screenshot-localhost_6006-2023 03 16-14_58_54](https://user-images.githubusercontent.com/56511816/225659620-353ee495-9484-42b8-838e-e98d2578bc6e.png)
