### PR TITLE
TD-2097 New status icon and label for "No Metrics"

### DIFF
--- a/src/Status/StatusIcon/StatusIcon.stories.tsx
+++ b/src/Status/StatusIcon/StatusIcon.stories.tsx
@@ -27,6 +27,5 @@ export const Default = {
     status: statusTypes[0],
     width: 40
   },
-
   render: Template
 };

--- a/src/Status/StatusIcon/StatusIcon.types.ts
+++ b/src/Status/StatusIcon/StatusIcon.types.ts
@@ -14,13 +14,14 @@ export type StatusIconProps = {
    * The status type.
    */
   status:
-    | "passed"
-    | "not-run"
-    | "pending"
     | "cancelled"
     | "completed"
     | "failed"
+    | "no-metrics"
     | "not-ready"
+    | "not-run"
+    | "passed"
+    | "pending"
     | "ready"
     | "running"
     | "submitted";

--- a/src/Status/StatusLabel/StatusLabel.stories.tsx
+++ b/src/Status/StatusLabel/StatusLabel.stories.tsx
@@ -30,6 +30,5 @@ export const Default = {
     status: statusTypes[0],
     variant: "body2"
   },
-
   render: Template
 };

--- a/src/Status/StatusLabel/StatusLabel.types.ts
+++ b/src/Status/StatusLabel/StatusLabel.types.ts
@@ -1,21 +1,12 @@
 import { CSSProperties } from "react";
+import type { StatusIconProps } from "../StatusIcon";
 
 export type StatusLabelProps = {
   /**
    *
    * The status type.
    */
-  status:
-    | "passed"
-    | "not-run"
-    | "pending"
-    | "cancelled"
-    | "completed"
-    | "failed"
-    | "not-ready"
-    | "ready"
-    | "running"
-    | "submitted";
+  status: StatusIconProps["status"];
   /**
    * The Variant type.
    */

--- a/src/Status/statuses.ts
+++ b/src/Status/statuses.ts
@@ -4,6 +4,7 @@ import {
   Cancel,
   ChangeCircle,
   CheckCircle,
+  Error,
   Task,
   Timelapse,
   Warning
@@ -39,6 +40,15 @@ const statuses = {
     },
     label: {
       text: "Failed"
+    }
+  },
+  "no-metrics": {
+    icon: {
+      color: grey[400],
+      type: Error
+    },
+    label: {
+      text: "No Metrics"
     }
   },
   "not-ready": {
@@ -108,6 +118,6 @@ const statuses = {
 
 export default statuses;
 
-export const statusTypes = Object.keys(statuses) as Array<
+export const statusTypes = Object.keys(statuses).sort() as Array<
   keyof typeof statuses
 >;


### PR DESCRIPTION
Contributes to [TD-2097](TD-2097)

## Changes

Added a new status icon and label to support the case of "No Metrics" as per recently modified [Figma design](https://www.figma.com/proto/1PlPUZAHb4H74zmDZEceTy/VIRTO.RESULT?type=design&node-id=870-67181&t=4tc7qWoF9rHHOrQL-0&scaling=scale-down&page-id=870%3A56163&starting-point-node-id=870%3A67269) for RESULT.

Also tidied up the types for StatusIcon and StatusLabel so they can both reference the same list of status options.

Also updated so that the status dropdown options in Storybook are alphabetical.

## Dependencies

N/A

## UI/UX

StatusIcon
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/7e621e66-c8af-42b9-a283-c368cd043660)

![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/3b59de8c-730c-4f63-b79d-08f2781badf6)

StatusLabel
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/a5853a23-26da-43b0-a5b6-4f3c51f39ce8)

![image](https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/04e8b5a6-36ee-4423-8255-e212cede17ee)


## Testing notes

* `npm run storybook` and check StatusIcon and StatusLabel components include the new option for no-metrics.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker. - N/A
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Appropriate tests have been added. - Existing test case already dynamic to cover the additional case.
- [x] Lint and test workflows pass.
