### PR TITLE
TD-2238 Changed exponent format to scientific notation for Line and surface Plots.

### DIFF
--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -78,7 +78,7 @@ const LinePlot = ({
             autosize: true,
             margin: {
               b: 35,
-              l: 60,
+              l: 80,
               r: 10,
               t: 30
             },

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -86,6 +86,7 @@ const LinePlot = ({
             plot_bgcolor: "rgba(0,0,0,0)",
             xaxis: {
               color: theme.palette.mode === "light" ? "" : "white",
+              exponentformat: "E",
               gridcolor:
                 theme.palette.mode === "light" ? "" : theme.palette.grey["500"],
               showgrid: false,
@@ -99,6 +100,7 @@ const LinePlot = ({
             },
             yaxis: {
               color: theme.palette.mode === "light" ? "" : "white",
+              exponentformat: "E",
               gridcolor:
                 theme.palette.mode === "light" ? "" : theme.palette.grey["500"],
               ticksuffix: " ",

--- a/src/SurfacePlot/SurfacePlot.tsx
+++ b/src/SurfacePlot/SurfacePlot.tsx
@@ -88,6 +88,7 @@ const SurfacePlot = ({
               camera: { eye: { x: 2 } },
               xaxis: {
                 color: theme.palette.mode === "light" ? "" : "white",
+                exponentformat: "E",
                 gridcolor:
                   theme.palette.mode === "light"
                     ? ""
@@ -103,6 +104,7 @@ const SurfacePlot = ({
               },
               yaxis: {
                 color: theme.palette.mode === "light" ? "" : "white",
+                exponentformat: "E",
                 gridcolor:
                   theme.palette.mode === "light"
                     ? ""
@@ -117,6 +119,7 @@ const SurfacePlot = ({
               },
               zaxis: {
                 color: theme.palette.mode === "light" ? "" : "white",
+                exponentformat: "E",
                 gridcolor:
                   theme.palette.mode === "light"
                     ? ""


### PR DESCRIPTION
Closes [TD-2238](https://sce.myjetbrains.com/youtrack/agiles/115-26/current?issue=TD-2238)

This PR changes the exponent label on x and y axis for Line and surface plots. Previously, Plotly would apply a prefix to the label to indicate the order of magnitude of the axis for either very large or very small numbers. This is not very informative for the us
er, thus it was decided to change it to exponents.

#
# Changes
- Adds option to Line Plot and Surface plot components to display exponent in scientific notation. 

## UI/UX
Currently, Plotly will scale the axis with a prefix indicating the order of magnitude. Here it uses "mu", which indicates and order of magnitude of 10^-6
![Screenshot 2023-10-30 134025](https://github.com/IPG-Automotive-UK/react-ui/assets/91531258/88c1e63c-6b9a-40b2-a988-8347e581ccf1)

Now it will instead use exponents in the axis scaling: 
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/91531258/94340dd3-7373-406f-969c-c35ce2a06dcd)

## Testing notes
This PR can be tested by using storybook to verify that the axis labels behave as intended. For the line plot, set the xdata or ydata value to something small:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/91531258/41be11da-f6a2-4ae6-bfff-be86db7ffee8)

Check that the line plot renders with exponents on the axis label:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/91531258/f797b9ce-4627-4fac-af0c-14269f466d6d)

The same can also be checked for the surface plot component:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/91531258/e8988b21-57c0-4a3e-aa8c-b1cad823d025)

If the reviewer would like to test the component in result manager, this branch of react-ui can be temporarily installed by the following commands:
```
npm i "https://github.com/IPG-Automotive-UK/react-ui.git#bugfix/TD-2238-Units-Appear-Wrong-In-Some-Post-Processed-Channels" --save -f
```
Then rebuild the virto-result container:
```
npm run docker
```
## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Appropriate tests have been added.
- [x] Lint and test workflows pass.
