### PR TITLE
Added errorMessage prop in vehicleSelectDialog

### DIFF
--- a/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.stories.tsx
@@ -49,6 +49,7 @@ const Template: StoryFn<CombinedVehicleProps> = args => {
 export const Default = {
   args: {
     cancelText: "cancel",
+    errorMessage: "New error message",
     flexDirection: "column",
     flexWrap: "nowrap",
     gates: ["Gate 1", "Gate 2", "Gate 3"],

--- a/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.test.tsx
@@ -95,4 +95,18 @@ describe("VehicleSelectDialog", () => {
       ]);
     }
   });
+
+  it("displays the error message in an Alert component", () => {
+    // render the component with the error message
+    const { getByText } = render(
+      <VehicleSelectDialog
+        {...defaultProps}
+        errorMessage="This is an error message"
+      />
+    );
+
+    // check if the error message is displayed within the Alert component
+    const errorMessageElement = getByText("This is an error message");
+    expect(errorMessageElement).toBeInTheDocument();
+  });
 });

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -110,7 +110,7 @@ const VehicleSelectDialog = ({
           </Box>
         ) : null}
       </DialogContent>
-      <DialogActions sx={{ px: 3, py: 2 }}>
+      <DialogActions sx={{ pb: 3, pt: 2, px: 3 }}>
         <Button onClick={onCancelClick}>{cancelText}</Button>
         <Button
           variant="contained"

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -1,13 +1,13 @@
 import {
   Alert,
+  Box,
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Divider,
-  IconButton,
-  Stack
+  IconButton
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
 
@@ -94,23 +94,22 @@ const VehicleSelectDialog = ({
       </DialogTitle>
       <Divider />
       <DialogContent sx={{ pt: 1 }}>
-        <Stack spacing={3}>
-          <VehicleSelect
-            variants={variants}
-            value={value}
-            flexDirection={flexDirection}
-            flexWrap={flexWrap}
-            gates={gates}
-            onChange={setValue}
-          />
-          {errorMessage ? (
+        <VehicleSelect
+          variants={variants}
+          value={value}
+          flexDirection={flexDirection}
+          flexWrap={flexWrap}
+          gates={gates}
+          onChange={setValue}
+        />
+        {errorMessage ? (
+          <Box display={"flex"} mt={2}>
             <Alert variant="filled" severity="error">
               {errorMessage}
             </Alert>
-          ) : null}
-        </Stack>
+          </Box>
+        ) : null}
       </DialogContent>
-
       <DialogActions sx={{ px: 3, py: 2 }}>
         <Button onClick={onCancelClick}>{cancelText}</Button>
         <Button

--- a/src/VehicleSelectDialog/VehicleSelectDialog.tsx
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.tsx
@@ -1,9 +1,11 @@
 import {
+  Alert,
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   IconButton,
   Stack
 } from "@mui/material";
@@ -17,6 +19,7 @@ import VehicleSelect from "src/VehicleSelect/VehicleSelect";
 const VehicleSelectDialog = ({
   onCancelClick = () => {},
   onSaveClick = () => {},
+  errorMessage,
   title = "Some title",
   cancelText = "cancel",
   saveText = "Save",
@@ -68,13 +71,10 @@ const VehicleSelectDialog = ({
             maxWidth: width,
             width: "100%"
           }
-        },
-        "& .MuiDialogActions-root": {
-          p: [2, 3]
         }
       }}
     >
-      <DialogTitle fontWeight={600}>
+      <DialogTitle fontWeight={600} sx={{ px: 2 }}>
         {title}
         {showCloseIcon ? (
           <IconButton
@@ -92,7 +92,8 @@ const VehicleSelectDialog = ({
           </IconButton>
         ) : null}
       </DialogTitle>
-      <DialogContent>
+      <Divider />
+      <DialogContent sx={{ pt: 1 }}>
         <Stack spacing={3}>
           <VehicleSelect
             variants={variants}
@@ -102,9 +103,15 @@ const VehicleSelectDialog = ({
             gates={gates}
             onChange={setValue}
           />
+          {errorMessage ? (
+            <Alert variant="filled" severity="error">
+              {errorMessage}
+            </Alert>
+          ) : null}
         </Stack>
       </DialogContent>
-      <DialogActions>
+
+      <DialogActions sx={{ px: 3, py: 2 }}>
         <Button onClick={onCancelClick}>{cancelText}</Button>
         <Button
           variant="contained"

--- a/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
+++ b/src/VehicleSelectDialog/VehicleSelectDialog.types.ts
@@ -9,6 +9,10 @@ export interface VehicleSelectDialogProps {
    */
   cancelText?: string;
   /**
+   * Error message to display in the dialog.
+   */
+  errorMessage?: string;
+  /**
    * Callback fired when cancel button clicked.
    */
   onCancelClick: React.MouseEventHandler<HTMLButtonElement>;


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Contributes to [TD-2069](https://sce.myjetbrains.com/youtrack/issue/TD-2069/Create-add-vehicle-dialog)
Figma:https://www.figma.com/proto/B75H0DFTEiUFjJtehIKa8M/VIRTO.MODEL?type=design&node-id=348-41199&scaling=min-zoom&page-id=0%3A1&starting-point-node-id=228%3A28915&show-proto-sidebar=1

Note: Adding errorMessage functionality inside vehicleSelectDialog(which I missed to add previously)

## Changes
- Added error message prop based on that alert is shown.

## UI/UX
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/49191249/e9029f4b-fb52-4584-a780-f371d3f87c2c)

## Author checklist before assigning a reviewer

- [ ] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [ ] PR assigned to me or an appropriate delegate.
- [ ] Relevant labels added to the PR.
- [ ] Appropriate tests have been added.
- [ ] Lint and test workflows pass.
