### PR TITLE
Bugfix/summary card more options click to close

### DIFF
--- a/src/Card/SummaryCard/SummaryCard.js
+++ b/src/Card/SummaryCard/SummaryCard.js
@@ -355,6 +355,7 @@ function SummaryCard({
         open={isMoreOptionsOpen}
         anchorEl={moreOptionsAnchorEl}
         onClose={handleMoreOptionsClose}
+        onClick={handleMoreOptionsClose}
         anchorOrigin={{
           horizontal: "left",
           vertical: "bottom"

--- a/src/Card/SummaryCard/SummaryCard.stories.js
+++ b/src/Card/SummaryCard/SummaryCard.stories.js
@@ -6,6 +6,8 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  MenuItem,
+  MenuList,
   Table,
   TableBody,
   TableCell,
@@ -130,24 +132,20 @@ export const withMoreOptionsPopover = Template.bind({});
 withMoreOptionsPopover.args = {
   ...Default.args,
   moreOptionsPopover: (
-    <List>
-      <ListItem disablePadding>
-        <ListItemButton onClick={action("onEditClick")}>
-          <ListItemIcon>
-            <Edit />
-          </ListItemIcon>
-          <ListItemText primary="Edit" />
-        </ListItemButton>
-      </ListItem>
-      <ListItem disablePadding>
-        <ListItemButton onClick={action("onDeleteClick")}>
-          <ListItemIcon>
-            <Delete />
-          </ListItemIcon>
-          <ListItemText primary="Delete" />
-        </ListItemButton>
-      </ListItem>
-    </List>
+    <MenuList>
+      <MenuItem onClick={action("onEditClick")}>
+        <ListItemIcon>
+          <Edit />
+        </ListItemIcon>
+        <ListItemText primary="Edit" />
+      </MenuItem>
+      <MenuItem onClick={action("onDeleteClick")}>
+        <ListItemIcon>
+          <Delete />
+        </ListItemIcon>
+        <ListItemText primary="Delete" />
+      </MenuItem>
+    </MenuList>
   )
 };
 

--- a/src/Card/SummaryCard/SummaryCard.test.js
+++ b/src/Card/SummaryCard/SummaryCard.test.js
@@ -6,6 +6,8 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  MenuItem,
+  MenuList,
   Stack
 } from "@mui/material";
 import { Delete, Edit } from "@mui/icons-material";
@@ -115,8 +117,39 @@ describe("SummaryCard", () => {
     await userEvent.click(screen.getByRole("button", { name: "settings" }));
 
     // expect the popover to be in the document
-    expect(screen.getByText("Edit")).toBeInTheDocument();
-    expect(screen.getByText("Delete")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeVisible();
+    expect(screen.getByText("Delete")).toBeVisible();
+  });
+
+  it("closes more options popover when clicked", async () => {
+    const editFcn = jest.fn();
+
+    render(
+      <SummaryCard
+        title="summary card title"
+        subtitle="summary card subtitle"
+        moreOptionsPopover={
+          <MenuList>
+            <MenuItem onClick={editFcn}>Test Menu</MenuItem>
+          </MenuList>
+        }
+      />
+    );
+
+    // find the ... button and click it
+    await userEvent.click(screen.getByRole("button", { name: "settings" }));
+
+    // expect the popover to be in the document
+    expect(screen.getByText("Test Menu")).toBeVisible();
+
+    // click one of the options
+    await userEvent.click(screen.getByText("Test Menu"));
+
+    // expect callback to be called
+    expect(editFcn).toHaveBeenCalledTimes(1);
+
+    // expect the popover to be removed from the document
+    expect(screen.queryByText("Test Menu")).not.toBeVisible();
   });
 
   // test that a content is rendered in summary card


### PR DESCRIPTION
### Bug
Resolves bug raised by @Sowbhagya-ipg. When a more options menu item is pressed, the menu itself remains open. The Menu should close on click.

### Resolution
The Popover now closes onClick. This works because javascript events bubble up the DOM tree.

### Testing
* See the Card/SummaryCard/With more options popover story. 
* I've added a test to confirm the behaviour fixed in this bug.

### UI/UX demo
https://user-images.githubusercontent.com/27866636/231292766-750daf7e-cbae-481b-982e-b8b30f7da5e3.mov

