### PR TITLE
TD-2221 New status "No Metrics" for Card Status

### DIFF
--- a/src/Status/StatusCard/StatusCard.test.tsx
+++ b/src/Status/StatusCard/StatusCard.test.tsx
@@ -22,7 +22,7 @@ describe("StatusCard", () => {
     expect(nameElement).toBeInTheDocument();
   });
 
-  test.each(["passed", "failed", "not-run", "pending"] as const)(
+  test.each(["passed", "failed", "not-run", "pending", "no-metrics"] as const)(
     "renders correct icon for %s",
     status => {
       // render component

--- a/src/Status/StatusCard/StatusCard.types.ts
+++ b/src/Status/StatusCard/StatusCard.types.ts
@@ -2,7 +2,7 @@ export type StatusCardProps = {
   /**
    * The status type.
    */
-  status: "passed" | "failed" | "pending" | "not-run";
+  status: "passed" | "failed" | "pending" | "not-run" | "no-metrics";
   /**
    * The status message.
    */


### PR DESCRIPTION
Contributes to [TD-2221](https://sce.myjetbrains.com/youtrack/issue/TD-2221/Different-definition-of-Result-in-VIRTO.RESULT-and-Quality-in-VIRTO.FLEET)

## Changes

Implemented the `no-metrics` status for the StatusCard component. This modification is essential for obtaining the `No Metrics` status in FLEET, ensuring consistency with the statuses in RESULT.

## Dependencies

N/A

## UI/UX

Light mode:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/89025096/9f5f24bb-1b45-409b-a16b-cd5c2ab45b4d)

Dark mode:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/89025096/30325f04-ad1b-4e1f-a7c3-272fd88f59c2)

## Testing notes

* `npm run storybook` and check StatusCard component includes the new option for no-metrics.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
