### PR TITLE
Bugfix/sidebar border

### DIFF
--- a/src/Sidebar/SidebarItem/SidebarItem.stories.tsx
+++ b/src/Sidebar/SidebarItem/SidebarItem.stories.tsx
@@ -132,3 +132,14 @@ NestedAndStacked.args = {
   icon: <Settings />,
   name: "Settings"
 };
+
+/**
+ * Story for the SidebarItem component that is nested with a the item selected
+ */
+export const NestedAndSelected = Template.bind({});
+NestedAndSelected.args = {
+  display: "stacked",
+  icon: <Person />,
+  name: "Profile",
+  selected: true
+};

--- a/src/Sidebar/SidebarItem/SidebarItem.tsx
+++ b/src/Sidebar/SidebarItem/SidebarItem.tsx
@@ -145,10 +145,10 @@ export default function SidebarItem({
         className={className}
         sx={{
           ...(display === "inline" ? {} : { pb: 2, pl: 0, pr: 0, pt: 2 }),
-          ...(selected === true
+          ...(selected === true && display === "stacked"
             ? {
-                borderColor: theme => theme.palette.primary.main,
-                borderRight: "2px solid"
+                borderRight: "2px solid",
+                borderRightColor: theme => theme.palette.primary.main
               }
             : {})
         }}


### PR DESCRIPTION
Fixed :
- bug where a sidebar border is shown when the sidebar item is has "inline" display. 
- bug where sidebar border was not the correct colour.

 This bug was introduced [here]( https://github.com/IPG-Automotive-UK/react-ui/pull/604/files#diff-d5837082dccb1cf673ec990570403e90733db49262647ce42d2edaa86b743540R146-R154) and released in [v4.0.0](https://github.com/IPG-Automotive-UK/react-ui/releases/tag/v4.0.0)


## Changes
- Added missing conditional on the border styling to only be shown when the display = "stacked"
- Updated border color styling from "borderColor" to "borderRightColor"
- Added a story for a nested and stacked sidebar item.

## UI/UX

### Before: 
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/75164177/29c01f77-9902-42ff-9f3c-1bb671d8ae1e)
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/75164177/dba4036f-ca5e-4ed8-bb37-f18e46ccc3aa)

### After: 
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/75164177/9d6b9fad-0493-4b83-8bcd-cc486bd1eb44)
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/75164177/204dbd73-86e3-43c9-b003-5a903c4ca253)

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Assigned to me.
- [x] Relevant tags added.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
