### PR TITLE
Feature/sidebar icon item 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipguk/react-ui",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/src/Sidebar/Sidebar.stories.tsx
+++ b/src/Sidebar/Sidebar.stories.tsx
@@ -39,7 +39,9 @@ const Template: Story<SidebarProps> = args => (
   </div>
 );
 
-// default story
+/**
+ * Default story for the Sidebar component
+ */
 export const Default = Template.bind({});
 Default.args = {
   appVersion: version,
@@ -56,7 +58,9 @@ Default.args = {
   showVersion: true
 };
 
-// hidden logo story
+/**
+ * Story for the Sidebar component with the logo hidden
+ */
 export const HiddenLogo = Template.bind({});
 HiddenLogo.args = {
   appVersion: version,
@@ -75,7 +79,9 @@ HiddenLogo.args = {
   showVersion: true
 };
 
-// hidden version story
+/**
+ * Story for the Sidebar component with the version hidden
+ */
 export const HiddenVersion = Template.bind({});
 HiddenVersion.args = {
   children: (
@@ -93,7 +99,9 @@ HiddenVersion.args = {
   showVersion: false
 };
 
-// items only story
+/**
+ * Story for the Sidebar component with the logo and version hidden
+ */
 export const ItemsOnly = Template.bind({});
 ItemsOnly.args = {
   children: (
@@ -111,7 +119,9 @@ ItemsOnly.args = {
   showVersion: false
 };
 
-// icons only story
+/**
+ * Story for the Sidebar component with only icons and no text
+ */
 export const IconsOnly = Template.bind({});
 IconsOnly.args = {
   children: (
@@ -127,7 +137,9 @@ IconsOnly.args = {
   width: 60
 };
 
-// Custom Logo Link story
+/**
+ * Story for the Sidebar component with a custom logo link
+ */
 export const CustomLogoLink = Template.bind({});
 CustomLogoLink.args = {
   appVersion: version,
@@ -144,7 +156,9 @@ CustomLogoLink.args = {
   showVersion: true
 };
 
-// items only story
+/**
+ * Story for the Sidebar component with stacked items
+ */
 export const StackedSidebar = Template.bind({});
 StackedSidebar.args = {
   appVersion: version,

--- a/src/Sidebar/Sidebar.stories.tsx
+++ b/src/Sidebar/Sidebar.stories.tsx
@@ -4,6 +4,7 @@ import {
   Default as SidebarItemDefault,
   Disabled as SidebarItemDisabled,
   Nested as SidebarItemNested,
+  NestedAndStacked as SidebarItemNestedAndStacked,
   Selected as SidebarItemSelected,
   WithCount as SidebarItemWithCount
 } from "./SidebarItem/SidebarItem.stories";
@@ -137,6 +138,25 @@ CustomLogoLink.args = {
       <SidebarDivider />
       <SidebarItem {...SidebarItemDisabled.args} />
       <SidebarItem {...SidebarItemWithCount.args} />
+    </>
+  ),
+  showLogo: true,
+  showVersion: true
+};
+
+// items only story
+export const StackedSidebar = Template.bind({});
+StackedSidebar.args = {
+  appVersion: version,
+  children: (
+    <>
+      <SidebarItem {...SidebarItemDefault.args} display="stacked" />
+      <SidebarItem {...SidebarItemSelected.args} display="stacked" />
+      <SidebarDivider />
+      <SidebarItem {...SidebarItemDisabled.args} display="stacked" />
+      <SidebarItem {...SidebarItemWithCount.args} display="stacked" />
+      <SidebarDivider />
+      <SidebarItem {...SidebarItemNestedAndStacked.args} display="stacked" />
     </>
   ),
   showLogo: true,

--- a/src/Sidebar/SidebarItem/SidebarItem.stories.tsx
+++ b/src/Sidebar/SidebarItem/SidebarItem.stories.tsx
@@ -21,13 +21,22 @@ const meta: Meta<typeof SidebarItem> = {
 };
 export default meta;
 
+/**
+ * Story template for the SidebarItem component
+ */
 const Template: Story<SidebarItemProps> = args => (
   <SidebarItem {...args} onClick={action("onClick")} />
 );
 
+/**
+ * Default story for the SidebarItem component
+ */
 export const Default = Template.bind({});
 Default.args = { icon: <Home />, name: "Home" };
 
+/**
+ * Story for the SidebarItem component with a custom icon style
+ */
 export const IconStyle = Template.bind({});
 IconStyle.args = {
   icon: <Home />,
@@ -35,6 +44,9 @@ IconStyle.args = {
   name: "Home"
 };
 
+/**
+ * Story for the SidebarItem component with a custom text style
+ */
 export const TextStyle = Template.bind({});
 TextStyle.args = {
   icon: <Home />,
@@ -42,9 +54,15 @@ TextStyle.args = {
   textStyle: { border: "1px solid blue" }
 };
 
+/**
+ * Story for the SidebarItem component with a the item selected
+ */
 export const Selected = Template.bind({});
 Selected.args = { icon: <Person />, name: "Profile", selected: true };
 
+/**
+ * Story for the SidebarItem component with a the item disabled
+ */
 export const Disabled = Template.bind({});
 Disabled.args = {
   count: 2,
@@ -53,9 +71,15 @@ Disabled.args = {
   name: "Calendar"
 };
 
+/**
+ * Story for the SidebarItem component with a count
+ */
 export const WithCount = Template.bind({});
 WithCount.args = { count: 12, icon: <Mail />, name: "Inbox" };
 
+/**
+ * Story for the SidebarItem that has nested items
+ */
 export const Nested = Template.bind({});
 Nested.args = {
   children: [
@@ -69,6 +93,9 @@ Nested.args = {
   name: "Settings"
 };
 
+/**
+ * Story for the SidebarItem that has nested items and is initially open
+ */
 export const NestedInitiallyOpen = Template.bind({});
 NestedInitiallyOpen.args = {
   children: [
@@ -80,5 +107,28 @@ NestedInitiallyOpen.args = {
   ],
   icon: <Settings />,
   initialOpen: true,
+  name: "Settings"
+};
+
+/**
+ * Story for the SidebarItem that has a stacked display
+ */
+export const Stacked = Template.bind({});
+Stacked.args = { display: "stacked", icon: <Home />, name: "Home" };
+
+/**
+ * Story for the SidebarItem that has nested items and Stacked display
+ */
+export const NestedAndStacked = Template.bind({});
+NestedAndStacked.args = {
+  children: [
+    <SidebarItem key="default" {...Default.args} display="stacked" />,
+    <SidebarItem key="withCount" {...WithCount.args} display="stacked">
+      <SidebarItem key="default" {...Default.args} display="stacked" />
+      <SidebarItem key="disabled" {...Disabled.args} display="stacked" />
+    </SidebarItem>
+  ],
+  display: "stacked",
+  icon: <Settings />,
   name: "Settings"
 };

--- a/src/Sidebar/SidebarItem/SidebarItem.tsx
+++ b/src/Sidebar/SidebarItem/SidebarItem.tsx
@@ -79,7 +79,7 @@ export default function SidebarItem({
   // Sidebar In Line component that gets displayed when the display prop is set to in-line
   const SidebarInLine = () => {
     return (
-      <>
+      <React.Fragment>
         <ListItemIcon sx={iconStyle}>
           {React.cloneElement(icon, { color })}
         </ListItemIcon>
@@ -90,7 +90,7 @@ export default function SidebarItem({
         />
         <CountBadge />
         <ExpandIcon />
-      </>
+      </React.Fragment>
     );
   };
 

--- a/src/Sidebar/SidebarItem/SidebarItem.tsx
+++ b/src/Sidebar/SidebarItem/SidebarItem.tsx
@@ -48,6 +48,7 @@ export default function SidebarItem({
     onClick && onClick(event);
   };
 
+  // Count badge component that displays the count
   const CountBadge = () => {
     return count ? (
       <Badge
@@ -64,6 +65,7 @@ export default function SidebarItem({
     ) : null;
   };
 
+  // Expand icon component that displays the expand icon depending on the expanded state
   const ExpandIcon = () => {
     return children ? (
       expanded ? (
@@ -74,6 +76,7 @@ export default function SidebarItem({
     ) : null;
   };
 
+  // Sidebar In Line component that gets displayed when the display prop is set to in-line
   const SidebarInLine = () => {
     return (
       <>
@@ -91,7 +94,7 @@ export default function SidebarItem({
     );
   };
 
-  // Sidebar Stacked
+  // Sidebar Stacked component that gets displayed when the display prop is set to stacked
   const SidebarStacked = () => {
     return (
       <Box
@@ -130,6 +133,7 @@ export default function SidebarItem({
     );
   };
 
+  // return the sidebar item component
   return (
     <Box display="flex" flexDirection="column">
       <ListItemButton

--- a/src/Sidebar/SidebarItem/SidebarItem.tsx
+++ b/src/Sidebar/SidebarItem/SidebarItem.tsx
@@ -27,7 +27,7 @@ export default function SidebarItem({
   onClick,
   selected = false,
   textStyle = {},
-  display = "in-line"
+  display = "inline"
 }: SidebarItemProps) {
   // use styles
   const color = selected ? "primary" : "inherit";
@@ -57,7 +57,7 @@ export default function SidebarItem({
         color="primary"
         // if display is inline then add a margin to the right
         sx={{
-          ...(display === "in-line"
+          ...(display === "inline"
             ? { marginRight: (theme: Theme) => theme.spacing(3) }
             : {})
         }}
@@ -76,7 +76,7 @@ export default function SidebarItem({
     ) : null;
   };
 
-  // Sidebar In Line component that gets displayed when the display prop is set to in-line
+  // Sidebar In Line component that gets displayed when the display prop is set to inline
   const SidebarInLine = () => {
     return (
       <React.Fragment>
@@ -141,7 +141,7 @@ export default function SidebarItem({
         disabled={disabled}
         className={className}
       >
-        {display === "in-line" ? <SidebarInLine /> : <SidebarStacked />}
+        {display === "inline" ? <SidebarInLine /> : <SidebarStacked />}
       </ListItemButton>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
         {React.Children.map(children, child =>

--- a/src/Sidebar/SidebarItem/SidebarItem.tsx
+++ b/src/Sidebar/SidebarItem/SidebarItem.tsx
@@ -26,7 +26,8 @@ export default function SidebarItem({
   name,
   onClick,
   selected = false,
-  textStyle = {}
+  textStyle = {},
+  display = "in-line"
 }: SidebarItemProps) {
   // use styles
   const color = selected ? "primary" : "inherit";
@@ -47,15 +48,35 @@ export default function SidebarItem({
     onClick && onClick(event);
   };
 
-  // define components
-  return (
-    <Box display="flex" flexDirection="column">
-      <ListItemButton
-        selected={selected}
-        onClick={handleClick}
-        disabled={disabled}
-        className={className}
-      >
+  const CountBadge = () => {
+    return count ? (
+      <Badge
+        badgeContent={count}
+        max={9}
+        color="primary"
+        // if display is inline then add a margin to the right
+        sx={{
+          ...(display === "in-line"
+            ? { marginRight: (theme: Theme) => theme.spacing(3) }
+            : {})
+        }}
+      />
+    ) : null;
+  };
+
+  const ExpandIcon = () => {
+    return children ? (
+      expanded ? (
+        <Badge badgeContent={<ArrowDropDown />} />
+      ) : (
+        <Badge badgeContent={<ArrowRight />} />
+      )
+    ) : null;
+  };
+
+  const SidebarInLine = () => {
+    return (
+      <>
         <ListItemIcon sx={iconStyle}>
           {React.cloneElement(icon, { color })}
         </ListItemIcon>
@@ -64,15 +85,60 @@ export default function SidebarItem({
           primaryTypographyProps={primaryTypographyProps}
           sx={textStyle}
         />
-        {count ? (
-          <Badge
-            badgeContent={count}
-            max={9}
-            color="primary"
-            sx={{ marginRight: theme => theme.spacing(2) }}
+        <CountBadge />
+        <ExpandIcon />
+      </>
+    );
+  };
+
+  // Sidebar Stacked
+  const SidebarStacked = () => {
+    return (
+      <Box
+        display="flex"
+        width="100%"
+        flexDirection="row"
+        justifyContent="center"
+      >
+        <Box display="flex" flexDirection="column" justifyContent="center">
+          <ListItemIcon
+            sx={{
+              display: "flex",
+              justifyContent: "center",
+              ...iconStyle
+            }}
+          >
+            {React.cloneElement(icon, {
+              color,
+              fontSize: "large"
+            })}
+            <CountBadge />
+          </ListItemIcon>
+          <ExpandIcon />
+
+          <ListItemText
+            primary={name}
+            primaryTypographyProps={primaryTypographyProps}
+            sx={{
+              display: "flex",
+              justifyContent: "center",
+              ...textStyle
+            }}
           />
-        ) : null}
-        {children && (expanded ? <ArrowDropDown /> : <ArrowRight />)}
+        </Box>
+      </Box>
+    );
+  };
+
+  return (
+    <Box display="flex" flexDirection="column">
+      <ListItemButton
+        selected={selected}
+        onClick={handleClick}
+        disabled={disabled}
+        className={className}
+      >
+        {display === "in-line" ? <SidebarInLine /> : <SidebarStacked />}
       </ListItemButton>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
         {React.Children.map(children, child =>

--- a/src/Sidebar/SidebarItem/SidebarItem.tsx
+++ b/src/Sidebar/SidebarItem/SidebarItem.tsx
@@ -118,7 +118,6 @@ export default function SidebarItem({
             <CountBadge />
           </ListItemIcon>
           <ExpandIcon />
-
           <ListItemText
             primary={name}
             primaryTypographyProps={primaryTypographyProps}

--- a/src/Sidebar/SidebarItem/SidebarItem.types.ts
+++ b/src/Sidebar/SidebarItem/SidebarItem.types.ts
@@ -34,11 +34,11 @@ export interface SidebarItemProps {
    */
   name: string;
   /**
-   * The display type of the sidebar item. Defaults to "in-line".
-   * Where "in-line" displays the icon and text on the same line.
+   * The display type of the sidebar item. Defaults to "inline".
+   * Where "inline" displays the icon and text on the same line.
    * "stacked" displays the icon and text on separate lines.
    */
-  display?: "in-line" | "stacked";
+  display?: "inline" | "stacked";
   /**
    * Callback fired when the user clicks on item.
    *

--- a/src/Sidebar/SidebarItem/SidebarItem.types.ts
+++ b/src/Sidebar/SidebarItem/SidebarItem.types.ts
@@ -34,6 +34,12 @@ export interface SidebarItemProps {
    */
   name: string;
   /**
+   * The display type of the sidebar item. Defaults to "in-line".
+   * Where "in-line" displays the icon and text on the same line.
+   * "stacked" displays the icon and text on separate lines.
+   */
+  display?: "in-line" | "stacked";
+  /**
    * Callback fired when the user clicks on item.
    *
    * **Signature**


### PR DESCRIPTION
relates to https://github.com/IPG-Automotive-UK/cloud-licensing-web/issues/274

-  The sidebar items in cloud licensing have an Icon with text underneath it (stacked) rather than the default inline icon and text that is currently available.

## Changes
This PR enables to user to pass in an optional display property which can be either "inline" or "stacked" which will allow the user to specifically set the orientation of the icon and text in the sidebar item. The default behavior of this component is maintained as the default value of the display property is "inline". 

-  In order to reduce code duplication I have created separate components inside sidebar item for the Count badge and the expand icon so that I can use them for both the SidebarInLine and SidebarStacked components. 
- The SidebarInLine and SidebarStacked components implement their desired layouts respectively which the main SidebarItem component switches between depending on the display value. 
- I have updated the Sidebar Item types to include the new display property
- I have added SidebarItem.stories to show what a stacked SidebarItem will look like 
- I have also updated the Sidebar.stories to include a view of what a sidebar with stacked items will look like. 

## Dependencies
Do Not Merge: This PR is built on the work done here :  https://github.com/IPG-Automotive-UK/react-ui/pull/583 this will need to be approved and merged before this can be merged. 

## UI/UX

Cloud Licensing Web Figma: https://www.figma.com/proto/O3IAobLTPcjIO1WaxaPod6/IPG-Cloud-Licensing?node-id=68-14265&starting-point-node-id=68%3A14265

Cloud Licensing Sidebar in Figma:
![image](https://user-images.githubusercontent.com/75164177/234905338-bcca9011-521b-463d-a1aa-4abba98fe3d6.png)

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Assigned to me.
- [x] Relevant tags added.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
