### PR TITLE
DeletableList delete icon button can only delete the list item

### DIFF
--- a/src/DeletableList/DeletableList.test.tsx
+++ b/src/DeletableList/DeletableList.test.tsx
@@ -1,6 +1,7 @@
+import { fireEvent, render } from "@testing-library/react";
+
 import DeletableList from ".";
 import React from "react";
-import { render } from "@testing-library/react";
 
 // tests for the DeletableList component
 describe("DeletableList", () => {
@@ -20,11 +21,17 @@ describe("DeletableList", () => {
   // test that checks the delete button click called with the deleted item
   test("test list delete works", () => {
     const onDelete = jest.fn();
-    const { container } = render(
+    const { queryAllByTestId } = render(
       <DeletableList items={["Apple", "Mango", "Banana"]} onDelete={onDelete} />
     );
-    const deleteButton = container.querySelector("button");
-    deleteButton && deleteButton.click();
+
+    // find the IconButton by its data-testid attribute
+    const deleteButtons = queryAllByTestId("close");
+
+    // trigger a click event on the IconButton
+    fireEvent.click(deleteButtons[0]);
+
+    // check if onDelete was called with the expected argument
     expect(onDelete).toHaveBeenCalledWith("Apple");
   });
 });

--- a/src/DeletableList/DeletableList.tsx
+++ b/src/DeletableList/DeletableList.tsx
@@ -18,9 +18,8 @@ const DeletableList = ({
             data-testid="deletableList"
             key={value}
             role="listitem2"
-            onClick={() => onDelete(value)}
             secondaryAction={
-              <IconButton edge="end">
+              <IconButton edge="end" onClick={() => onDelete(value)}>
                 <CloseIcon data-testid="close" />
               </IconButton>
             }

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 
 import React from "react";
 import TransferList from ".";
@@ -93,22 +93,37 @@ describe("TransferList", () => {
     expect(onChange).toHaveBeenCalledWith(["Pears"]);
   });
 
-  test("Can remove a list item selection", async () => {
+  it("Can remove a list item selection", async () => {
     // render component
     const user = userEvent.setup();
     const onChange = jest.fn();
-    const { container } = render(
-      <SelectedItemsWithState onChange={onChange} />
+    render(
+      <SelectedItemsWithState
+        onChange={onChange}
+        items={["Apples", "Pears", "Oranges"]}
+        selectedItem={[]}
+      />
     );
 
-    // remove selected item
-    const listItem = screen.getByRole("listitem2");
-    await user.click(listItem);
+    // select item
+    const list = screen.getByRole("list");
+    const { getAllByRole } = within(list);
+    const items = getAllByRole("listitem1");
+    await user.click(items[1]);
 
-    // check selections have been cleared
-    expect(container.querySelector(".MuiTypography-body1")?.textContent).toBe(
-      "None Selected"
-    );
+    // check if the item has been selected
+    expect(onChange).toHaveBeenCalledWith(["Pears"]);
+
+    // find the IconButton by its data-testid attribute
+    const deleteButtons = screen.getAllByTestId("close");
+
+    // trigger a click event on the IconButton
+    fireEvent.click(deleteButtons[0]);
+
+    // check if the onChange function was called with an empty array (selection removed)
     expect(onChange).toHaveBeenCalledWith([]);
+
+    // check if the "None Selected" text is displayed
+    expect(screen.getByTestId("none-selected")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-2176](https://sce.myjetbrains.com/youtrack/issue/TD-2176/DeletableList-click-to-delete)

## Changes
- Added onDelete callback to fire  when the user clicks on the Delete("X") button
- Fixed tests for the DeletableList component to delete items only when the list item ("X") button clicked
- As the DeletableList component is used inside TransferList. Fixed tests for the TransferList component to delete items only when the list item ("X") button clicked

## UI/UX
![DeletableList](https://github.com/IPG-Automotive-UK/react-ui/assets/49191249/e78dfaf4-369f-4ffa-93f5-5d185334404d)

## Testing notes
- Now  onDelete Callback should be fired only when the list item ("X") button clicked

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
