### PR TITLE
Snackbar flex-wrap

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -65,6 +65,10 @@ export default function Snackbar({
   // icon
   const Icon = icons[variant];
 
+  // variant styling
+  const variantStyle = sx[variant];
+  variantStyle.flexWrap = "nowrap";
+
   // callback for closing
   const handleClose = (event, reason = "action") => {
     if (reason === "clickaway") return;
@@ -98,7 +102,7 @@ export default function Snackbar({
       open={open}
     >
       <SnackbarContent
-        sx={sx[variant]}
+        sx={variantStyle}
         message={
           <span>
             <Icon sx={sx.icon} />

--- a/src/Snackbar/Snackbar.stories.tsx
+++ b/src/Snackbar/Snackbar.stories.tsx
@@ -1,29 +1,47 @@
 import { Box, Button, LinearProgress } from "@mui/material";
+import { Meta, Story } from "@storybook/react";
+
 import React from "react";
 import Snackbar from "./Snackbar";
+import { SnackbarProps } from "./Snackbar.types";
 import { action } from "@storybook/addon-actions";
 
-export default {
+/**
+ * Story metadata
+ */
+const meta: Meta<typeof Snackbar> = {
+  argTypes: {
+    actionCallback: {
+      control: false
+    },
+    autoHideDuration: {
+      control: {
+        type: "number"
+      }
+    },
+    onClose: {
+      control: false
+    }
+  },
   component: Snackbar,
   title: "General/Snackbar"
 };
+export default meta;
 
-const Template = args => {
+// Template for the Snackbar stories to manage the state of the Snackbar
+const Template: Story<SnackbarProps> = args => {
   const [open, setOpen] = React.useState(false);
   const [actionText, setActionText] = React.useState(args.actionText);
   const [autoHideDuration, setAutoHideDuration] = React.useState(
     args.autoHideDuration
   );
   const onClose = () => setOpen(false);
-
   React.useEffect(() => {
     setOpen(args.open);
   }, [args.open]);
-
   React.useEffect(() => {
     setActionText(args.actionText);
   }, [args.actionText]);
-
   React.useEffect(() => {
     setAutoHideDuration(args.autoHideDuration);
   }, [args.autoHideDuration]);
@@ -45,9 +63,24 @@ const Template = args => {
   );
 };
 
+// Default story for the Snackbar component
 export const Default = Template.bind({});
-Default.args = { message: "This is a snackbar", open: false };
+Default.args = {
+  message: "This is a snackbar",
+  open: false,
+  variant: "info"
+};
 
+// Multi-line message story for the Snackbar component
+export const MultiLineMessage = Template.bind({});
+MultiLineMessage.args = {
+  message:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+  open: false,
+  variant: "info"
+};
+
+// Action button story for the Snackbar component
 export const ActionButton = Template.bind({});
 ActionButton.args = {
   actionCallback: action("onAction"),
@@ -57,6 +90,7 @@ ActionButton.args = {
   variant: "warning"
 };
 
+// Complex message story for the Snackbar component
 export const ComplexMessage = Template.bind({});
 ComplexMessage.args = {
   message: (
@@ -67,5 +101,6 @@ ComplexMessage.args = {
       </Box>
     </>
   ),
-  open: false
+  open: false,
+  variant: "info"
 };

--- a/src/Snackbar/Snackbar.test.tsx
+++ b/src/Snackbar/Snackbar.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
+
 import React from "react";
-import Snackbar from "./";
+import Snackbar from ".";
 import userEvent from "@testing-library/user-event";
 
 describe("Snackbar", () => {

--- a/src/Snackbar/Snackbar.tsx
+++ b/src/Snackbar/Snackbar.tsx
@@ -2,13 +2,15 @@ import {
   Button,
   IconButton,
   Snackbar as MuiSnackbar,
+  SnackbarCloseReason,
   SnackbarContent
 } from "@mui/material";
 import { CheckCircle, Close, Error, Info, Warning } from "@mui/icons-material";
 import { amber, green } from "@mui/material/colors";
 
-import PropTypes from "prop-types";
 import React from "react";
+import { SnackbarProps } from "./Snackbar.types";
+import { Theme } from "@mui/material/styles";
 
 // icon map
 const icons = {
@@ -27,26 +29,30 @@ const sx = {
     fontSize: 15
   },
   error: {
-    backgroundColor: theme => theme.palette.error.dark,
-    color: "#fff"
+    backgroundColor: (theme: Theme) => theme.palette.error.dark,
+    color: "#fff",
+    flexWrap: "nowrap"
   },
   icon: {
     float: "left",
     fontSize: 20,
-    marginRight: theme => theme.spacing(1),
+    marginRight: (theme: Theme) => theme.spacing(1),
     opacity: 0.9
   },
   info: {
-    backgroundColor: theme => theme.palette.primary.main,
-    color: "#fff"
+    backgroundColor: (theme: Theme) => theme.palette.primary.main,
+    color: "#fff",
+    flexWrap: "nowrap"
   },
   success: {
     backgroundColor: green[600],
-    color: "#fff"
+    color: "#fff",
+    flexWrap: "nowrap"
   },
   warning: {
     backgroundColor: amber[700],
-    color: "#fff"
+    color: "#fff",
+    flexWrap: "nowrap"
   }
 };
 
@@ -56,23 +62,27 @@ const sx = {
 export default function Snackbar({
   actionCallback,
   actionText,
-  autoHideDuration = null,
+  autoHideDuration,
   message,
   onClose,
   open,
   variant = "info"
-}) {
-  // icon
+}: SnackbarProps) {
+  // get icon based on variant
   const Icon = icons[variant];
 
-  // variant styling
+  // get styling based on variant
   const variantStyle = sx[variant];
-  variantStyle.flexWrap = "nowrap";
 
   // callback for closing
-  const handleClose = (event, reason = "action") => {
+  const handleClose = (
+    event: React.SyntheticEvent<HTMLElement>,
+    reason: SnackbarCloseReason = "timeout"
+  ) => {
     if (reason === "clickaway") return;
-    onClose(event, reason);
+    if (onClose) {
+      onClose(event, reason);
+    }
   };
 
   // action button
@@ -81,7 +91,7 @@ export default function Snackbar({
       <Button
         key="action"
         onClick={event => {
-          handleClose(event, "action");
+          handleClose(event, "timeout");
           actionCallback(event);
         }}
         sx={sx.action}
@@ -125,49 +135,3 @@ export default function Snackbar({
     </MuiSnackbar>
   );
 }
-// prop types
-Snackbar.propTypes = {
-  /**
-   * Callback fired when the user clicks the action button.
-   *
-   * **Signature**
-   * ```
-   * function(event: object) => void
-   * ```
-   * _event_: The event source of the callback.
-   */
-  actionCallback: PropTypes.func,
-  /**
-   * The action button text to display. It renders after the message, at the end of the snackbar.
-   */
-  actionText: PropTypes.string,
-  /**
-   * The number of milliseconds to wait before automatically calling the onClose function. onClose should then set the state of the open prop to hide the Snackbar. This behavior is disabled by default with the null value.
-   */
-  autoHideDuration: PropTypes.number,
-  /**
-   * The message to display.
-   */
-  message: PropTypes.node.isRequired,
-  /**
-   * Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop.
-   *
-   * **Signature**
-   * ```
-   * function(event, reason) => void
-   * ```
-   *
-   * _event_: The event source of the callback.
-   *
-   * _reason_: Can be: "timeout" (autoHideDuration expired), "clickaway", "action".
-   */
-  onClose: PropTypes.func,
-  /**
-   * If true, Snackbar is open.
-   */
-  open: PropTypes.bool.isRequired,
-  /**
-   * Variant used to control the styling and icon.
-   */
-  variant: PropTypes.oneOf(Object.keys(icons))
-};

--- a/src/Snackbar/Snackbar.types.ts
+++ b/src/Snackbar/Snackbar.types.ts
@@ -6,12 +6,6 @@ import {
 export interface SnackbarProps {
   /**
    * Callback fired when the user clicks the action button.
-   *
-   * **Signature**
-   * ```
-   * function(event: object) => void
-   * ```
-   * _event_: The event source of the callback.
    */
   actionCallback?: (event: React.SyntheticEvent<HTMLElement>) => void;
   /**
@@ -28,17 +22,8 @@ export interface SnackbarProps {
   message: SnackbarContentProps["message"];
   /**
    * Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop.
-   *
-   * **Signature**
-   * ```
-   * function(event, reason) => void
-   * ```
-   *
-   * _event_: The event source of the callback.
-   *
-   * _reason_: Can be: "timeout" (autoHideDuration expired), "clickaway", "action".
    */
-  onClose: MuiSnackbarProps["onClose"];
+  onClose?: MuiSnackbarProps["onClose"];
   /**
    * If true, Snackbar is open.
    */

--- a/src/Snackbar/Snackbar.types.ts
+++ b/src/Snackbar/Snackbar.types.ts
@@ -1,0 +1,50 @@
+import {
+  SnackbarProps as MuiSnackbarProps,
+  SnackbarContentProps
+} from "@mui/material";
+
+export interface SnackbarProps {
+  /**
+   * Callback fired when the user clicks the action button.
+   *
+   * **Signature**
+   * ```
+   * function(event: object) => void
+   * ```
+   * _event_: The event source of the callback.
+   */
+  actionCallback?: (event: React.SyntheticEvent<HTMLElement>) => void;
+  /**
+   * The action button text to display. It renders after the message, at the end of the snackbar.
+   */
+  actionText?: string;
+  /**
+   * The number of milliseconds to wait before automatically calling the onClose function. onClose should then set the state of the open prop to hide the Snackbar. This behavior is disabled by default with the null value.
+   */
+  autoHideDuration?: MuiSnackbarProps["autoHideDuration"];
+  /**
+   * The message to display.
+   */
+  message: SnackbarContentProps["message"];
+  /**
+   * Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop.
+   *
+   * **Signature**
+   * ```
+   * function(event, reason) => void
+   * ```
+   *
+   * _event_: The event source of the callback.
+   *
+   * _reason_: Can be: "timeout" (autoHideDuration expired), "clickaway", "action".
+   */
+  onClose: MuiSnackbarProps["onClose"];
+  /**
+   * If true, Snackbar is open.
+   */
+  open: boolean;
+  /**
+   * Variant used to control the styling and icon.
+   */
+  variant?: "error" | "info" | "success" | "warning";
+}

--- a/src/Snackbar/index.js
+++ b/src/Snackbar/index.js
@@ -1,1 +1,0 @@
-export { default } from "./Snackbar";

--- a/src/Snackbar/index.ts
+++ b/src/Snackbar/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./Snackbar";
+export { SnackbarProps } from "./Snackbar.types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export {
 } from "./Sidebar";
 export { default as AppLauncher, AppLauncherProps } from "./AppLauncher";
 export { default as Slider } from "./Slider";
-export { default as Snackbar } from "./Snackbar";
+export { default as Snackbar, SnackbarProps } from "./Snackbar";
 export { SnackbarProvider, useSnackbar } from "./SnackbarProvider";
 export { StatusIcon, StatusLabel, StatusMessage } from "./Status";
 export { default as SwitchField } from "./SwitchField";


### PR DESCRIPTION
Fixes an issue spotted in a cloud licensing pull request https://github.com/IPG-Automotive-UK/cloud-licensing-web/pull/298#issuecomment-1641880722.

## Changes

If the snackbar message was long or the screen width was small then the text was wrapping onto a newline, however so was the action button to close the dialog. The action button is now always on the right and vertically centre aligned with the message text.

## UI/UX

Before:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/7ce01f2e-3a07-480c-a028-80592abed471)

After:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/73dea85b-0ef4-4039-88ce-758dd51ac6a9)

## Testing notes

Open up storybook for Snackbar, set a long message or resize the screen width so the message wraps onto multiple lines and confirm close action button is as expected.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Lint and test workflows pass.
