### PR TITLE
Bugfix/label selector long string

### DIFF
--- a/src/LabelSelector/LabelSelector.js
+++ b/src/LabelSelector/LabelSelector.js
@@ -4,6 +4,7 @@ import {
   Button,
   IconButton,
   Paper,
+  Stack,
   TextField,
   Tooltip
 } from "@mui/material";
@@ -14,6 +15,7 @@ import Checkbox from "../Checkbox";
 import DeleteLabelDialog from "./DeleteLabelDialog/DeleteLabelDialog";
 import EditLabelDialog from "./EditLabelDialog/EditLabelDialog";
 import LabelChip from "./LabelChip/LabelChip";
+import NoWrapTypography from "../NoWrapTypography/NoWrapTypography";
 import PropTypes from "prop-types";
 
 // custom styling
@@ -37,9 +39,6 @@ const styles = {
     height: 18,
     opacity: 0.6,
     width: 18
-  },
-  text: {
-    flexGrow: 1
   }
 };
 
@@ -189,43 +188,51 @@ function LabelSelector({
         }}
         renderOption={(props, option, { selected }) => (
           <Box key={option._id} component="li" {...props}>
-            <Checkbox
-              checked={selected}
-              size={size}
-              style={{
-                "&.Mui-checked": { color: option.color },
-                color: option.color
-              }}
-            />
-            <div style={styles.text}>
-              {option.name}
-              <br />
-              <div style={{ fontSize: "80%" }}>{option.description}</div>
-            </div>
-            <>
-              {editEnabled && (
-                <Tooltip title="Edit">
-                  <IconButton
-                    data-testid={`edit-label-${option._id}`}
-                    size={size}
-                    onClick={event => onEditClick(event, option)}
-                  >
-                    <Edit sx={styles.editIcon} />
-                  </IconButton>
-                </Tooltip>
-              )}
-              {deleteEnabled && (
-                <Tooltip title="Delete">
-                  <IconButton
-                    data-testid={`delete-label-${option._id}`}
-                    size={size}
-                    onClick={event => onDeleteClick(event, option)}
-                  >
-                    <Delete sx={styles.deleteIcon} />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </>
+            <Stack
+              direction="row"
+              alignItems="center"
+              overflow="hidden"
+              flexGrow={1}
+            >
+              <Checkbox
+                checked={selected}
+                size={size}
+                style={{
+                  "&.Mui-checked": { color: option.color },
+                  color: option.color
+                }}
+              />
+              <Stack direction="column" flexGrow={1} overflow="hidden">
+                <NoWrapTypography>{option.name}</NoWrapTypography>
+                <NoWrapTypography variant="caption">
+                  {option.description}
+                </NoWrapTypography>
+              </Stack>
+              <>
+                {editEnabled && (
+                  <Tooltip title="Edit">
+                    <IconButton
+                      data-testid={`edit-label-${option._id}`}
+                      size={size}
+                      onClick={event => onEditClick(event, option)}
+                    >
+                      <Edit sx={styles.editIcon} />
+                    </IconButton>
+                  </Tooltip>
+                )}
+                {deleteEnabled && (
+                  <Tooltip title="Delete">
+                    <IconButton
+                      data-testid={`delete-label-${option._id}`}
+                      size={size}
+                      onClick={event => onDeleteClick(event, option)}
+                    >
+                      <Delete sx={styles.deleteIcon} />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </>
+            </Stack>
           </Box>
         )}
         renderTags={options =>

--- a/src/LabelSelector/LabelSelector.stories.js
+++ b/src/LabelSelector/LabelSelector.stories.js
@@ -1,3 +1,4 @@
+import { Box } from "@mui/material";
 import LabelSelector from "./LabelSelector";
 import React from "react";
 import { action } from "@storybook/addon-actions";
@@ -15,64 +16,66 @@ const Template = args => {
   const [options, setOptions] = React.useState(args.options);
 
   return (
-    <LabelSelector
-      {...args}
-      onChange={selectedValues => {
-        setValue(selectedValues);
+    <Box maxWidth={300}>
+      <LabelSelector
+        {...args}
+        onChange={selectedValues => {
+          setValue(selectedValues);
 
-        // fire action
-        action("onChange")(selectedValues);
-      }}
-      options={options}
-      value={value}
-      onNew={newLabel => {
-        // append id to new label
-        newLabel._id = options.length + 1;
+          // fire action
+          action("onChange")(selectedValues);
+        }}
+        options={options}
+        value={value}
+        onNew={newLabel => {
+          // append id to new label
+          newLabel._id = options.length + 1;
 
-        // add new label to options
-        setOptions([...options, newLabel]);
+          // add new label to options
+          setOptions([...options, newLabel]);
 
-        // add new label to current value
-        setValue([...value, newLabel]);
+          // add new label to current value
+          setValue([...value, newLabel]);
 
-        // fire action
-        action("onNew")(newLabel);
-      }}
-      onEdit={editedLabel => {
-        // replace edited label in options
-        setOptions(
-          options.map(option => {
-            if (option._id === editedLabel._id) {
-              return editedLabel;
-            }
-            return option;
-          })
-        );
+          // fire action
+          action("onNew")(newLabel);
+        }}
+        onEdit={editedLabel => {
+          // replace edited label in options
+          setOptions(
+            options.map(option => {
+              if (option._id === editedLabel._id) {
+                return editedLabel;
+              }
+              return option;
+            })
+          );
 
-        // replace edited label in current value
-        setValue(
-          value.map(value => {
-            if (value._id === editedLabel._id) {
-              return editedLabel;
-            }
-            return value;
-          })
-        );
+          // replace edited label in current value
+          setValue(
+            value.map(value => {
+              if (value._id === editedLabel._id) {
+                return editedLabel;
+              }
+              return value;
+            })
+          );
 
-        // fire action
-        action("onEdit")(editedLabel);
-      }}
-      onDelete={deletedLabel => {
-        // remove deleted label from options
-        setOptions(options.filter(option => option._id !== deletedLabel._id));
+          // fire action
+          action("onEdit")(editedLabel);
+        }}
+        onDelete={deletedLabel => {
+          // remove deleted label from options
+          setOptions(options.filter(option => option._id !== deletedLabel._id));
 
-        // remove deleted label from current value
-        setValue(value.filter(value => value._id !== deletedLabel._id));
+          // remove deleted label from current value
+          setValue(value.filter(value => value._id !== deletedLabel._id));
 
-        // fire action
-        action("onDelete")(deletedLabel);
-      }}
-    />
+          // fire action
+          action("onDelete")(deletedLabel);
+        }}
+      />
+    </Box>
   );
 };
 

--- a/src/LabelSelector/LabelSelector.stories.js
+++ b/src/LabelSelector/LabelSelector.stories.js
@@ -100,8 +100,18 @@ export const WithLabelOptions = Template.bind({});
 WithLabelOptions.args = {
   ...Default.args,
   options: [
-    { _id: 1, color: "#005FA8", description: "first label", name: "label 1" },
-    { _id: 2, color: "#f542e0", description: "second label", name: "label 2" }
+    {
+      _id: 1,
+      color: "#005FA8",
+      description: "a really looooooooooooooooooong string",
+      name: "label 1"
+    },
+    {
+      _id: 2,
+      color: "#f542e0",
+      description: "second label",
+      name: "a really looooooooooooooooooong string"
+    }
   ]
 };
 

--- a/src/LabelSelector/LabelSelector.test.js
+++ b/src/LabelSelector/LabelSelector.test.js
@@ -57,7 +57,9 @@ describe("LabelSelector", () => {
     render(<LabelSelector options={options} value={options} />);
 
     // find the chip
-    const chip = screen.getByText("label 1").parentElement;
+    const chip = screen.getByRole("button", {
+      name: /label 1/i
+    });
 
     // check that the chip is rendered with the correct name and color
     expect(chip).toHaveStyle("background-color: rgb(0, 95, 168)");
@@ -88,7 +90,9 @@ describe("LabelSelector", () => {
     expect(onChange).toHaveBeenCalled();
 
     // find the chip
-    const chip = screen.getByText("label 1").parentElement;
+    const chip = screen.getByRole("button", {
+      name: /label 1/i
+    });
 
     // check that the chip is rendered with the correct name and color
     expect(chip).toHaveStyle("background-color: rgb(0, 95, 168)");
@@ -125,14 +129,18 @@ describe("LabelSelector", () => {
     expect(onChange).toHaveBeenCalled();
 
     // find the first chip
-    const chip1 = screen.getByText("label 1").parentElement;
+    const chip1 = screen.getByRole("button", {
+      name: /label 1/i
+    });
 
     // check that the first chip is rendered with the correct name and color
     expect(chip1).toHaveStyle("background-color: rgb(0, 95, 168)");
     expect(chip1).toHaveTextContent("label 1");
 
     // find the second chip
-    const chip2 = screen.getByText("label 2").parentElement;
+    const chip2 = screen.getByRole("button", {
+      name: /label 2/i
+    });
 
     // check that the second chip is rendered with the correct name and color
     expect(chip2).toHaveStyle("background-color: rgb(245, 66, 224)");

--- a/src/NoWrapTypography/NoWrapTypography.js
+++ b/src/NoWrapTypography/NoWrapTypography.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 /**
  * Typography component to show a tooltip if the text overflows.
  */
-export default function NoWrapTypography({ children, sx }) {
+export default function NoWrapTypography({ children, sx, variant }) {
   const [tooltipEnabled, setTooltipEnabled] = useState(false);
 
   // if the text overflows its bounding box, then show the tooltip
@@ -28,12 +28,18 @@ export default function NoWrapTypography({ children, sx }) {
     >
       <Typography
         noWrap
-        sx={{
-          ...sx,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap"
-        }}
+        component="p" // forces a block element
+        sx={[
+          {
+            hyphens: "auto",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            wordBreak: "break-all"
+          },
+          ...(Array.isArray(sx) ? sx : [sx])
+        ]}
+        variant={variant}
       >
         {children}
       </Typography>
@@ -49,5 +55,27 @@ NoWrapTypography.propTypes = {
   /**
    * The CSS styles applied to the component.
    */
-  sx: PropTypes.object
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.object
+  ]),
+  /**
+   * The variant to use.
+   */
+  variant: PropTypes.oneOf([
+    "body1",
+    "body2",
+    "button",
+    "caption",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "inherit",
+    "overline",
+    "subtitle1",
+    "subtitle2"
+  ])
 };


### PR DESCRIPTION
### Bug
@Sowbhagya-ipg noted that long strings in either label name or description could lead to the edit and delete buttons being unavailable to the user in the dropdown.

### Resolution
Correctly employ flexbox and NoWrapTypography to deliver the same UI, but with cut-off strings using ellipsis and tooltips.

### UI/UX
https://user-images.githubusercontent.com/27866636/231403014-bdd05141-89fb-4663-9f1b-6c3d5817835a.mov

### Testing
* Check storybook stories. I've updated them to have long strings.