### PR TITLE
Bug Fix - useColorMap incorrect typedef

### DIFF
--- a/src/UserAvatar/index.d.ts
+++ b/src/UserAvatar/index.d.ts
@@ -6,8 +6,6 @@ export type UserAvatarProps = {
 
 declare const UserAvatar: React.FC<UserAvatarProps>;
 
-declare const useColorMap: (names: string[]) => {
-  getColor: (name: string) => string;
-};
+declare const useColorMap: (names: string[]) => (name: string) => string;
 
 export { UserAvatar, useColorMap };


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Contributes to [TD-2030](https://sce.myjetbrains.com/youtrack/issue/TD-2030)

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

Changed the typedef for useColorMap.

- The error `TS2349: This expression is not callable` occurred because the function was expected to return directly a callable function but was returning an object with a getColor method.
- Changing the return type of `useColorMap` from an object with a getColor method to a directly callable function resolved this error.

![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/7529117d-4775-4597-8b0b-20c0cd1cdf79)

## Testing notes

- Before the change, to get a color, you had to call `useColorMap(names).getColor(name)`.
- After the change, you can simply call `useColorMap(names)(name)`.

    
## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Appropriate tests have been added.
- [x] Lint and test workflows pass.
