### PR TITLE
Switch to relative app links

### DIFF
--- a/src/AppHeader/AppHeader.js
+++ b/src/AppHeader/AppHeader.js
@@ -159,9 +159,9 @@ function AppHeader({
           }}
         >
           <AppLauncher
+            baseUrl={baseUrl}
             logoLinkUrl={virtoLogoLinkUrl}
             onAppButtonClick={() => setAppOpen(false)}
-            url={baseUrl}
           />
         </Drawer>
       </Hidden>

--- a/src/AppHeader/AppHeader.js
+++ b/src/AppHeader/AppHeader.js
@@ -111,7 +111,7 @@ function Header({
 // app header component
 function AppHeader({
   appName,
-  appUrls,
+  baseUrl,
   mode,
   onChangePassword,
   onLogout,
@@ -159,9 +159,9 @@ function AppHeader({
           }}
         >
           <AppLauncher
-            appUrls={appUrls}
             logoLinkUrl={virtoLogoLinkUrl}
             onAppButtonClick={() => setAppOpen(false)}
+            url={baseUrl}
           />
         </Drawer>
       </Hidden>
@@ -171,28 +171,18 @@ function AppHeader({
 
 AppHeader.propTypes = {
   /**
-   * App version to display in header.
+   * App name to display in header.
    */
   appName: PropTypes.string.isRequired,
   /**
-   *  List of apps to display in the AppLauncher
-   * @default []
-   * @type {array}
-   * @example
-   * [
-   * {
-   * "VIRTO.BUILD": "https://someurl.com",
-   * "VIRTO.ID": "https://someurl.com",
-   * }
-   * ]
+   * Base URL for VIRTO home page.
    */
-  appUrls: PropTypes.array,
+  baseUrl: PropTypes.string,
   /**
    * The color mode selection
    * @default "light"
    */
   mode: PropTypes.oneOf(["light", "dark"]),
-
   /**
    * Callback fired when the user clicks on "Change password".
    *

--- a/src/AppHeader/AppHeader.stories.js
+++ b/src/AppHeader/AppHeader.stories.js
@@ -29,14 +29,7 @@ const Template = args => {
 export const Default = Template.bind({});
 Default.args = {
   appName: "APP NAME",
-  appUrls: [
-    {
-      "VIRTO.BUILD": "https://someurl.com",
-      "VIRTO.DATA": "https://someurl.com",
-      "VIRTO.FLEET": "https://someurl.com",
-      "VIRTO.ID": "https://someurl.com"
-    }
-  ],
+  baseUrl: "http://localhost:3000",
   mode: "light",
   username: "Ruud van Nistelrooy"
 };

--- a/src/AppLauncher/AppLauncher.js
+++ b/src/AppLauncher/AppLauncher.js
@@ -17,10 +17,10 @@ import VirtoLogo from "../SvgIcons/VirtoLogo";
 
 // AppLauncher component for app which displays logo, list of items and app version
 function AppLauncher({
+  baseUrl = "http://localhost:3000",
   logoLinkUrl = null,
   onAppButtonClick = () => {},
-  showLogo = true,
-  url = "http://localhost:3000"
+  showLogo = true
 }) {
   // styles for virto app icons
   const iconStyle = { height: 74, mb: 1, width: 74 };
@@ -30,47 +30,47 @@ function AppLauncher({
     {
       icon: <VirtoBuild sx={iconStyle} />,
       name: "VIRTO.BUILD",
-      url: `${url}/fleet/build`
+      url: `${baseUrl}/fleet/build`
     },
     {
       icon: <VirtoFleet sx={iconStyle} />,
       name: "VIRTO.FLEET",
-      url: `${url}/fleet`
+      url: `${baseUrl}/fleet`
     },
     {
       icon: <VirtoModel sx={iconStyle} />,
       name: "VIRTO.MODEL",
-      url: `${url}/model`
+      url: `${baseUrl}/model`
     },
     {
       icon: <VirtoScene sx={iconStyle} />,
       name: "VIRTO.SCENE",
-      url: `${url}/scene`
+      url: `${baseUrl}/scene`
     },
     {
       icon: <VirtoTest sx={iconStyle} />,
       name: "VIRTO.TEST",
-      url: `${url}/test`
+      url: `${baseUrl}/test`
     },
     {
       icon: <VirtoResult sx={iconStyle} />,
       name: "VIRTO.RESULT",
-      url: `${url}/result`
+      url: `${baseUrl}/result`
     },
     {
       icon: <VirtoData sx={iconStyle} />,
       name: "VIRTO.DATA",
-      url: `${url}/data`
+      url: `${baseUrl}/data`
     },
     {
       icon: <VirtoVehicle sx={iconStyle} />,
       name: "VIRTO.VEHICLE",
-      url: `${url}/vehicle`
+      url: `${baseUrl}/vehicle`
     },
     {
       icon: <VirtoID sx={iconStyle} />,
       name: "VIRTO.ID",
-      url: `${url}/id`
+      url: `${baseUrl}/id`
     }
   ];
 
@@ -170,6 +170,12 @@ function AppLauncher({
 
 AppLauncher.propTypes = {
   /**
+   * Base URL for VIRTO home page. All apps are served relative to this URL.
+   * @default 'http://localhost:3000'
+   * @type {string}
+   */
+  baseUrl: PropTypes.string,
+  /**
    * A String of the href URL for the Link of the IPG Logo, default is null (link disabled)
    */
   logoLinkUrl: PropTypes.string,
@@ -186,13 +192,7 @@ AppLauncher.propTypes = {
   /**
    * Boolean to determine if logo should be displayed at the top of the AppLauncher
    */
-  showLogo: PropTypes.bool,
-  /**
-   *  Base URL for VIRTO home page. All apps are served relative to this URL.
-   * @default 'http://localhost:3000'
-   * @type {string}
-   */
-  url: PropTypes.string
+  showLogo: PropTypes.bool
 };
 
 export default AppLauncher;

--- a/src/AppLauncher/AppLauncher.js
+++ b/src/AppLauncher/AppLauncher.js
@@ -18,9 +18,9 @@ import VirtoLogo from "../SvgIcons/VirtoLogo";
 // AppLauncher component for app which displays logo, list of items and app version
 function AppLauncher({
   logoLinkUrl = null,
+  onAppButtonClick = () => {},
   showLogo = true,
-  appUrls,
-  onAppButtonClick
+  url = "http://localhost:3000"
 }) {
   // styles for virto app icons
   const iconStyle = { height: 74, mb: 1, width: 74 };
@@ -29,39 +29,48 @@ function AppLauncher({
   const appList = [
     {
       icon: <VirtoBuild sx={iconStyle} />,
-      name: "VIRTO.BUILD"
+      name: "VIRTO.BUILD",
+      url: `${url}/fleet/build`
     },
     {
       icon: <VirtoFleet sx={iconStyle} />,
-      name: "VIRTO.FLEET"
+      name: "VIRTO.FLEET",
+      url: `${url}/fleet`
     },
     {
       icon: <VirtoModel sx={iconStyle} />,
-      name: "VIRTO.MODEL"
+      name: "VIRTO.MODEL",
+      url: `${url}/model`
     },
     {
       icon: <VirtoScene sx={iconStyle} />,
-      name: "VIRTO.SCENE"
+      name: "VIRTO.SCENE",
+      url: `${url}/scene`
     },
     {
       icon: <VirtoTest sx={iconStyle} />,
-      name: "VIRTO.TEST"
+      name: "VIRTO.TEST",
+      url: `${url}/test`
     },
     {
       icon: <VirtoResult sx={iconStyle} />,
-      name: "VIRTO.RESULT"
+      name: "VIRTO.RESULT",
+      url: `${url}/result`
     },
     {
       icon: <VirtoData sx={iconStyle} />,
-      name: "VIRTO.DATA"
+      name: "VIRTO.DATA",
+      url: `${url}/data`
     },
     {
       icon: <VirtoVehicle sx={iconStyle} />,
-      name: "VIRTO.VEHICLE"
+      name: "VIRTO.VEHICLE",
+      url: `${url}/vehicle`
     },
     {
       icon: <VirtoID sx={iconStyle} />,
-      name: "VIRTO.ID"
+      name: "VIRTO.ID",
+      url: `${url}/id`
     }
   ];
 
@@ -117,7 +126,7 @@ function AppLauncher({
               onClick={handleAppButtonClick(onAppButtonClick)}
               key={app.name}
               component="a"
-              href={appUrls?.length > 0 ? appUrls[0][app.name] : "#"}
+              href={app.url}
               target="_blank"
               data-testid={app.name}
               sx={theme => ({
@@ -132,14 +141,6 @@ function AppLauncher({
                 boxShadow: "none",
                 cursor: "pointer",
                 mb: 2,
-                opacity:
-                  appUrls?.length > 0 && appUrls[0][app.name] !== undefined
-                    ? 1
-                    : 0.5,
-                pointerEvents:
-                  appUrls?.length > 0 && appUrls[0][app.name] !== undefined
-                    ? "auto"
-                    : "none",
                 textDecoration: "none",
                 width: 120
               })}
@@ -169,19 +170,6 @@ function AppLauncher({
 
 AppLauncher.propTypes = {
   /**
-   *  List of apps to display in the AppLauncher
-   * @default []
-   * @type {array}
-   * @example
-   * [
-   * {
-   * "VIRTO.BUILD": "https://someurl.com",
-   * "VIRTO.ID": "https://someurl.com",
-   * }
-   * ]
-   */
-  appUrls: PropTypes.array,
-  /**
    * A String of the href URL for the Link of the IPG Logo, default is null (link disabled)
    */
   logoLinkUrl: PropTypes.string,
@@ -198,7 +186,13 @@ AppLauncher.propTypes = {
   /**
    * Boolean to determine if logo should be displayed at the top of the AppLauncher
    */
-  showLogo: PropTypes.bool
+  showLogo: PropTypes.bool,
+  /**
+   *  Base URL for VIRTO home page. All apps are served relative to this URL.
+   * @default 'http://localhost:3000'
+   * @type {string}
+   */
+  url: PropTypes.string
 };
 
 export default AppLauncher;

--- a/src/AppLauncher/AppLauncher.stories.js
+++ b/src/AppLauncher/AppLauncher.stories.js
@@ -26,14 +26,7 @@ const Template = args => {
 // default story
 export const Default = Template.bind({});
 Default.args = {
-  appUrls: [
-    {
-      "VIRTO.BUILD": "https://someurl.com",
-      "VIRTO.DATA": "https://someurl.com",
-      "VIRTO.FLEET": "https://someurl.com",
-      "VIRTO.ID": "https://someurl.com"
-    }
-  ],
+  baseUrl: "http://localhost:3000",
   showLogo: true
 };
 

--- a/src/AppLayout/AppLayout.js
+++ b/src/AppLayout/AppLayout.js
@@ -151,7 +151,7 @@ function AppLayout({
 
 AppLayout.propTypes = {
   /**
-   * App version to display in header.
+   * App name to display in header.
    */
   appName: PropTypes.string.isRequired,
   /**

--- a/src/AppLayout/AppLayout.js
+++ b/src/AppLayout/AppLayout.js
@@ -11,7 +11,7 @@ import useTheme from "../ThemeProvider/useTheme";
 // app layout component
 function Layout({
   appVersion,
-  appUrls,
+  baseUrl,
   sidebarContent,
   virtoLogoLinkUrl = null,
   appName,
@@ -45,7 +45,7 @@ function Layout({
           onModeChange={newMode => setTheme(newMode)}
           username={username}
           mode={theme}
-          appUrls={appUrls}
+          baseUrl={baseUrl}
           virtoLogoLinkUrl={virtoLogoLinkUrl}
         />
         <Box
@@ -123,7 +123,7 @@ function Layout({
 // app layout wrapper component
 function AppLayout({
   appVersion,
-  appUrls,
+  baseUrl,
   sidebarContent,
   virtoLogoLinkUrl = null,
   appName,
@@ -136,7 +136,7 @@ function AppLayout({
     <ThemeProvider>
       <Layout
         appVersion={appVersion}
-        appUrls={appUrls}
+        baseUrl={baseUrl}
         sidebarContent={sidebarContent}
         virtoLogoLinkUrl={virtoLogoLinkUrl}
         appName={appName}
@@ -155,22 +155,13 @@ AppLayout.propTypes = {
    */
   appName: PropTypes.string.isRequired,
   /**
-   *  List of apps to display in the AppLauncher
-   * @default []
-   * @type {array}
-   * @example
-   * [
-   * {
-   * "VIRTO.BUILD": "https://someurl.com",
-   * "VIRTO.ID": "https://someurl.com",
-   * }
-   * ]
-   */
-  appUrls: PropTypes.array,
-  /**
    * App version to display at base of sidebar.
    */
   appVersion: PropTypes.string,
+  /**
+   * Base URL for VIRTO home page.
+   */
+  baseUrl: PropTypes.string,
   /**
    * The RHS content of the component app. Valid react element can be used.
    */

--- a/src/AppLayout/AppLayout.stories.js
+++ b/src/AppLayout/AppLayout.stories.js
@@ -25,15 +25,8 @@ const Template = args => {
 export const Default = Template.bind({});
 Default.args = {
   appName: "APP NAME",
-  appUrls: [
-    {
-      "VIRTO.BUILD": "https://someurl.com",
-      "VIRTO.DATA": "https://someurl.com",
-      "VIRTO.FLEET": "https://someurl.com",
-      "VIRTO.ID": "https://someurl.com"
-    }
-  ],
   appVersion: version,
+  baseUrl: "http://localhost:3000",
   /**
    * Content set to something that forces the content to be scrollable
    */


### PR DESCRIPTION
Contributes to TD-1604.

Now that each app is served from a sub-path relative to a base URL, rather than sub-domains, we no longer need to manage links for each app. Instead we can just pass a base URL and then fix the relative links for each app inside the React-UI component. This simplifies usage in each app and reduces the number of environment variables down to just one for the base URL rather than the current implementation requiring a variable for each app.

AppLauncher is the component that contains the links for each app in the dropdown drawer. This now has a new url prop which replaces appUrls. The URL links for each app are then fixed inside this component relative to the base URL. AppLayout is the top level component we actually use in each app and this propagates the baseUrl through to AppLauncher.

These app links here are the ones related to these changes.
![image](https://user-images.githubusercontent.com/8976377/228799809-5f40af91-4394-4f0f-a5f5-dd4f88257d17.png)
