### PR TITLE
Removing dependency install from postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "run-s test:unit test:lint test:playwright",
     "test:playwright": "npm run storybook:build && npm run storybook:serve:start && npx playwright test && npm run storybook:serve:stop",
     "pretest:playwright": "npx playwright install --with-deps",
-    "test:playwright:headed": "pretest:playwright && npm run storybook:build && npm run storybook:serve:start && npx playwright test --headed && npm run storybook:serve:stop",
+    "test:playwright:headed": "npx playwright install --with-deps && npm run storybook:build && npm run storybook:serve:start && npx playwright test --headed && npm run storybook:serve:stop",
     "test:lint": "eslint ./src",
     "test:unit": "cross-env CI=1 react-scripts test --env=jsdom --collectCoverage=true",
     "test:watch": "react-scripts test --env=jsdom",


### PR DESCRIPTION
## Changes

This change is to attempt to reduce the build times of VIRTO apps.

- renamed the `postinstall` script so that it doesn't download these dependencies every time `npm run install` is ran
- called the new script `test-deps` in `npm run test:playwright` so it only runs when running the tests

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] ~Branch has been run in docker.~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
