### PR TITLE
TD-1300 Label Chip in Detail Card

### DIFF
--- a/src/Card/DetailCard/DetailCard.test.tsx
+++ b/src/Card/DetailCard/DetailCard.test.tsx
@@ -5,7 +5,6 @@ import DetailCard from "./DetailCard";
 import FileCard from "../FileCard/FileCard";
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import userEvent from "@testing-library/user-event";
 
 // a set of default inputs so that tests can change what theyre testing
 const defaultInputs = {
@@ -34,7 +33,7 @@ describe("DetailCard", () => {
   });
 
   // test that detail card renders with label that can be clicked
-  it("renders label and can be clicked", async () => {
+  it("renders label and can be clicked", () => {
     const labels = [
       {
         _id: "1",
@@ -55,12 +54,6 @@ describe("DetailCard", () => {
     );
     // expect label to be in the document
     expect(screen.getByText("National Highways")).toBeInTheDocument();
-    // find the nearest button to the label and click it
-    await userEvent.click(
-      screen.getByRole("button", { name: "National Highways" })
-    );
-    // expect the mock function to be called
-    expect(onClickLabel).toHaveBeenCalled();
   });
 
   // test that image is rendered in detail card

--- a/src/Card/DetailCard/DetailCard.tsx
+++ b/src/Card/DetailCard/DetailCard.tsx
@@ -358,7 +358,6 @@ function LableStack({
             <Fragment>
               {labels?.map(label => (
                 <LabelChip
-                  clickable
                   color={label.color}
                   key={label._id}
                   label={label.name}
@@ -371,7 +370,6 @@ function LableStack({
             <Fragment>
               {notOverflowingLabels?.map(label => (
                 <LabelChip
-                  clickable
                   color={label.color}
                   key={label._id}
                   label={label.name}
@@ -417,7 +415,6 @@ function LableStack({
             if (!notOverflowingLabels?.includes(label)) {
               return (
                 <LabelChip
-                  clickable
                   key={label._id}
                   label={label.name}
                   color={label.color}


### PR DESCRIPTION
contributes to: https://sce.myjetbrains.com/youtrack/issue/TD-1300/Clicking-the-label-chips-does-not-do-anything

raised in PR here:  https://github.com/IPG-Automotive-UK/virto/pull/434#pullrequestreview-1805702144

## Changes

- updated label chip in the detail card to not be clickable. 

## UI/UX

Confirmed with @Sowbhagya-ipg that the label should not be clickable in the detail card : https://github.com/IPG-Automotive-UK/virto/pull/434#issuecomment-1878623486

## Testing notes
 
- check that the label chips are no longer clickable in the detail card component. 

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- ~~[ ] Branch has been run in docker.~~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- ~~[ ] Appropriate tests have been added.~~
- [ ] Lint and test workflows pass.
