### PR TITLE
Fix spread syntax bundling error with VehicleSelect

### DIFF
--- a/src/VehicleSelect/VehicleSelect.tsx
+++ b/src/VehicleSelect/VehicleSelect.tsx
@@ -3,6 +3,11 @@ import { Box } from "@mui/material";
 import React from "react";
 import { VehicleSelectProps } from "./VehicleSelect.types";
 
+// function to return unique sorted array of values from a string array
+function uniqueSortedArray(values: string[]) {
+  return values.filter((item, i, ar) => ar.indexOf(item) === i).sort();
+}
+
 // component to select a vehicle
 function VehicleSelect({
   flexDirection = "column",
@@ -13,57 +18,52 @@ function VehicleSelect({
   variants = []
 }: VehicleSelectProps) {
   // derive state for selected project
-  const selectedProjects = [
-    ...new Set(value.map(vehicle => vehicle.projectCode))
-  ];
+  const selectedProjects = uniqueSortedArray(
+    value.map(vehicle => vehicle.projectCode)
+  );
   if (selectedProjects.length > 1)
     throw new Error("Project selection is ambiguous");
   const selectedProject = selectedProjects[0] ?? null;
 
   // derive state for all projects
-  const allProjects = [
-    ...new Set(variants.map(vehicle => vehicle.projectCode))
-  ].sort();
+  const allProjects = uniqueSortedArray(
+    variants.map(vehicle => vehicle.projectCode)
+  );
 
   // derive state for selected model year
-  const selectedModelYears = [
-    ...new Set(value.map(vehicle => vehicle.modelYear))
-  ];
+  const selectedModelYears = uniqueSortedArray(
+    value.map(vehicle => vehicle.modelYear)
+  );
   if (selectedModelYears.length > 1)
     throw new Error("Multiple year is ambiguous");
   const selectedModelYear = selectedModelYears[0] ?? null;
 
   // derive state for all model years
-  const allModelYears = [
-    ...new Set(
-      variants
-        .filter(v => v.projectCode === selectedProject)
-        .map(vehicle => vehicle.modelYear)
-    )
-  ].sort();
+  const allModelYears = uniqueSortedArray(
+    variants
+      .filter(v => v.projectCode === selectedProject)
+      .map(vehicle => vehicle.modelYear)
+  );
 
-  // derive state for select variants
-  const selectedVariants = [...new Set(value.map(vehicle => vehicle.variant))]
-    .filter(v => v !== "")
-    .sort();
+  // derive state for selected variants
+  const selectedVariants = uniqueSortedArray(
+    value.map(vehicle => vehicle.variant)
+  ).filter(v => v !== "");
 
   // derive state for all variants
-  const allVariants = [
-    ...new Set(
-      variants
-        .filter(
-          v =>
-            v.projectCode === selectedProject &&
-            v.modelYear === selectedModelYear
-        )
-        .map(v => v.variant)
-    )
-  ].sort();
+  const allVariants = uniqueSortedArray(
+    variants
+      .filter(
+        v =>
+          v.projectCode === selectedProject && v.modelYear === selectedModelYear
+      )
+      .map(vehicle => vehicle.variant)
+  );
 
   // derive state for selected gates
-  const selectedGates = [...new Set(value.map(vehicle => vehicle.gate))]
-    .filter(v => v !== "")
-    .sort();
+  const selectedGates = uniqueSortedArray(
+    value.map(vehicle => vehicle.gate)
+  ).filter(v => v !== "");
 
   // create the selector components for project, model year, variant and gate with single select for project and model year and multi select for variant and gate
   return (


### PR DESCRIPTION
Contributes to [TD-1435](https://sce.myjetbrains.com/youtrack/issue/TD-1435/Multiselection-of-Vehicle-Variants-in-Data-Model-upload)

## Changes

When trying to make use of the new VehicleSelect component in one of our apps I noticed we were getting this weird behaviour.
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/41cd7db2-2a8b-4826-be32-555d35da167e)

I've tracked it down to an issue with the bundler and known issue https://github.com/developit/microbundle/issues/945.

We were making use of spread syntax to get unique values in an array
```
const selectedProjects = [
    ...new Set(value.map(vehicle => vehicle.projectCode))
  ];
```

When bundled this was building down to this which is not the same.
```
var selectedProjects = [].concat(new Set(value.map(function (vehicle) {
    return vehicle.projectCode;
  })));
```

You can check the bundled code using `npm run build` and then inspecting `dist/index.js` and finding the VehicleSelect function.

This is what it used to be
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/abebb0b2-9065-4533-8d31-0aca16f099cf)

I've switched away from using the spread syntax. In the future we may switch to a different bundler but for now this workaround is fine. We should just keep in mind for any future enhancements.

## Testing notes

The automated tests and type checks cover the change but you could also manually test the VehicleSelect component in storybook `npm run storybook`

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker. N/A
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Appropriate tests have been added. N/A already covered by existing tests.
- [x] Lint and test workflows pass.
