### PR TITLE
Fixed issue disabling vehicle select with empty value

### DIFF
--- a/src/VehicleSelect/VehicleSelect.stories.tsx
+++ b/src/VehicleSelect/VehicleSelect.stories.tsx
@@ -38,15 +38,7 @@ export const Default = {
     flexDirection: "column",
     flexWrap: "nowrap",
     gates: ["Gate 1", "Gate 2", "Gate 3"],
-    value: [
-      {
-        _id: "",
-        gate: "",
-        modelYear: "",
-        projectCode: "",
-        variant: ""
-      }
-    ],
+    value: [],
     variants: [
       {
         _id: "64c8c4cccc8d6f00130b366b",
@@ -85,6 +77,5 @@ export const WithFlexStyles = {
     flexDirection: "row",
     flexWrap: "wrap"
   },
-
   render: Template
 };

--- a/src/VehicleSelect/VehicleSelect.test.tsx
+++ b/src/VehicleSelect/VehicleSelect.test.tsx
@@ -385,9 +385,9 @@ describe("Vehicle Select", () => {
         {...defaultProps}
         value={[
           {
-            _id: "64c8c4cccc8d6f00130b366b",
+            _id: "64c8c4cccc8d6f00130b3691",
             gate: "Gate 1",
-            modelYear: "2015",
+            modelYear: "2016",
             projectCode: "911",
             variant: "DB"
           }

--- a/src/VehicleSelect/VehicleSelect.test.tsx
+++ b/src/VehicleSelect/VehicleSelect.test.tsx
@@ -71,9 +71,12 @@ const VehicleSelectWithState = ({
  * Tests
  */
 describe("Vehicle Select", () => {
+  // test that the component renders with the default props
   it("renders component", () => {
     render(<VehicleSelectWithState {...defaultProps} />);
   });
+
+  // test that on change is called with the expected value
   it("onChange called", async () => {
     const onChange = jest.fn();
     render(<VehicleSelectWithState {...defaultProps} onChange={onChange} />);
@@ -266,7 +269,8 @@ describe("Vehicle Select", () => {
     ]);
   });
 
-  it("Called with value", () => {
+  // test that the component renders with the expected value when fully populated
+  it("Called with fully populated value", () => {
     // selected vehicles example
     const value = [
       {
@@ -278,7 +282,6 @@ describe("Vehicle Select", () => {
       }
     ];
     render(<VehicleSelectWithState {...defaultProps} value={value} />);
-
     expect(screen.getByRole("combobox", { name: /project code/i })).toHaveValue(
       "911"
     );
@@ -293,6 +296,7 @@ describe("Vehicle Select", () => {
     expect(screen.getByRole("button", { name: /gate 1/i })).toBeInTheDocument();
   });
 
+  // test that flex styles are applied
   it("has flex direction and flex wrap styles applied", () => {
     render(
       <VehicleSelectWithState
@@ -305,5 +309,98 @@ describe("Vehicle Select", () => {
       flexDirection: "row",
       flexWrap: "wrap"
     });
+  });
+
+  // test that correct fields are disabled when value is empty - only project code should be enabled
+  it("correct fields disabled when value is empty", () => {
+    render(<VehicleSelectWithState {...defaultProps} value={[]} />);
+    expect(
+      screen.getByRole("combobox", { name: /project code/i })
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("combobox", { name: /model year/i })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("combobox", { name: /vehicle variant/i })
+    ).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: /gate/i })).toBeDisabled();
+  });
+
+  // test that correct fields are disabled when variant is empty - gate should be disabled
+  it("correct fields disabled when variant is empty", () => {
+    render(
+      <VehicleSelectWithState
+        {...defaultProps}
+        value={[
+          {
+            _id: "64c8c4cccc8d6f00130b366b",
+            gate: "",
+            modelYear: "2015",
+            projectCode: "911",
+            variant: ""
+          }
+        ]}
+      />
+    );
+    expect(
+      screen.getByRole("combobox", { name: /project code/i })
+    ).toBeEnabled();
+    expect(screen.getByRole("combobox", { name: /model year/i })).toBeEnabled();
+    expect(
+      screen.getByRole("combobox", { name: /vehicle variant/i })
+    ).toBeEnabled();
+    expect(screen.getByRole("combobox", { name: /gate/i })).toBeDisabled();
+  });
+
+  // test that correct fields are disabled when model year is empty - gate and variant should be disabled
+  it("correct fields disabled when model year is empty", () => {
+    render(
+      <VehicleSelectWithState
+        {...defaultProps}
+        value={[
+          {
+            _id: "64c8c4cccc8d6f00130b366b",
+            gate: "",
+            modelYear: "",
+            projectCode: "911",
+            variant: ""
+          }
+        ]}
+      />
+    );
+    expect(
+      screen.getByRole("combobox", { name: /project code/i })
+    ).toBeEnabled();
+    expect(screen.getByRole("combobox", { name: /model year/i })).toBeEnabled();
+    expect(
+      screen.getByRole("combobox", { name: /vehicle variant/i })
+    ).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: /gate/i })).toBeDisabled();
+  });
+
+  // test that all fields are enabled when all fields are populated
+  it("all fields enabled when all fields populated", () => {
+    render(
+      <VehicleSelectWithState
+        {...defaultProps}
+        value={[
+          {
+            _id: "64c8c4cccc8d6f00130b366b",
+            gate: "Gate 1",
+            modelYear: "2015",
+            projectCode: "911",
+            variant: "DB"
+          }
+        ]}
+      />
+    );
+    expect(
+      screen.getByRole("combobox", { name: /project code/i })
+    ).toBeEnabled();
+    expect(screen.getByRole("combobox", { name: /model year/i })).toBeEnabled();
+    expect(
+      screen.getByRole("combobox", { name: /vehicle variant/i })
+    ).toBeEnabled();
+    expect(screen.getByRole("combobox", { name: /gate/i })).toBeEnabled();
   });
 });

--- a/src/VehicleSelect/VehicleSelect.tsx
+++ b/src/VehicleSelect/VehicleSelect.tsx
@@ -99,7 +99,7 @@ function VehicleSelect({
       </Box>
       <Box flex="40%">
         <Autocomplete
-          disabled={selectedProject === ""}
+          disabled={selectedProject === null || selectedProject === ""}
           label="Model Year"
           required
           multiple={false}
@@ -122,7 +122,7 @@ function VehicleSelect({
       <Box flex="40%">
         <Autocomplete
           disableCloseOnSelect={true}
-          disabled={selectedModelYear === ""}
+          disabled={selectedModelYear === null || selectedModelYear === ""}
           label="Vehicle Variant"
           required
           multiple={true}
@@ -179,7 +179,7 @@ function VehicleSelect({
       <Box flex="40%">
         <Autocomplete
           disableCloseOnSelect={true}
-          disabled={selectedVariants.length === 0}
+          disabled={selectedVariants === null || selectedVariants.length === 0}
           required
           multiple={true}
           label="Gate"


### PR DESCRIPTION
Contributes to [TD-2065](https://sce.myjetbrains.com/youtrack/issue/TD-2065/Create-AddVehicle-component)

## Changes

When making use of the recently released VehicleSelect component in DATA https://github.com/IPG-Automotive-UK/virto/pull/111 it was spotted that on first render in DATA the model year and variant fields were not disabled. Gate was correctly disabled but those two were not. The logic should be that all subsequent fields are disabled until the prior field is disabled, e.g. model year is disabled until a valid project has been selected etc. The issue was the fact that the component was dealing with empty value.

This was not being dealt with:
```
value = [];
```

But this was being dealt with:
```
value = {
        _id: "",
        gate: "",
        modelYear: "",
        projectCode: "",
        variant: ""
      }
```

The default for value is actually an empty array `value: []`. We didn't spot this because the default prop value in the story was an empty object not and empty array. We also didn't have any tests to check the logic for disabling the fields. I've fixed the issue and have improved the test coverage to check for all posibilities.

## Testing notes

The new tests I have added should provide full coverage for this case and all other variants of value. You could also manually check by opening storybook and checking the default story for VehicleSelect now correctly only shows project code field enabled and all others disabled. I updated the default story to correctly show with value as empty array.
`npm run storybook`

## Author checklist before assigning a reviewer

- [ ] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [ ] PR assigned to me or an appropriate delegate.
- [ ] Relevant labels added to the PR.
- [ ] Appropriate tests have been added.
- [ ] Lint and test workflows pass.
