### PR TITLE
Fixed inconsistency with project and projectCode

### DIFF
--- a/src/VehicleSelect/VehicleSelect.stories.tsx
+++ b/src/VehicleSelect/VehicleSelect.stories.tsx
@@ -43,7 +43,7 @@ export const Default = {
         _id: "",
         gate: "",
         modelYear: "",
-        project: "",
+        projectCode: "",
         variant: ""
       }
     ],

--- a/src/VehicleSelect/VehicleSelect.test.tsx
+++ b/src/VehicleSelect/VehicleSelect.test.tsx
@@ -97,7 +97,7 @@ describe("Vehicle Select", () => {
         _id: "",
         gate: "",
         modelYear: "",
-        project: "911",
+        projectCode: "911",
         variant: ""
       }
     ]);
@@ -121,7 +121,7 @@ describe("Vehicle Select", () => {
         _id: "",
         gate: "",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: ""
       }
     ]);
@@ -147,7 +147,7 @@ describe("Vehicle Select", () => {
         _id: "64c8c4cccc8d6f00130b367e",
         gate: "",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "JS"
       }
     ]);
@@ -173,14 +173,14 @@ describe("Vehicle Select", () => {
         _id: "64c8c4cccc8d6f00130b366b",
         gate: "",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "MP"
       },
       {
         _id: "64c8c4cccc8d6f00130b367e",
         gate: "",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "JS"
       }
     ]);
@@ -206,14 +206,14 @@ describe("Vehicle Select", () => {
         _id: "64c8c4cccc8d6f00130b366b",
         gate: "Gate 1",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "MP"
       },
       {
         _id: "64c8c4cccc8d6f00130b367e",
         gate: "Gate 1",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "JS"
       }
     ]);
@@ -239,28 +239,28 @@ describe("Vehicle Select", () => {
         _id: "64c8c4cccc8d6f00130b366b",
         gate: "Gate 1",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "MP"
       },
       {
         _id: "64c8c4cccc8d6f00130b367e",
         gate: "Gate 1",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "JS"
       },
       {
         _id: "64c8c4cccc8d6f00130b366b",
         gate: "Gate 2",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "MP"
       },
       {
         _id: "64c8c4cccc8d6f00130b367e",
         gate: "Gate 2",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "JS"
       }
     ]);
@@ -273,7 +273,7 @@ describe("Vehicle Select", () => {
         _id: "64c8c4cccc8d6f00130b367e",
         gate: "Gate 1",
         modelYear: "2015",
-        project: "911",
+        projectCode: "911",
         variant: "MP"
       }
     ];

--- a/src/VehicleSelect/VehicleSelect.tsx
+++ b/src/VehicleSelect/VehicleSelect.tsx
@@ -13,7 +13,9 @@ function VehicleSelect({
   variants = []
 }: VehicleSelectProps) {
   // derive state for selected project
-  const selectedProjects = [...new Set(value.map(vehicle => vehicle.project))];
+  const selectedProjects = [
+    ...new Set(value.map(vehicle => vehicle.projectCode))
+  ];
   if (selectedProjects.length > 1)
     throw new Error("Project selection is ambiguous");
   const selectedProject = selectedProjects[0] ?? null;
@@ -87,7 +89,7 @@ function VehicleSelect({
                 _id: "",
                 gate: "",
                 modelYear: "",
-                project: newValue,
+                projectCode: newValue,
                 variant: ""
               }
             ]);
@@ -109,7 +111,7 @@ function VehicleSelect({
                 _id: "",
                 gate: "",
                 modelYear: newValue,
-                project: selectedProject,
+                projectCode: selectedProject,
                 variant: ""
               }
             ]);
@@ -139,7 +141,7 @@ function VehicleSelect({
                   _id: "",
                   gate: "",
                   modelYear: selectedModelYear,
-                  project: selectedProject,
+                  projectCode: selectedProject,
                   variant: ""
                 }
               ]);
@@ -152,7 +154,7 @@ function VehicleSelect({
                   _id: v._id,
                   gate: "",
                   modelYear: v.modelYear,
-                  project: v.projectCode,
+                  projectCode: v.projectCode,
                   variant: v.variant
                 }))
               );
@@ -164,7 +166,7 @@ function VehicleSelect({
                   _id: v._id,
                   gate,
                   modelYear: v.modelYear,
-                  project: v.projectCode,
+                  projectCode: v.projectCode,
                   variant: v.variant
                 }))
               );
@@ -196,7 +198,7 @@ function VehicleSelect({
                   _id: v._id,
                   gate: "",
                   modelYear: v.modelYear,
-                  project: v.projectCode,
+                  projectCode: v.projectCode,
                   variant: v.variant
                 }))
               );
@@ -208,7 +210,7 @@ function VehicleSelect({
                 _id: v._id,
                 gate,
                 modelYear: v.modelYear,
-                project: v.projectCode,
+                projectCode: v.projectCode,
                 variant: v.variant
               }))
             );

--- a/src/VehicleSelect/VehicleSelect.types.ts
+++ b/src/VehicleSelect/VehicleSelect.types.ts
@@ -9,7 +9,7 @@ export type Vehicle = {
 // types for the selected vehicle
 export type SelectedVehicle = {
   _id: string;
-  project: string;
+  projectCode: string;
   modelYear: string;
   variant: string;
   gate: string;

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -39,7 +39,7 @@ const VehicleSelectDialog = ({
         !vehicle._id ||
         !vehicle.gate ||
         !vehicle.modelYear ||
-        !vehicle.project ||
+        !vehicle.projectCode ||
         !vehicle.variant
     );
 


### PR DESCRIPTION
Contributes to [TD-1435](https://sce.myjetbrains.com/youtrack/issue/TD-1435/Multiselection-of-Vehicle-Variants-in-Data-Model-upload)

## Changes

Fixed an issue I spotted when trying to make use of the [recently released](https://github.com/IPG-Automotive-UK/react-ui/pull/694) VehicleSelect component. There was an inconsistency with the input and output objects. We were passing in an object with a field `projectCode` but getting back and object with a field `project`. VIRTO.VEHICLE uses `projectCode` so it makes sense to stick with this so we can just pass data directly through.

Before:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/5049ade4-48ab-4894-88c6-819f3b333cbf)

After:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/50ec4395-b19d-409d-b551-90e3de34b619)

## Testing notes

No manual testing is required here. The automated tests and type-checks already cater for this. If you do want to manually test something then you could `npm run storybook` and check you can still interact with the VehicleSelect component.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker. N/A
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Appropriate tests have been added. N/A already have test coverage
- [ ] Lint and test workflows pass.
