### PR TITLE
TD 2069 vehicle select dialog

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install -force

--- a/src/ActionDialog/ActionDialog.stories.tsx
+++ b/src/ActionDialog/ActionDialog.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof ActionDialog> = {
     }
   },
   component: ActionDialog,
-  title: "General/ActionDialog"
+  title: "Dialog/ActionDialog"
 };
 export default meta;
 

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -75,6 +75,7 @@ export const Default: StoryObj<typeof Autocomplete> = {
 
 export const MultiSelect: StoryObj<typeof Autocomplete> = {
   args: {
+    disableCloseOnSelect: true,
     disabled: false,
     error: false,
     helperText: "Helper Text",

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -15,6 +15,7 @@ export default function Autocomplete<
   Value extends string,
   Multiple extends boolean | undefined
 >({
+  disableCloseOnSelect = false,
   disabled = false,
   error = false,
   helperText,
@@ -31,6 +32,7 @@ export default function Autocomplete<
 }: AutocompleteProps<Value, Multiple>) {
   return (
     <MuiAutocomplete
+      disableCloseOnSelect={disableCloseOnSelect}
       limitTags={limitTags}
       multiple={multiple}
       onChange={onChange}

--- a/src/Autocomplete/Autocomplete.types.ts
+++ b/src/Autocomplete/Autocomplete.types.ts
@@ -15,6 +15,7 @@ export type AutocompleteProps<
   | "disabled"
   | "size"
   | "limitTags"
+  | "disableCloseOnSelect"
 > &
   Pick<
     TextFieldProps,

--- a/src/DialogTitle/DialogTitle.stories.js
+++ b/src/DialogTitle/DialogTitle.stories.js
@@ -6,7 +6,7 @@ import React from "react";
 
 export default {
   component: DialogTitle,
-  title: "General/DialogTitle"
+  title: "Dialog/DialogTitle"
 };
 
 const Template = ({ children, ...rest }) => {

--- a/src/VehicleSelect/VehicleSelect.test.tsx
+++ b/src/VehicleSelect/VehicleSelect.test.tsx
@@ -85,6 +85,9 @@ describe("Vehicle Select", () => {
     // click the first option
     await userEvent.click(screen.getByRole("option", { name: /911/i }));
 
+    // explicitly close the dropdown
+    await userEvent.click(document.body);
+
     // expect the onChange callback to be called first time
     expect(onChange).toHaveBeenCalledTimes(1);
 
@@ -105,6 +108,9 @@ describe("Vehicle Select", () => {
     );
     // click the first option
     await userEvent.click(screen.getByRole("option", { name: /2015/i }));
+
+    // explicitly close the dropdown
+    await userEvent.click(document.body);
 
     // expect the onChange callback to be called second time
     expect(onChange).toHaveBeenCalledTimes(2);
@@ -129,6 +135,9 @@ describe("Vehicle Select", () => {
     // click the first option
     await userEvent.click(screen.getByRole("option", { name: /JS/i }));
 
+    // explicitly close the dropdown
+    await userEvent.click(document.body);
+
     // expect the onChange callback to be called third time
     expect(onChange).toHaveBeenCalledTimes(3);
 
@@ -151,6 +160,9 @@ describe("Vehicle Select", () => {
     );
     // click the second option
     await userEvent.click(screen.getByRole("option", { name: /MP/i }));
+
+    // explicitly close the dropdown
+    await userEvent.click(document.body);
 
     // expect the onChange callback to be called fourth time
     expect(onChange).toHaveBeenCalledTimes(4);
@@ -182,6 +194,9 @@ describe("Vehicle Select", () => {
     // click the first option
     await userEvent.click(screen.getByRole("option", { name: /Gate 1/i }));
 
+    // explicitly close the dropdown
+    await userEvent.click(document.body);
+
     // expect the onChange callback to be called fifth time
     expect(onChange).toHaveBeenCalledTimes(5);
 
@@ -211,6 +226,9 @@ describe("Vehicle Select", () => {
     );
     // click the second option
     await userEvent.click(screen.getByRole("option", { name: /Gate 2/i }));
+
+    // explicitly close the dropdown
+    await userEvent.click(document.body);
 
     // expect the onChange callback to be called sixth time
     expect(onChange).toHaveBeenCalledTimes(6);

--- a/src/VehicleSelect/VehicleSelect.tsx
+++ b/src/VehicleSelect/VehicleSelect.tsx
@@ -119,6 +119,7 @@ function VehicleSelect({
       </Box>
       <Box flex="40%">
         <Autocomplete
+          disableCloseOnSelect={true}
           disabled={selectedModelYear === ""}
           label="Vehicle Variant"
           required
@@ -175,6 +176,7 @@ function VehicleSelect({
       </Box>
       <Box flex="40%">
         <Autocomplete
+          disableCloseOnSelect={true}
           disabled={selectedVariants.length === 0}
           required
           multiple={true}

--- a/src/VehicleSelect/VehicleSelect.types.ts
+++ b/src/VehicleSelect/VehicleSelect.types.ts
@@ -1,70 +1,12 @@
-// User group
-export type UserGroup = {
-  _id: string;
-  name: string;
-  createdAt: string;
-  updatedAt: string;
-};
-
-// Vehicle milestone timing
-export type Timing = {
-  gate: string;
-  date: string;
-};
-
-// Vehicle project milestone
-export type Milestone = {
-  timings: Timing[];
-  color: string;
-};
-export type EmptyMilestone = {
-  timings: [];
-};
-
-// Vehicle
+// Vehicle types
 export type Vehicle = {
-  DMF?: string;
-  __v: number;
   _id: string;
-  bodyStyle?: string;
-  brakeCircuit?: string;
-  brand: string;
-  drive: string;
-  driveSource: string;
-  engineOrientation?: string;
-  frontDiffType?: string;
-  milestones: EmptyMilestone | Milestone[];
   modelYear: string;
-  mountElectricMotor?: string;
-  numberElectricMotors?: number | null;
-  numberEngineMounts?: number | null;
-  powerSteering: string;
-  powerSupplyEV?: string;
-  powertrain?: string;
-  powertrainCoordinateOrientation: string;
-  powertrainCoordinateOrigin: string;
   projectCode: string;
-  rearDiffType?: string;
-  restricted: boolean;
-  restrictedGroups: UserGroup[];
-  rimSizeFA: string;
-  rimSizeRA: string;
-  suspension: string;
-  systemPowerkW: number;
-  tireAspectRatioFA: number;
-  tireAspectRatioRA: number;
-  tireWidthFA: number;
-  tireWidthRA: number;
-  transmissionGears: number;
-  transmissionType: string;
-  transmissonGears: number | null;
-  turbochargerEquipped?: string;
   variant: string;
-  vehicleCoordinateOrientation: string;
-  vehicleCoordinateOrigin: string;
-  vehicleSegment: string;
 };
 
+// types for the selected vehicle
 export type SelectedVehicle = {
   _id: string;
   project: string;
@@ -81,7 +23,7 @@ export interface VehicleSelectProps {
   /**
    * Array of all vehicles
    */
-  allVehicles: Pick<Vehicle, "_id" | "projectCode" | "modelYear" | "variant">[];
+  allVehicles: Vehicle[];
   /**
    * The currently selected vehicles
    */

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -1,13 +1,10 @@
 import { Meta, StoryFn } from "@storybook/react";
 import React, { MouseEventHandler } from "react";
-import {
-  SelectedVehicle,
-  VehicleSelectProps
-} from "../VehicleSelect/VehicleSelect.types";
 
 import { Button } from "@mui/material";
+import { CombinedVehicleProps } from "./VehicleSelectDialog.types";
+import { SelectedVehicle } from "../VehicleSelect/VehicleSelect.types";
 import VehicleSelectDialog from "./VehicleSelectDialog";
-import { VehicleSelectDialogProps } from "./VehicleSelectDialog.types";
 import { action } from "@storybook/addon-actions";
 import { useArgs } from "@storybook/client-api";
 
@@ -21,7 +18,7 @@ const meta: Meta<typeof VehicleSelectDialog> = {
 
 export default meta;
 
-const Template: StoryFn<VehicleSelectDialogProps> = args => {
+const Template: StoryFn<CombinedVehicleProps> = args => {
   const [open, setOpen] = React.useState(false);
   const handleClickOpen = () => setOpen(true);
   const handleCancel: MouseEventHandler<HTMLButtonElement> = args => {
@@ -34,7 +31,7 @@ const Template: StoryFn<VehicleSelectDialogProps> = args => {
   };
 
   // useArgs is a hook that returns the current state of the args object
-  const [{ selectedVehicles }, updateArgs] = useArgs<VehicleSelectProps>();
+  const [{ selectedVehicles }, updateArgs] = useArgs<CombinedVehicleProps>();
 
   // update the args object with the new selectedVehicles value
   React.useEffect(() => {
@@ -65,16 +62,6 @@ const Template: StoryFn<VehicleSelectDialogProps> = args => {
 
 export const Default = {
   args: {
-    cancelText: "cancel",
-    content: <div>Some content</div>,
-    dividers: false,
-    onCancelClick: () => {},
-    onSaveClick: () => {},
-    saveDisabled: false,
-    saveText: "ADD VEHICLE",
-    showCloseIcon: true,
-    title: "Add Vehicle",
-    width: "800px",
     allGates: ["Gate 1", "Gate 2", "Gate 3"],
     allVehicles: [
       {
@@ -102,6 +89,13 @@ export const Default = {
         variant: "MC - 397kW - 7MT - R20"
       }
     ],
+    cancelText: "cancel",
+    content: <div>Some content</div>,
+    dividers: false,
+    onCancelClick: () => {},
+    onSaveClick: () => {},
+    saveDisabled: false,
+    saveText: "ADD VEHICLE",
     selectedVehicles: [
       {
         _id: "",
@@ -110,7 +104,10 @@ export const Default = {
         project: "",
         variant: ""
       }
-    ]
+    ],
+    showCloseIcon: true,
+    title: "Add Vehicle",
+    width: "800px"
   },
   render: Template
 };

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -32,17 +32,17 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
   };
 
   // useArgs is a hook that returns the current state of the args object
-  const [{ selectedVehicles }, updateArgs] = useArgs<CombinedVehicleProps>();
+  const [{ value }, updateArgs] = useArgs<CombinedVehicleProps>();
 
-  // update the args object with the new selectedVehicles value
+  // update the args object with the new value value
   React.useEffect(() => {
-    updateArgs({ selectedVehicles });
-  }, [selectedVehicles, updateArgs]);
+    updateArgs({ value });
+  }, [value, updateArgs]);
 
   // callback for when the selected vehicles change
-  const onVehicleChange = (selectedVehicle: SelectedVehicle[]) => {
-    updateArgs({ selectedVehicles: selectedVehicle });
-    action("onVehicleChange")(selectedVehicle);
+  const onChange = (selectedVehicle: SelectedVehicle[]) => {
+    updateArgs({ value: selectedVehicle });
+    action("onChange")(selectedVehicle);
   };
   // render the dialog with the vehicle select component
   return (
@@ -55,8 +55,8 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
         open={open}
         onCancelClick={handleCancel}
         onSaveClick={handleSave}
-        onVehicleChange={onVehicleChange}
-        selectedVehicles={selectedVehicles}
+        onChange={onChange}
+        value={value}
       />
     </>
   );
@@ -64,8 +64,26 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
 
 export const Default = {
   args: {
-    allGates: ["Gate 1", "Gate 2", "Gate 3"],
-    allVehicles: [
+    cancelText: "cancel",
+    content: <div>Some content</div>,
+    dividers: false,
+    flexDirection: "column",
+    flexWrap: "nowrap",
+    gates: ["Gate 1", "Gate 2", "Gate 3"],
+    saveDisabled: false,
+    saveText: "ADD VEHICLE",
+    showCloseIcon: true,
+    title: "Add Vehicle",
+    value: [
+      {
+        _id: "",
+        gate: "",
+        modelYear: "",
+        project: "",
+        variant: ""
+      }
+    ],
+    variants: [
       {
         _id: "64c8c4cccc8d6f00130b366b",
         modelYear: "2015",
@@ -91,24 +109,6 @@ export const Default = {
         variant: "MC - 397kW - 7MT - R20"
       }
     ],
-    cancelText: "cancel",
-    content: <div>Some content</div>,
-    dividers: false,
-    flexDirection: "column",
-    flexWrap: "nowrap",
-    saveDisabled: false,
-    saveText: "ADD VEHICLE",
-    selectedVehicles: [
-      {
-        _id: "",
-        gate: "",
-        modelYear: "",
-        project: "",
-        variant: ""
-      }
-    ],
-    showCloseIcon: true,
-    title: "Add Vehicle",
     width: "800px"
   },
   render: Template

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -1,0 +1,116 @@
+import { Meta, StoryFn } from "@storybook/react";
+import React, { MouseEventHandler } from "react";
+import {
+  SelectedVehicle,
+  VehicleSelectProps
+} from "../VehicleSelect/VehicleSelect.types";
+
+import { Button } from "@mui/material";
+import VehicleSelectDialog from "./VehicleSelectDialog";
+import { VehicleSelectDialogProps } from "./VehicleSelectDialog.types";
+import { action } from "@storybook/addon-actions";
+import { useArgs } from "@storybook/client-api";
+
+/**
+ * Story metadata
+ */
+const meta: Meta<typeof VehicleSelectDialog> = {
+  component: VehicleSelectDialog,
+  title: "General/VehicleSelectDialog"
+};
+
+export default meta;
+
+const Template: StoryFn<VehicleSelectDialogProps> = args => {
+  const [open, setOpen] = React.useState(false);
+  const handleClickOpen = () => setOpen(true);
+  const handleCancel: MouseEventHandler<HTMLButtonElement> = args => {
+    setOpen(false);
+    action("onCancelClick")(args);
+  };
+  const handleSave: MouseEventHandler<HTMLButtonElement> = args => {
+    setOpen(false);
+    action("onSaveClick")(args);
+  };
+
+  // useArgs is a hook that returns the current state of the args object
+  const [{ selectedVehicles }, updateArgs] = useArgs<VehicleSelectProps>();
+
+  // update the args object with the new selectedVehicles value
+  React.useEffect(() => {
+    updateArgs({ selectedVehicles });
+  }, [selectedVehicles, updateArgs]);
+
+  // callback for when the selected vehicles change
+  const onVehicleChange = (selectedVehicle: SelectedVehicle[]) => {
+    updateArgs({ selectedVehicles: selectedVehicle });
+    action("onVehicleChange")(selectedVehicle);
+  };
+  return (
+    <>
+      <Button variant="outlined" onClick={handleClickOpen}>
+        Open dialog
+      </Button>
+      <VehicleSelectDialog
+        {...args}
+        open={open}
+        onCancelClick={handleCancel}
+        onSaveClick={handleSave}
+        onVehicleChange={onVehicleChange}
+        selectedVehicles={selectedVehicles}
+      />
+    </>
+  );
+};
+
+export const Default = {
+  args: {
+    cancelText: "cancel",
+    content: <div>Some content</div>,
+    dividers: false,
+    onCancelClick: () => {},
+    onSaveClick: () => {},
+    saveDisabled: false,
+    saveText: "ADD VEHICLE",
+    showCloseIcon: true,
+    title: "Add Vehicle",
+    width: "800px",
+    allGates: ["Gate 1", "Gate 2", "Gate 3"],
+    allVehicles: [
+      {
+        _id: "64c8c4cccc8d6f00130b366b",
+        modelYear: "2015",
+        projectCode: "911",
+        variant: "MP - 3.6 l6 - 397kW - 7MT - R20"
+      },
+      {
+        _id: "64c8c4cccc8d6f00130b367e",
+        modelYear: "2015",
+        projectCode: "911",
+        variant: "JS - 3.6 l6 - 397kW - 7MT - R20"
+      },
+      {
+        _id: "64c8c4cccc8d6f00130b3691",
+        modelYear: "2016",
+        projectCode: "911",
+        variant: "DB - 3.6 l6 - 397kW - 7MT - R20"
+      },
+      {
+        _id: "64c8c4cccc8d6f00130b36a4",
+        modelYear: "2016",
+        projectCode: "911",
+        variant: "MC - 397kW - 7MT - R20"
+      }
+    ],
+    selectedVehicles: [
+      {
+        _id: "",
+        gate: "",
+        modelYear: "",
+        project: "",
+        variant: ""
+      }
+    ]
+  },
+  render: Template
+};

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -3,11 +3,8 @@ import React, { MouseEventHandler } from "react";
 
 import { Button } from "@mui/material";
 import { CombinedVehicleProps } from "./VehicleSelectDialog.types";
-// import { SelectedVehicle } from "../VehicleSelect/VehicleSelect.types";
 import VehicleSelectDialog from "./VehicleSelectDialog";
 import { action } from "@storybook/addon-actions";
-
-// import { useArgs } from "@storybook/client-api";
 
 /**
  * Story metadata

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -92,8 +92,8 @@ export const Default = {
     cancelText: "cancel",
     content: <div>Some content</div>,
     dividers: false,
-    onCancelClick: () => {},
-    onSaveClick: () => {},
+    flexDirection: "column",
+    flexWrap: "nowrap",
     saveDisabled: false,
     saveText: "ADD VEHICLE",
     selectedVehicles: [

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -20,8 +20,6 @@ export default meta;
 
 const Template: StoryFn<CombinedVehicleProps> = args => {
   const [open, setOpen] = React.useState(false);
-  // saveDisabled is a boolean that is passed to the dialog
-  const [isSaveDisabled, setIsSaveDisabled] = React.useState(true);
 
   const handleClickOpen = () => setOpen(true);
   const handleCancel: MouseEventHandler<HTMLButtonElement> = args => {
@@ -29,10 +27,8 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
     action("onCancelClick")(args);
   };
   const handleSave: MouseEventHandler<HTMLButtonElement> = args => {
-    if (!isSaveDisabled) {
-      setOpen(false);
-      action("onSaveClick")(args);
-    }
+    setOpen(false);
+    action("onSaveClick")(args);
   };
 
   // useArgs is a hook that returns the current state of the args object
@@ -41,26 +37,12 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
   // update the args object with the new selectedVehicles value
   React.useEffect(() => {
     updateArgs({ selectedVehicles });
-    setIsSaveDisabled(!isValidSelection(selectedVehicles));
   }, [selectedVehicles, updateArgs]);
 
   // callback for when the selected vehicles change
   const onVehicleChange = (selectedVehicle: SelectedVehicle[]) => {
     updateArgs({ selectedVehicles: selectedVehicle });
     action("onVehicleChange")(selectedVehicle);
-    setIsSaveDisabled(!isValidSelection(selectedVehicle));
-  };
-
-  // check if the selected vehicles are valid (i.e. all fields are filled in)
-  const isValidSelection = (selectedVehicles: SelectedVehicle[]) => {
-    return selectedVehicles.every(
-      vehicle =>
-        !!vehicle._id &&
-        !!vehicle.gate &&
-        !!vehicle.modelYear &&
-        !!vehicle.project &&
-        !!vehicle.variant
-    );
   };
 
   return (
@@ -75,7 +57,6 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
         onSaveClick={handleSave}
         onVehicleChange={onVehicleChange}
         selectedVehicles={selectedVehicles}
-        saveDisabled={isSaveDisabled}
       />
     </>
   );

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -20,14 +20,19 @@ export default meta;
 
 const Template: StoryFn<CombinedVehicleProps> = args => {
   const [open, setOpen] = React.useState(false);
+  // saveDisabled is a boolean that is passed to the dialog
+  const [isSaveDisabled, setIsSaveDisabled] = React.useState(true);
+
   const handleClickOpen = () => setOpen(true);
   const handleCancel: MouseEventHandler<HTMLButtonElement> = args => {
     setOpen(false);
     action("onCancelClick")(args);
   };
   const handleSave: MouseEventHandler<HTMLButtonElement> = args => {
-    setOpen(false);
-    action("onSaveClick")(args);
+    if (!isSaveDisabled) {
+      setOpen(false);
+      action("onSaveClick")(args);
+    }
   };
 
   // useArgs is a hook that returns the current state of the args object
@@ -36,13 +41,28 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
   // update the args object with the new selectedVehicles value
   React.useEffect(() => {
     updateArgs({ selectedVehicles });
+    setIsSaveDisabled(!isValidSelection(selectedVehicles));
   }, [selectedVehicles, updateArgs]);
 
   // callback for when the selected vehicles change
   const onVehicleChange = (selectedVehicle: SelectedVehicle[]) => {
     updateArgs({ selectedVehicles: selectedVehicle });
     action("onVehicleChange")(selectedVehicle);
+    setIsSaveDisabled(!isValidSelection(selectedVehicle));
   };
+
+  // check if the selected vehicles are valid (i.e. all fields are filled in)
+  const isValidSelection = (selectedVehicles: SelectedVehicle[]) => {
+    return selectedVehicles.every(
+      vehicle =>
+        !!vehicle._id &&
+        !!vehicle.gate &&
+        !!vehicle.modelYear &&
+        !!vehicle.project &&
+        !!vehicle.variant
+    );
+  };
+
   return (
     <>
       <Button variant="outlined" onClick={handleClickOpen}>
@@ -55,6 +75,7 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
         onSaveClick={handleSave}
         onVehicleChange={onVehicleChange}
         selectedVehicles={selectedVehicles}
+        saveDisabled={isSaveDisabled}
       />
     </>
   );

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -3,6 +3,7 @@ import React, { MouseEventHandler } from "react";
 
 import { Button } from "@mui/material";
 import { CombinedVehicleProps } from "./VehicleSelectDialog.types";
+import { SelectedVehicle } from "../VehicleSelect/VehicleSelect.types";
 import VehicleSelectDialog from "./VehicleSelectDialog";
 import { action } from "@storybook/addon-actions";
 
@@ -24,7 +25,7 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
     setOpen(false);
     action("onCancelClick")(args);
   };
-  const handleSave: MouseEventHandler<HTMLButtonElement> = args => {
+  const handleSave: (vehicle: SelectedVehicle[]) => void = args => {
     setOpen(false);
     action("onSaveClick")(args);
   };

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof VehicleSelectDialog> = {
 };
 
 export default meta;
-
+// Default story with all props
 const Template: StoryFn<CombinedVehicleProps> = args => {
   const [open, setOpen] = React.useState(false);
 
@@ -44,7 +44,7 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
     updateArgs({ selectedVehicles: selectedVehicle });
     action("onVehicleChange")(selectedVehicle);
   };
-
+  // render the dialog with the vehicle select component
   return (
     <>
       <Button variant="outlined" onClick={handleClickOpen}>

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -13,7 +13,7 @@ import { useArgs } from "@storybook/client-api";
  */
 const meta: Meta<typeof VehicleSelectDialog> = {
   component: VehicleSelectDialog,
-  title: "General/VehicleSelectDialog"
+  title: "Dialog/VehicleSelectDialog"
 };
 
 export default meta;

--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -3,10 +3,11 @@ import React, { MouseEventHandler } from "react";
 
 import { Button } from "@mui/material";
 import { CombinedVehicleProps } from "./VehicleSelectDialog.types";
-import { SelectedVehicle } from "../VehicleSelect/VehicleSelect.types";
+// import { SelectedVehicle } from "../VehicleSelect/VehicleSelect.types";
 import VehicleSelectDialog from "./VehicleSelectDialog";
 import { action } from "@storybook/addon-actions";
-import { useArgs } from "@storybook/client-api";
+
+// import { useArgs } from "@storybook/client-api";
 
 /**
  * Story metadata
@@ -31,19 +32,6 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
     action("onSaveClick")(args);
   };
 
-  // useArgs is a hook that returns the current state of the args object
-  const [{ value }, updateArgs] = useArgs<CombinedVehicleProps>();
-
-  // update the args object with the new value value
-  React.useEffect(() => {
-    updateArgs({ value });
-  }, [value, updateArgs]);
-
-  // callback for when the selected vehicles change
-  const onChange = (selectedVehicle: SelectedVehicle[]) => {
-    updateArgs({ value: selectedVehicle });
-    action("onChange")(selectedVehicle);
-  };
   // render the dialog with the vehicle select component
   return (
     <>
@@ -55,8 +43,6 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
         open={open}
         onCancelClick={handleCancel}
         onSaveClick={handleSave}
-        onChange={onChange}
-        value={value}
       />
     </>
   );
@@ -65,24 +51,12 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
 export const Default = {
   args: {
     cancelText: "cancel",
-    content: <div>Some content</div>,
-    dividers: false,
     flexDirection: "column",
     flexWrap: "nowrap",
     gates: ["Gate 1", "Gate 2", "Gate 3"],
-    saveDisabled: false,
     saveText: "ADD VEHICLE",
     showCloseIcon: true,
     title: "Add Vehicle",
-    value: [
-      {
-        _id: "",
-        gate: "",
-        modelYear: "",
-        project: "",
-        variant: ""
-      }
-    ],
     variants: [
       {
         _id: "64c8c4cccc8d6f00130b366b",

--- a/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
@@ -3,9 +3,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import VehicleSelectDialog from "./VehicleSelectDialog";
 
-// Define a mock function for onSaveClick
+// mock function for onSaveClick
 const mockOnSaveClick = jest.fn();
 
+// some mock data for selected vehicles
 const selectedVehicles = [
   {
     _id: "64c8c4cccc8d6f00130b367e",
@@ -16,7 +17,7 @@ const selectedVehicles = [
   }
 ];
 
-// Define some mock data for testing.
+// some mock data for testing.
 const defaultProps = {
   allGates: ["Gate 1", "Gate 2", "Gate 3"],
   allVehicles: [
@@ -80,9 +81,10 @@ test("calls onSaveClick when Save button is clicked", () => {
 });
 
 test("disables the Save button when any field is empty", () => {
-  // render the component with an empty field in one of the selected vehicles
+  // modify the selected vehicles to have an empty gate field
   const modifiedVehicles = [...selectedVehicles];
-  modifiedVehicles[0].gate = ""; // Empty gate field
+  // empty the gate field
+  modifiedVehicles[0].gate = "";
 
   render(
     <VehicleSelectDialog

--- a/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
@@ -7,7 +7,7 @@ import VehicleSelectDialog from "./VehicleSelectDialog";
 const mockOnSaveClick = jest.fn();
 
 // some mock data for selected vehicles
-const selectedVehicles = [
+const value = [
   {
     _id: "64c8c4cccc8d6f00130b367e",
     gate: "Gate 1",
@@ -19,8 +19,13 @@ const selectedVehicles = [
 
 // some mock data for testing.
 const defaultProps = {
-  allGates: ["Gate 1", "Gate 2", "Gate 3"],
-  allVehicles: [
+  flexDirection: "column",
+  flexWrap: "nowrap",
+  gates: ["Gate 1", "Gate 2", "Gate 3"],
+  onChange: () => {},
+  onSaveClick: mockOnSaveClick,
+  value,
+  variants: [
     {
       _id: "64c8c4cccc8d6f00130b366b",
       modelYear: "2015",
@@ -45,12 +50,7 @@ const defaultProps = {
       projectCode: "911",
       variant: "MC"
     }
-  ],
-  flexDirection: "column",
-  flexWrap: "nowrap",
-  onSaveClick: mockOnSaveClick,
-  onVehicleChange: () => {},
-  selectedVehicles
+  ]
 };
 
 test("renders the VehicleSelectDialog component", () => {
@@ -77,21 +77,16 @@ test("calls onSaveClick when Save button is clicked", () => {
   fireEvent.click(saveButton);
 
   // check that the onSaveClick function was called
-  expect(mockOnSaveClick).toHaveBeenCalledWith(selectedVehicles);
+  expect(mockOnSaveClick).toHaveBeenCalledWith(value);
 });
 
 test("disables the Save button when any field is empty", () => {
   // modify the selected vehicles to have an empty gate field
-  const modifiedVehicles = [...selectedVehicles];
+  const modifiedVehicles = [...value];
   // empty the gate field
   modifiedVehicles[0].gate = "";
   // render the component with the modified selected vehicles
-  render(
-    <VehicleSelectDialog
-      {...defaultProps}
-      selectedVehicles={modifiedVehicles}
-    />
-  );
+  render(<VehicleSelectDialog {...defaultProps} value={modifiedVehicles} />);
 
   // check that the Save button is disabled
   const saveButton = screen.getByText("Save");

--- a/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import React from "react";
+import VehicleSelectDialog from "./VehicleSelectDialog";
+
+// Define a mock function for onSaveClick
+const mockOnSaveClick = jest.fn();
+
+const selectedVehicles = [
+  {
+    _id: "64c8c4cccc8d6f00130b367e",
+    gate: "Gate 1",
+    modelYear: "2015",
+    project: "911",
+    variant: "MP"
+  }
+];
+
+// Define some mock data for testing.
+const defaultProps = {
+  allGates: ["Gate 1", "Gate 2", "Gate 3"],
+  allVehicles: [
+    {
+      _id: "64c8c4cccc8d6f00130b366b",
+      modelYear: "2015",
+      projectCode: "911",
+      variant: "MP"
+    },
+    {
+      _id: "64c8c4cccc8d6f00130b367e",
+      modelYear: "2015",
+      projectCode: "911",
+      variant: "JS"
+    },
+    {
+      _id: "64c8c4cccc8d6f00130b3691",
+      modelYear: "2016",
+      projectCode: "911",
+      variant: "DB"
+    },
+    {
+      _id: "64c8c4cccc8d6f00130b36a4",
+      modelYear: "2016",
+      projectCode: "911",
+      variant: "MC"
+    }
+  ],
+  flexDirection: "column",
+  flexWrap: "nowrap",
+  onSaveClick: mockOnSaveClick,
+  onVehicleChange: () => {},
+  selectedVehicles
+};
+
+test("renders the VehicleSelectDialog component", () => {
+  render(<VehicleSelectDialog {...defaultProps} />);
+  // render the component
+  expect(screen.getByText("Some title")).toBeInTheDocument();
+});
+
+test("enables the Save button when all fields are filled", () => {
+  // render the component with all fields filled in selected vehicles
+  render(<VehicleSelectDialog {...defaultProps} />);
+
+  // check that the Save button is enabled
+  const saveButton = screen.getByText("Save");
+  expect(saveButton).toBeEnabled();
+});
+
+test("calls onSaveClick when Save button is clicked", () => {
+  // render the component
+  render(<VehicleSelectDialog {...defaultProps} />);
+
+  // click the Save button
+  const saveButton = screen.getByText("Save");
+  fireEvent.click(saveButton);
+
+  // check that the onSaveClick function was called
+  expect(mockOnSaveClick).toHaveBeenCalledWith(selectedVehicles);
+});
+
+test("disables the Save button when any field is empty", () => {
+  // render the component with an empty field in one of the selected vehicles
+  const modifiedVehicles = [...selectedVehicles];
+  modifiedVehicles[0].gate = ""; // Empty gate field
+
+  render(
+    <VehicleSelectDialog
+      {...defaultProps}
+      selectedVehicles={modifiedVehicles}
+    />
+  );
+
+  // check that the Save button is disabled
+  const saveButton = screen.getByText("Save");
+  expect(saveButton).toBeDisabled();
+});

--- a/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
@@ -85,7 +85,7 @@ test("disables the Save button when any field is empty", () => {
   const modifiedVehicles = [...selectedVehicles];
   // empty the gate field
   modifiedVehicles[0].gate = "";
-
+  // render the component with the modified selected vehicles
   render(
     <VehicleSelectDialog
       {...defaultProps}

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -46,7 +46,7 @@ const VehicleSelectDialog = ({
       onSaveClick(selectedVehicles);
     }
   };
-
+  // render the dialog with the vehicle select component
   return (
     <Dialog
       open={open}

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -7,10 +7,10 @@ import {
   IconButton,
   Stack
 } from "@mui/material";
+import React, { useState } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
 import { CombinedVehicleProps } from "./VehicleSelectDialog.types";
-import React from "react";
 import { SelectedVehicle } from "src/VehicleSelect/VehicleSelect.types";
 import VehicleSelect from "src/VehicleSelect/VehicleSelect";
 
@@ -24,28 +24,32 @@ const VehicleSelectDialog = ({
   width = "400px",
   showCloseIcon = true,
   variants = [],
-  value = [],
   flexDirection = "column",
   flexWrap = "nowrap",
-  gates = [],
-  onChange = () => {}
+  gates = []
 }: CombinedVehicleProps) => {
+  // internal state to manage selected vehicles
+  const [value, setValue] = useState<SelectedVehicle[]>([]);
+
   // check if all fields are filled for each selected vehicle
-  const isSaveDisabled = value.some(
-    vehicle =>
-      !vehicle._id ||
-      !vehicle.gate ||
-      !vehicle.modelYear ||
-      !vehicle.project ||
-      !vehicle.variant
-  );
+  const isSaveDisabled =
+    value.length === 0 ||
+    value.some(
+      vehicle =>
+        !vehicle._id ||
+        !vehicle.gate ||
+        !vehicle.modelYear ||
+        !vehicle.project ||
+        !vehicle.variant
+    );
 
   // handle save click will return callback with selected vehicles
-  const handleSaveClick = (value: SelectedVehicle[]) => {
+  const handleSaveClick = () => {
     if (!isSaveDisabled) {
       onSaveClick(value);
     }
   };
+
   // render the dialog with the vehicle select component
   return (
     <Dialog
@@ -89,7 +93,7 @@ const VehicleSelectDialog = ({
             flexDirection={flexDirection}
             flexWrap={flexWrap}
             gates={gates}
-            onChange={onChange}
+            onChange={setValue}
           />
         </Stack>
       </DialogContent>
@@ -97,7 +101,7 @@ const VehicleSelectDialog = ({
         <Button onClick={onCancelClick}>{cancelText}</Button>
         <Button
           variant="contained"
-          onClick={() => handleSaveClick(value)}
+          onClick={handleSaveClick}
           disabled={isSaveDisabled}
         >
           {saveText}

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -1,0 +1,94 @@
+import { DialogTitle, Stack } from "@mui/material";
+
+import Button from "@mui/material/Button";
+import CloseIcon from "@mui/icons-material/Close";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import IconButton from "@mui/material/IconButton";
+import React from "react";
+import VehicleSelect from "src/VehicleSelect/VehicleSelect";
+import { VehicleSelectDialogProps } from "./VehicleSelectDialog.types";
+import { VehicleSelectProps } from "src/VehicleSelect/VehicleSelect.types";
+
+// Create a new interface that merges VehicleSelectProps and VehicleSelectDialogProps
+interface CombinedProps extends VehicleSelectProps, VehicleSelectDialogProps {}
+
+const VehicleSelectDialog = ({
+  onCancelClick,
+  onSaveClick,
+  title = "Some title",
+  cancelText = "cancel",
+  saveText = "Save",
+  open = true,
+  saveDisabled = false,
+  width = "400px",
+  showCloseIcon = true,
+  allVehicles = [],
+  selectedVehicles = [],
+  flexDirection = "column",
+  flexWrap = "nowrap",
+  allGates = [],
+  onVehicleChange = () => {}
+}: CombinedProps) => {
+  return (
+    <Dialog
+      open={open}
+      data-testid="action-dialog"
+      sx={{
+        "& .MuiDialog-container": {
+          "& .MuiPaper-root": {
+            maxWidth: width,
+            width: "100%"
+          }
+        },
+        "& .MuiDialogActions-root": {
+          p: [2, 3]
+        }
+      }}
+    >
+      <DialogTitle fontWeight={600}>
+        {title}
+        {showCloseIcon ? (
+          <IconButton
+            data-testid="close-icon"
+            aria-label="close"
+            onClick={onCancelClick}
+            sx={{
+              color: theme => theme.palette.grey[500],
+              position: "absolute",
+              right: 8,
+              top: 8
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        ) : null}
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={3}>
+          <VehicleSelect
+            allVehicles={allVehicles}
+            selectedVehicles={selectedVehicles}
+            flexDirection={flexDirection}
+            flexWrap={flexWrap}
+            allGates={allGates}
+            onVehicleChange={onVehicleChange}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancelClick}>{cancelText}</Button>
+        <Button
+          variant="contained"
+          onClick={onSaveClick}
+          disabled={saveDisabled}
+        >
+          {saveText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default VehicleSelectDialog;

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -21,7 +21,6 @@ const VehicleSelectDialog = ({
   cancelText = "cancel",
   saveText = "Save",
   open = true,
-  saveDisabled = false,
   width = "400px",
   showCloseIcon = true,
   allVehicles = [],
@@ -31,11 +30,27 @@ const VehicleSelectDialog = ({
   allGates = [],
   onVehicleChange = () => {}
 }: CombinedVehicleProps) => {
+  // check if all fields are filled for each selected vehicle
+  const isSaveDisabled = selectedVehicles.some(
+    vehicle =>
+      !vehicle._id ||
+      !vehicle.gate ||
+      !vehicle.modelYear ||
+      !vehicle.project ||
+      !vehicle.variant
+  );
+
   const handleSaveClick = (selectedVehicles: SelectedVehicle[]) => {
-    if (!saveDisabled) {
+    if (!isSaveDisabled) {
       onSaveClick(selectedVehicles);
     }
   };
+
+  // const handleSaveClick = (selectedVehicles: SelectedVehicle[]) => {
+  //   if (!saveDisabled) {
+  //     onSaveClick(selectedVehicles);
+  //   }
+  // };
   return (
     <Dialog
       open={open}
@@ -87,7 +102,7 @@ const VehicleSelectDialog = ({
         <Button
           variant="contained"
           onClick={() => handleSaveClick(selectedVehicles)}
-          disabled={saveDisabled}
+          disabled={isSaveDisabled}
         >
           {saveText}
         </Button>

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -23,15 +23,15 @@ const VehicleSelectDialog = ({
   open = true,
   width = "400px",
   showCloseIcon = true,
-  allVehicles = [],
-  selectedVehicles = [],
+  variants = [],
+  value = [],
   flexDirection = "column",
   flexWrap = "nowrap",
-  allGates = [],
-  onVehicleChange = () => {}
+  gates = [],
+  onChange = () => {}
 }: CombinedVehicleProps) => {
   // check if all fields are filled for each selected vehicle
-  const isSaveDisabled = selectedVehicles.some(
+  const isSaveDisabled = value.some(
     vehicle =>
       !vehicle._id ||
       !vehicle.gate ||
@@ -41,9 +41,9 @@ const VehicleSelectDialog = ({
   );
 
   // handle save click will return callback with selected vehicles
-  const handleSaveClick = (selectedVehicles: SelectedVehicle[]) => {
+  const handleSaveClick = (value: SelectedVehicle[]) => {
     if (!isSaveDisabled) {
-      onSaveClick(selectedVehicles);
+      onSaveClick(value);
     }
   };
   // render the dialog with the vehicle select component
@@ -84,12 +84,12 @@ const VehicleSelectDialog = ({
       <DialogContent>
         <Stack spacing={3}>
           <VehicleSelect
-            allVehicles={allVehicles}
-            selectedVehicles={selectedVehicles}
+            variants={variants}
+            value={value}
             flexDirection={flexDirection}
             flexWrap={flexWrap}
-            allGates={allGates}
-            onVehicleChange={onVehicleChange}
+            gates={gates}
+            onChange={onChange}
           />
         </Stack>
       </DialogContent>
@@ -97,7 +97,7 @@ const VehicleSelectDialog = ({
         <Button onClick={onCancelClick}>{cancelText}</Button>
         <Button
           variant="contained"
-          onClick={() => handleSaveClick(selectedVehicles)}
+          onClick={() => handleSaveClick(value)}
           disabled={isSaveDisabled}
         >
           {saveText}

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -1,18 +1,17 @@
-import { DialogTitle, Stack } from "@mui/material";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack
+} from "@mui/material";
 
-import Button from "@mui/material/Button";
 import CloseIcon from "@mui/icons-material/Close";
-import Dialog from "@mui/material/Dialog";
-import DialogActions from "@mui/material/DialogActions";
-import DialogContent from "@mui/material/DialogContent";
-import IconButton from "@mui/material/IconButton";
+import { CombinedVehicleProps } from "./VehicleSelectDialog.types";
 import React from "react";
 import VehicleSelect from "src/VehicleSelect/VehicleSelect";
-import { VehicleSelectDialogProps } from "./VehicleSelectDialog.types";
-import { VehicleSelectProps } from "src/VehicleSelect/VehicleSelect.types";
-
-// Create a new interface that merges VehicleSelectProps and VehicleSelectDialogProps
-interface CombinedProps extends VehicleSelectProps, VehicleSelectDialogProps {}
 
 const VehicleSelectDialog = ({
   onCancelClick,
@@ -30,7 +29,7 @@ const VehicleSelectDialog = ({
   flexWrap = "nowrap",
   allGates = [],
   onVehicleChange = () => {}
-}: CombinedProps) => {
+}: CombinedVehicleProps) => {
   return (
     <Dialog
       open={open}

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -40,17 +40,13 @@ const VehicleSelectDialog = ({
       !vehicle.variant
   );
 
+  // handle save click will return callback with selected vehicles
   const handleSaveClick = (selectedVehicles: SelectedVehicle[]) => {
     if (!isSaveDisabled) {
       onSaveClick(selectedVehicles);
     }
   };
 
-  // const handleSaveClick = (selectedVehicles: SelectedVehicle[]) => {
-  //   if (!saveDisabled) {
-  //     onSaveClick(selectedVehicles);
-  //   }
-  // };
   return (
     <Dialog
       open={open}

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -7,7 +7,7 @@ import {
   IconButton,
   Stack
 } from "@mui/material";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
 import { CombinedVehicleProps } from "./VehicleSelectDialog.types";
@@ -49,6 +49,13 @@ const VehicleSelectDialog = ({
       onSaveClick(value);
     }
   };
+
+  // reset the state when the dialog is opened
+  useEffect(() => {
+    if (open) {
+      setValue([]);
+    }
+  }, [open]);
 
   // render the dialog with the vehicle select component
   return (

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -11,11 +11,12 @@ import {
 import CloseIcon from "@mui/icons-material/Close";
 import { CombinedVehicleProps } from "./VehicleSelectDialog.types";
 import React from "react";
+import { SelectedVehicle } from "src/VehicleSelect/VehicleSelect.types";
 import VehicleSelect from "src/VehicleSelect/VehicleSelect";
 
 const VehicleSelectDialog = ({
-  onCancelClick,
-  onSaveClick,
+  onCancelClick = () => {},
+  onSaveClick = () => {},
   title = "Some title",
   cancelText = "cancel",
   saveText = "Save",
@@ -30,6 +31,11 @@ const VehicleSelectDialog = ({
   allGates = [],
   onVehicleChange = () => {}
 }: CombinedVehicleProps) => {
+  const handleSaveClick = (selectedVehicles: SelectedVehicle[]) => {
+    if (!saveDisabled) {
+      onSaveClick(selectedVehicles);
+    }
+  };
   return (
     <Dialog
       open={open}
@@ -80,7 +86,7 @@ const VehicleSelectDialog = ({
         <Button onClick={onCancelClick}>{cancelText}</Button>
         <Button
           variant="contained"
-          onClick={onSaveClick}
+          onClick={() => handleSaveClick(selectedVehicles)}
           disabled={saveDisabled}
         >
           {saveText}

--- a/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
@@ -9,10 +9,6 @@ export interface VehicleSelectDialogProps {
    */
   cancelText?: string;
   /**
-   * Dividers are vertical lines that separate content into groups.
-   */
-  dividers?: boolean;
-  /**
    * Callback fired when cancel button clicked.
    */
   onCancelClick: React.MouseEventHandler<HTMLButtonElement>;

--- a/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
@@ -46,9 +46,8 @@ export interface VehicleSelectDialogProps {
    * The width of the dialog. Valid css width can be used.
    */
   width?: string;
-  /**
-   * Callback function fired on each vehicle metadata change
-   */
-  onVehicleChange: VehicleSelectProps["onVehicleChange"];
-  selectedVehicles: VehicleSelectProps["selectedVehicles"];
 }
+
+// Create a new interface that merges VehicleSelectProps and VehicleSelectDialogProps
+export type CombinedVehicleProps = VehicleSelectProps &
+  VehicleSelectDialogProps;

--- a/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
@@ -1,14 +1,13 @@
-import { VehicleSelectProps } from "src/VehicleSelect/VehicleSelect.types";
+import {
+  SelectedVehicle,
+  VehicleSelectProps
+} from "src/VehicleSelect/VehicleSelect.types";
 
 export interface VehicleSelectDialogProps {
   /**
    * The text of the cancel button.
    * */
   cancelText?: string;
-  /**
-   * The content of the dialog. Valid react element can be used.
-   */
-  content: React.ReactNode;
   /**
    * Dividers are vertical lines that separate content into groups.
    */
@@ -20,7 +19,7 @@ export interface VehicleSelectDialogProps {
   /**
    * Callback fired when save button clicked.
    */
-  onSaveClick: React.MouseEventHandler<HTMLButtonElement>;
+  onSaveClick: (vehicle: SelectedVehicle[]) => void;
   /**
    * If true, the dialog is open.
    * */

--- a/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
@@ -6,7 +6,7 @@ import {
 export interface VehicleSelectDialogProps {
   /**
    * The text of the cancel button.
-   * */
+   */
   cancelText?: string;
   /**
    * Dividers are vertical lines that separate content into groups.
@@ -22,13 +22,11 @@ export interface VehicleSelectDialogProps {
   onSaveClick: (vehicle: SelectedVehicle[]) => void;
   /**
    * If true, the dialog is open.
-   * */
+   */
   open?: boolean;
-
   /**
    * The text of the save button.
-   * @default "Save"
-   * */
+   */
   saveText?: string;
   /**
    * If true, shows close icon in dialog title
@@ -36,7 +34,7 @@ export interface VehicleSelectDialogProps {
   showCloseIcon?: boolean;
   /**
    * The title of the dialog.
-   * */
+   */
   title?: string;
   /**
    * The width of the dialog. Valid css width can be used.
@@ -44,6 +42,6 @@ export interface VehicleSelectDialogProps {
   width?: string;
 }
 
-// Create a new interface that merges VehicleSelectProps and VehicleSelectDialogProps
+// Create a new type that merges VehicleSelectProps and VehicleSelectDialogProps
 export type CombinedVehicleProps = VehicleSelectProps &
   VehicleSelectDialogProps;

--- a/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
@@ -24,10 +24,7 @@ export interface VehicleSelectDialogProps {
    * If true, the dialog is open.
    * */
   open?: boolean;
-  /**
-   * If true, save button will be disabled.
-   */
-  saveDisabled?: boolean;
+
   /**
    * The text of the save button.
    * @default "Save"

--- a/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
@@ -39,5 +39,8 @@ export interface VehicleSelectDialogProps {
 }
 
 // Create a new type that merges VehicleSelectProps and VehicleSelectDialogProps
-export type CombinedVehicleProps = VehicleSelectProps &
+export type CombinedVehicleProps = Omit<
+  VehicleSelectProps,
+  "onChange" | "value"
+> &
   VehicleSelectDialogProps;

--- a/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
@@ -1,0 +1,54 @@
+import { VehicleSelectProps } from "src/VehicleSelect/VehicleSelect.types";
+
+export interface VehicleSelectDialogProps {
+  /**
+   * The text of the cancel button.
+   * */
+  cancelText?: string;
+  /**
+   * The content of the dialog. Valid react element can be used.
+   */
+  content: React.ReactNode;
+  /**
+   * Dividers are vertical lines that separate content into groups.
+   */
+  dividers?: boolean;
+  /**
+   * Callback fired when cancel button clicked.
+   */
+  onCancelClick: React.MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Callback fired when save button clicked.
+   */
+  onSaveClick: React.MouseEventHandler<HTMLButtonElement>;
+  /**
+   * If true, the dialog is open.
+   * */
+  open?: boolean;
+  /**
+   * If true, save button will be disabled.
+   */
+  saveDisabled?: boolean;
+  /**
+   * The text of the save button.
+   * @default "Save"
+   * */
+  saveText?: string;
+  /**
+   * If true, shows close icon in dialog title
+   */
+  showCloseIcon?: boolean;
+  /**
+   * The title of the dialog.
+   * */
+  title?: string;
+  /**
+   * The width of the dialog. Valid css width can be used.
+   */
+  width?: string;
+  /**
+   * Callback function fired on each vehicle metadata change
+   */
+  onVehicleChange: VehicleSelectProps["onVehicleChange"];
+  selectedVehicles: VehicleSelectProps["selectedVehicles"];
+}

--- a/src/VehicleSelectDialog/index.ts
+++ b/src/VehicleSelectDialog/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./VehicleSelectDialog";
+export { VehicleSelectDialogProps } from "./VehicleSelectDialog.types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,10 @@ export {
   IpgLogoProps
 } from "./SvgIcons";
 export { default as VehicleSelect, VehicleSelectProps } from "./VehicleSelect";
+export {
+  default as VehicleSelectDialog,
+  VehicleSelectDialogProps
+} from "./VehicleSelectDialog";
 export { default as ViewToggleButton } from "./ViewToggleButton";
 export {
   BackButton,


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-2069](https://sce.myjetbrains.com/youtrack/issue/TD-2069/Create-add-vehicle-dialog)
Figma: https://www.figma.com/proto/B75H0DFTEiUFjJtehIKa8M/VIRTO.MODEL?node-id=522-57017&scaling=scale-down&page-id=0%3A1&starting-point-node-id=228%3A28915

## Changes
- Created a new VehicleSelectDialog component
- Enables the "Add Vehicle" upon valid vehicle selection
- Added callback to return the currently selected vehicles
- Upgraded to node version 18 and upgraded the actions/setup-node action to the latest version
- Moved ActionDialog, DialogTitle, and VehicleSelectDialog components under the Dialog category from General
- Renamed selected vehicles to value, all gates to gates, on vehicle change to onChange, allVehicles to variants to be consistent with vehicleSelect Component
- Added a new prop disableCloseOnSelect to the AutoComplete Component
- Enabled disableCloseOnSelect on multi-select Autocompletes inside VehicleSelect Component
- Because of the disableCloseOnSelect prop which prevents the dropdown from closing when an option is selected (VehicleSlect Component test failed). Modified tests to explicitly close the dropdown after selecting an option using userEvent.click.

## UI/UX
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/49191249/519d0863-f342-4bc4-a83d-a91bba10d78f)

Enables the "Add Vehicle" upon valid vehicle selection
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/49191249/d6ab5e41-d5ea-4703-b94f-0f08e76a05e2)

 The callback returns the currently selected vehicles
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/49191249/0d74e9c5-3726-44a6-b1a5-09e036640559)

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
