### PR TITLE
Bugfix/app layout scroll area

### DIFF
--- a/src/AppHeader/AppHeader.js
+++ b/src/AppHeader/AppHeader.js
@@ -152,8 +152,8 @@ function AppHeader({
           onClose={() => setAppOpen(false)}
           sx={{
             "& .MuiDrawer-paper": {
-              height: `calc(100% - 64px)`,
-              top: "64px",
+              height: theme => `calc(100% - ${theme.mixins.toolbar.minHeight})`,
+              top: theme => theme.mixins.toolbar.minHeight,
               width: applancherWidth
             }
           }}

--- a/src/AppLayout/AppLayout.js
+++ b/src/AppLayout/AppLayout.js
@@ -101,11 +101,16 @@ function Layout({
         >
           <Box sx={theme => theme.mixins.toolbar} />
           <Box
-            sx={{
-              height: theme =>
-                `calc(100vh - ${theme.mixins.toolbar.minHeight}px)`,
-              overflow: "auto"
-            }}
+            sx={theme => ({
+              height: `calc(100vh - ${theme.mixins.toolbar.minHeight}px)`,
+              overflow: "auto",
+              [theme.breakpoints.down("md")]: {
+                width: "100vw"
+              },
+              [theme.breakpoints.up("md")]: {
+                width: `calc(100vw - ${sidebarWidth}px)`
+              }
+            })}
           >
             <SnackbarProvider>{content}</SnackbarProvider>
           </Box>

--- a/src/AppLayout/AppLayout.stories.js
+++ b/src/AppLayout/AppLayout.stories.js
@@ -34,7 +34,20 @@ Default.args = {
     }
   ],
   appVersion: version,
-  content: <div>App Content goes here</div>,
+  /**
+   * Content set to something that forces the content to be scrollable
+   */
+  content: (
+    <div
+      style={{
+        height: "110vw",
+        padding: "16px",
+        width: "110vw"
+      }}
+    >
+      App Content goes here
+    </div>
+  ),
   mode: "light",
   sidebarContent: (
     <>
@@ -48,4 +61,7 @@ Default.args = {
     </>
   ),
   username: "Ruud van Nistelrooy"
+};
+Default.parameters = {
+  layout: "fullscreen" // removes the padding from the story iframe for this story
 };


### PR DESCRIPTION
Resolves issue that the content area of the AppLayout does not have an explitly calculated width set. This meant that scrollbars appeared over the sidebar, rather than only in the content area:

Before:
<img width="1283" alt="image" src="https://user-images.githubusercontent.com/27866636/228068919-4d1d9c0b-9693-4644-8fd9-21c4af304f00.png">

After
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/27866636/228069031-bab2c25d-76db-4ce4-9e5b-cc714f18ed7e.png">
