### PR TITLE
TD-2038 color of the alert title in dark mode mismatched

### DIFF
--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -147,20 +147,20 @@ const darkTheme = createTheme(
           body: themeParam.palette.mode === "dark" ? darkScrollbar() : null
         })
       },
+      MuiAlertTitle: {
+        styleOverrides: {
+          root: {
+            color: 'inherit'
+          }
+        }
+      },
       MuiStepper: {
         styleOverrides: {
           root: {
             backgroundColor: "rgba(255, 255, 255, 0.08)"
           }
         }
-      },
-      MuiAlertTitle: {
-        styleOverrides: {
-          root: {
-            color: 'inherit',
-          },
-        },
-      },
+      }
     },
     palette: {
       background: {

--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -142,18 +142,19 @@ const lightTheme = createTheme(
 const darkTheme = createTheme(
   {
     components: {
+      MuiAlertTitle: {
+        styleOverrides: {
+          root: {
+            color: "inherit"
+          }
+        }
+      },
       MuiCssBaseline: {
         styleOverrides: themeParam => ({
           body: themeParam.palette.mode === "dark" ? darkScrollbar() : null
         })
       },
-      MuiAlertTitle: {
-        styleOverrides: {
-          root: {
-            color: 'inherit'
-          }
-        }
-      },
+
       MuiStepper: {
         styleOverrides: {
           root: {

--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -153,7 +153,14 @@ const darkTheme = createTheme(
             backgroundColor: "rgba(255, 255, 255, 0.08)"
           }
         }
-      }
+      },
+      MuiAlertTitle: {
+        styleOverrides: {
+          root: {
+            color: 'inherit',
+          },
+        },
+      },
     },
     palette: {
       background: {


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

[Closes TD-2038](https://sce.myjetbrains.com/youtrack/issue/TD-2038/The-color-of-the-alert-title-in-dark-mode-is-mismatched)

## Changes
- added root style to MuiAlertTitle class under the components


## UI/UX
Tested by integrating into VIRTO.FLEET
Before
![image](https://github.com/IPG-Automotive-UK/virto/assets/49191249/3ef9bb27-adbd-4dab-b6c8-803c00cafc9d)

After
![image](https://github.com/IPG-Automotive-UK/virto/assets/49191249/f159f863-d6bf-48bf-8d8f-664135df637e)


## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Appropriate tests have been added.
- [x] Lint and test workflows pass.
