### PR TITLE
Correct LabelChip font

### DIFF
--- a/src/LabelSelector/LabelChip/LabelChip.js
+++ b/src/LabelSelector/LabelChip/LabelChip.js
@@ -1,4 +1,4 @@
-import { Chip, darken } from "@mui/material";
+import { Chip, alpha, chipClasses, darken } from "@mui/material";
 
 import PropTypes from "prop-types";
 import React from "react";
@@ -21,10 +21,16 @@ export default function LabelChip({
       clickable={clickable}
       sx={{
         "&:hover": {
-          backgroundColor: darken(color, 0.2)
+          backgroundColor: clickable ? darken(color, 0.2) : color
         },
         backgroundColor: color,
-        color: theme => theme.palette.getContrastText(color)
+        color: theme => theme.palette.getContrastText(color),
+        [`& .${chipClasses.deleteIcon}`]: {
+          color: theme => alpha(theme.palette.getContrastText(color), 0.7)
+        },
+        [`& .${chipClasses.deleteIcon}:hover`]: {
+          color: theme => theme.palette.getContrastText(color)
+        }
       }}
       label={label}
       onClick={onClick}

--- a/src/LabelSelector/LabelChip/LabelChip.js
+++ b/src/LabelSelector/LabelChip/LabelChip.js
@@ -1,6 +1,5 @@
-import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { Chip, darken } from "@mui/material";
 
-import { Chip } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -15,29 +14,24 @@ export default function LabelChip({
   variant = "filled",
   ...props
 }) {
-  // create theme to overide primary color
-  const theme = createTheme({
-    palette: {
-      primary: {
-        main: color
-      }
-    }
-  });
-
   // return the styled chip component
   return (
-    <ThemeProvider theme={theme}>
-      <Chip
-        {...props}
-        clickable={clickable}
-        color="primary"
-        label={label}
-        onClick={onClick}
-        onDelete={onDelete}
-        size={size}
-        variant={variant}
-      />
-    </ThemeProvider>
+    <Chip
+      {...props}
+      clickable={clickable}
+      sx={{
+        "&:hover": {
+          backgroundColor: darken(color, 0.2)
+        },
+        backgroundColor: color,
+        color: theme => theme.palette.getContrastText(color)
+      }}
+      label={label}
+      onClick={onClick}
+      onDelete={onDelete}
+      size={size}
+      variant={variant}
+    />
   );
 }
 


### PR DESCRIPTION
### Bug

LabelChip is showing the Roboto font rather than the Montserra font as raised by @Sowbhagya-ipg

### Resolution

We were wrapping each Chip in its own ThemeProvider to override its colour, but this also overrode everything in our React-UI ThemeProvider meaning we lost the font. I've removed the wrapping ThemeProvider and instead styled it using the sx prop so that we get the best of both worlds.

### Testing

* Open Storybook
* Inspect the element
* Check font shows as Montserra

https://user-images.githubusercontent.com/27866636/231391246-02f456ba-adf6-41f7-a899-ac0f4b3fae0d.mov


