### PR TITLE
TD-1555 Replace peerDependencies with dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "5.10.0-0",
+  "version": "5.10.0-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipguk/react-ui",
-      "version": "5.10.0-0",
+      "version": "5.10.0-1",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,33 @@
       "name": "@ipguk/react-ui",
       "version": "5.9.0",
       "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "@mui/icons-material": "^5.14.8",
+        "@mui/x-data-grid": "^6.10.2",
+        "@types/css-mediaquery": "^0.1.2",
+        "@types/plotly.js": "^2.12.26",
+        "@types/react-plotly.js": "^2.6.0",
+        "@types/react-text-mask": "^5.4.11",
+        "colord": "^2.9.3",
+        "material-ui-confirm": "^3.0.9",
+        "material-ui-popup-state": "^5.0.9",
+        "plotly.js": "^2.26.0",
+        "react-colorful": "^5.6.1",
+        "react-dropzone": "^14.2.3",
+        "react-hook-form": "^7.45.2",
+        "react-plotly.js": "^2.6.0",
+        "react-text-mask": "^5.5.0",
+        "use-debouncy": "^4.4.0",
+        "zxcvbn": "^4.4.2"
+      },
       "devDependencies": {
         "@babel/core": "^7.23.7",
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@babel/preset-react": "^7.23.3",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
-        "@juggle/resize-observer": "^3.4.0",
-        "@mui/icons-material": "^5.15.3",
         "@mui/material": "^5.15.3",
-        "@mui/x-data-grid": "^6.18.7",
         "@playwright/test": "^1.40.1",
         "@storybook/addon-actions": "^7.6.7",
         "@storybook/addon-essentials": "^7.6.7",
@@ -43,10 +60,8 @@
         "@types/react-text-mask": "^5.4.14",
         "@typescript-eslint/eslint-plugin": "^6.17.0",
         "@typescript-eslint/parser": "^6.17.0",
-        "colord": "^2.9.3",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",
-        "css-mediaquery": "^0.1.2",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-standard": "^17.1.0",
@@ -59,27 +74,19 @@
         "eslint-plugin-standard": "^5.0.0",
         "express": "^4.18.2",
         "forever": "^4.0.3",
-        "material-ui-confirm": "^3.0.9",
-        "material-ui-popup-state": "^5.0.10",
         "microbundle-crl": "^0.13.11",
         "mutationobserver-shim": "^0.3.7",
         "npm-run-all": "^4.1.5",
         "playwright": "^1.40.1",
         "prettier": "^3.1.1",
         "react": "^18.2.0",
-        "react-colorful": "^5.6.1",
         "react-dom": "^18.2.0",
-        "react-dropzone": "^14.2.3",
-        "react-hook-form": "^7.49.2",
-        "react-text-mask": "^5.5.0",
         "rimraf": "^5.0.5",
         "storybook": "^7.6.7",
         "storybook-dark-mode": "^3.0.3",
         "ts-jest": "^29.1.1",
         "typescript": "^5.3.3",
-        "use-debouncy": "^5.0.1",
-        "webpack": "^5.89.0",
-        "zxcvbn": "^4.4.2"
+        "webpack": "^5.89.0"
       },
       "engines": {
         "node": ">=10"
@@ -87,78 +94,9 @@
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@juggle/resize-observer": "^3.4.0",
-        "@mui/icons-material": "^5.14.8",
         "@mui/material": "^5.14.8",
-        "@mui/x-data-grid": "^6.10.2",
-        "@types/css-mediaquery": "^0.1.2",
-        "@types/plotly.js": "^2.12.26",
-        "@types/react-plotly.js": "^2.6.0",
-        "@types/react-text-mask": "^5.4.11",
-        "colord": "^2.9.3",
-        "css-mediaquery": "^0.1.2",
-        "material-ui-confirm": "^3.0.9",
-        "material-ui-popup-state": "^5.0.9",
-        "plotly.js": "^2.26.0",
         "react": "^18.2.0",
-        "react-colorful": "^5.6.1",
-        "react-dom": "^18.2.0",
-        "react-dropzone": "^14.2.3",
-        "react-hook-form": "^7.45.2",
-        "react-plotly.js": "^2.6.0",
-        "react-text-mask": "^5.5.0",
-        "use-debouncy": "^4.4.0",
-        "zxcvbn": "^4.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@juggle/resize-observer": {
-          "optional": true
-        },
-        "@mui/x-data-grid": {
-          "optional": true
-        },
-        "@types/css-mediaquery": {
-          "optional": true
-        },
-        "@types/plotly.js": {
-          "optional": true
-        },
-        "@types/react-plotly.js": {
-          "optional": true
-        },
-        "@types/react-text-mask": {
-          "optional": true
-        },
-        "colord": {
-          "optional": true
-        },
-        "css-mediaquery": {
-          "optional": true
-        },
-        "material-ui-confirm": {
-          "optional": true
-        },
-        "material-ui-popup-state": {
-          "optional": true
-        },
-        "react-colorful": {
-          "optional": true
-        },
-        "react-dropzone": {
-          "optional": true
-        },
-        "react-hook-form": {
-          "optional": true
-        },
-        "react-text-mask": {
-          "optional": true
-        },
-        "use-debouncy": {
-          "optional": true
-        },
-        "zxcvbn": {
-          "optional": true
-        }
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -204,7 +142,7 @@
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
       "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
@@ -447,7 +385,7 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
       "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/types": "^7.22.15"
       },
@@ -569,7 +507,7 @@
       "version": "7.23.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
       "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -578,7 +516,7 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -624,7 +562,7 @@
       "version": "7.23.4",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
       "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -2377,7 +2315,6 @@
       "version": "7.23.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
       "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2388,8 +2325,7 @@
     "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
@@ -2430,7 +2366,7 @@
       "version": "7.23.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
       "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -2456,7 +2392,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
       "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
-      "peer": true,
       "dependencies": {
         "commander": "^2.15.1"
       },
@@ -2519,7 +2454,7 @@
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
       "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -2538,7 +2473,6 @@
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
       "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
-      "dev": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1",
         "@emotion/sheet": "^1.2.2",
@@ -2551,13 +2485,13 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
       "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -2565,14 +2499,13 @@
     "node_modules/@emotion/memoize": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
-      "dev": true
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/react": {
       "version": "11.11.3",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.3.tgz",
       "integrity": "sha512-Cnn0kuq4DoONOMcnoVsTOR8E+AdnKFf//6kUWc4LCdnxj31pZWn7rIULd6Y7/Js1PiPHzn7SKCM9vB/jBni8eA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -2596,7 +2529,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz",
       "integrity": "sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@emotion/hash": "^0.9.1",
         "@emotion/memoize": "^0.8.1",
@@ -2608,14 +2541,13 @@
     "node_modules/@emotion/sheet": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==",
-      "dev": true
+      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
     },
     "node_modules/@emotion/styled": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
       "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -2638,13 +2570,13 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
       "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -2652,14 +2584,12 @@
     "node_modules/@emotion/utils": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==",
-      "dev": true
+      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
-      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==",
-      "dev": true
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
@@ -3111,7 +3041,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
       "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
-      "dev": true,
       "dependencies": {
         "@floating-ui/utils": "^0.1.1"
       }
@@ -3120,7 +3049,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
       "integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
-      "dev": true,
       "dependencies": {
         "@floating-ui/core": "^1.4.1",
         "@floating-ui/utils": "^0.1.1"
@@ -3130,7 +3058,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.4.tgz",
       "integrity": "sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==",
-      "dev": true,
       "dependencies": {
         "@floating-ui/dom": "^1.5.1"
       },
@@ -3142,8 +3069,7 @@
     "node_modules/@floating-ui/utils": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
-      "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==",
-      "dev": true
+      "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
@@ -4106,8 +4032,7 @@
     "node_modules/@juggle/resize-observer": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
-      "dev": true
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -4119,7 +4044,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
       "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
-      "peer": true,
       "dependencies": {
         "get-stream": "^6.0.1",
         "minimist": "^1.2.6"
@@ -4131,14 +4055,12 @@
     "node_modules/@mapbox/geojson-types": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
-      "peer": true
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4147,7 +4069,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
       "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-      "peer": true,
       "peerDependencies": {
         "mapbox-gl": ">=0.32.1 <2.0.0"
       }
@@ -4155,26 +4076,22 @@
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
-      "peer": true
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
-      "peer": true
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
-      "peer": true
+      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
     },
     "node_modules/@mapbox/vector-tile": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
-      "peer": true,
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
       }
@@ -4183,7 +4100,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4209,7 +4125,6 @@
       "version": "5.0.0-beta.30",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.30.tgz",
       "integrity": "sha512-dc38W4W3K42atE9nSaOeoJ7/x9wGIfawdwC/UmMxMLlZ1iSsITQ8dQJaTATCbn98YvYPINK/EH541YA5enQIPQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.23.6",
         "@floating-ui/react-dom": "^2.0.4",
@@ -4241,7 +4156,6 @@
       "version": "5.15.3",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.3.tgz",
       "integrity": "sha512-sWeihiVyxdJjpLkp8SHkTy9kt2M/o11M60G1MzwljGL2BXdM3Ktzqv5QaQHdi00y7Y1ulvtI3GOSxP2xU8mQJw==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -4251,7 +4165,6 @@
       "version": "5.15.3",
       "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.3.tgz",
       "integrity": "sha512-7LEs8AnO2Se/XYH+CcJndRsGAE+M8KAExiiQHf0V11poqmPVGcbbY82Ry2IUYf9+rOilCVnWI18ErghZ625BPQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.23.6"
       },
@@ -4277,7 +4190,6 @@
       "version": "5.15.3",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.3.tgz",
       "integrity": "sha512-DODBBMouyq1B5f3YkEWL9vO8pGCxuEGqtfpltF6peMJzz/78tJFyLQsDas9MNLC/8AdFu2BQdkK7wox5UBPTAA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.23.6",
         "@mui/base": "5.0.0-beta.30",
@@ -4322,7 +4234,6 @@
       "version": "5.15.3",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.3.tgz",
       "integrity": "sha512-Q79MhVMmywC1l5bMsMZq5PsIudr1MNPJnx9/EqdMP0vpz5iNvFpnLmxsD7d8/hqTWgFAljI+LH3jX8MxlZH9Gw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.23.6",
         "@mui/utils": "^5.15.3",
@@ -4349,7 +4260,6 @@
       "version": "5.15.3",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.3.tgz",
       "integrity": "sha512-+d5XZCTeemOO/vBfWGEeHgTm8fjU1Psdgm+xAw+uegycO2EnoA/EfGSaG5UwZ6g3b66y48Mkxi35AggShMr88w==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.23.6",
         "@emotion/cache": "^11.11.0",
@@ -4381,7 +4291,6 @@
       "version": "5.15.3",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.3.tgz",
       "integrity": "sha512-ewVU4eRgo4VfNMGpO61cKlfWmH7l9s6rA8EknRzuMX3DbSLfmtW2WJJg6qPwragvpPIir0Pp/AdWVSDhyNy5Tw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.23.6",
         "@mui/private-theming": "^5.15.3",
@@ -4421,7 +4330,6 @@
       "version": "7.2.12",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.12.tgz",
       "integrity": "sha512-3kaHiNm9khCAo0pVe0RenketDSFoZGAlVZ4zDjB/QNZV0XiCj+sh1zkX0VVhQPgYJDlBEzAag+MHJ1tU3vf0Zw==",
-      "dev": true,
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0"
       },
@@ -4435,7 +4343,6 @@
       "version": "5.15.3",
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.3.tgz",
       "integrity": "sha512-mT3LiSt9tZWCdx1pl7q4Q5tNo6gdZbvJel286ZHGuj6LQQXjWNAh8qiF9d+LogvNUI+D7eLkTnj605d1zoazfg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.23.6",
         "@types/prop-types": "^15.7.11",
@@ -4463,7 +4370,6 @@
       "version": "6.18.7",
       "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-6.18.7.tgz",
       "integrity": "sha512-K1A3pMUPxI4/Mt5A4vrK45fBBQK5rZvBVqRMrB5n8zX++Bj+WLWKvLTtfCmlriUtzuadr/Hl7Z+FDRXUJAx6qg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "@mui/utils": "^5.14.16",
@@ -4577,14 +4483,12 @@
     "node_modules/@plotly/d3": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.1.tgz",
-      "integrity": "sha512-x49ThEu1FRA00kTso4Jdfyf2byaCPLBGmLjAYQz5OzaPyLUhHesX3/Nfv2OHEhynhdy2UB39DLXq6thYe2L2kg==",
-      "peer": true
+      "integrity": "sha512-x49ThEu1FRA00kTso4Jdfyf2byaCPLBGmLjAYQz5OzaPyLUhHesX3/Nfv2OHEhynhdy2UB39DLXq6thYe2L2kg=="
     },
     "node_modules/@plotly/d3-sankey": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
       "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
-      "peer": true,
       "dependencies": {
         "d3-array": "1",
         "d3-collection": "1",
@@ -4595,7 +4499,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
       "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
-      "peer": true,
       "dependencies": {
         "d3-array": "^1.2.1",
         "d3-collection": "^1.0.4",
@@ -4607,7 +4510,6 @@
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
       "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
-      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "binary-search-bounds": "^2.0.4",
@@ -4683,7 +4585,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -8883,7 +8784,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
       "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
-      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.5.0",
         "@turf/meta": "^6.5.0"
@@ -8896,7 +8796,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
       "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
-      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.5.0",
         "@turf/meta": "^6.5.0"
@@ -8909,7 +8808,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
       "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
-      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.5.0",
         "@turf/meta": "^6.5.0"
@@ -8922,7 +8820,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
       "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/turf"
       }
@@ -8931,7 +8828,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
       "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-      "peer": true,
       "dependencies": {
         "@turf/helpers": "^6.5.0"
       },
@@ -9267,14 +9163,13 @@
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/plotly.js": {
       "version": "2.12.26",
       "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-2.12.26.tgz",
-      "integrity": "sha512-vP1iaVL4HHYSbugv49pwtLL6D9CSqOnQLjiRRdRYjVMEDbjIWhMgxc49BJAxSUShupiJHDp35e0WJS9SwIB2WA==",
-      "devOptional": true
+      "integrity": "sha512-vP1iaVL4HHYSbugv49pwtLL6D9CSqOnQLjiRRdRYjVMEDbjIWhMgxc49BJAxSUShupiJHDp35e0WJS9SwIB2WA=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -9291,8 +9186,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -9313,7 +9207,6 @@
       "version": "18.2.47",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
       "integrity": "sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -9352,7 +9245,6 @@
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
       "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -9374,7 +9266,6 @@
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -10482,8 +10373,7 @@
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
-      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
-      "peer": true
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -10641,8 +10531,7 @@
     "node_modules/almost-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
-      "integrity": "sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A==",
-      "peer": true
+      "integrity": "sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A=="
     },
     "node_modules/alphanum-sort": {
       "version": "1.0.2",
@@ -10698,7 +10587,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -10795,8 +10684,7 @@
     "node_modules/array-bounds": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
-      "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ==",
-      "peer": true
+      "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ=="
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
@@ -10814,7 +10702,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10847,7 +10734,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
       "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
-      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.0"
       }
@@ -10855,14 +10741,12 @@
     "node_modules/array-range": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
-      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA==",
-      "peer": true
+      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA=="
     },
     "node_modules/array-rearrange": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
-      "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w==",
-      "peer": true
+      "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -11099,7 +10983,6 @@
     },
     "node_modules/attr-accept": {
       "version": "2.2.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -11357,7 +11240,7 @@
     },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -11658,8 +11541,7 @@
     "node_modules/binary-search-bounds": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
-      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==",
-      "peer": true
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -11674,14 +11556,12 @@
     "node_modules/bit-twiddle": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA==",
-      "peer": true
+      "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA=="
     },
     "node_modules/bitmap-sdf": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.4.tgz",
-      "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg==",
-      "peer": true
+      "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg=="
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -12137,7 +12017,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12204,7 +12084,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
       "integrity": "sha512-onIcjRpz69/Hx5bB5HGbYKUF2uC6QT6Gp+pfpGm3A7mPfcluSLV5v4Zu+oflDUwLdUw0rLIBhUbi0v8hM4FJQQ==",
-      "peer": true,
       "dependencies": {
         "element-size": "^1.1.1"
       }
@@ -12219,7 +12098,7 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -12232,7 +12111,7 @@
     },
     "node_modules/chalk/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -12339,8 +12218,7 @@
     "node_modules/clamp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
-      "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==",
-      "peer": true
+      "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA=="
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
@@ -12359,7 +12237,6 @@
     },
     "node_modules/classnames": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/clean-css": {
@@ -12535,7 +12412,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
       "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12596,14 +12472,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
       "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
-      "peer": true,
       "dependencies": {
         "color-parse": "^1.3.8"
       }
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -12613,7 +12488,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
       "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
-      "peer": true,
       "dependencies": {
         "clamp": "^1.0.1"
       }
@@ -12626,7 +12500,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
       "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
-      "peer": true,
       "dependencies": {
         "clamp": "^1.0.1",
         "color-rgba": "^2.1.1",
@@ -12637,7 +12510,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
       "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
-      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "defined": "^1.0.0",
@@ -12648,7 +12520,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
       "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
-      "peer": true,
       "dependencies": {
         "clamp": "^1.0.1",
         "color-parse": "^1.3.8",
@@ -12659,7 +12530,6 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
       "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
-      "peer": true,
       "dependencies": {
         "hsluv": "^0.0.3",
         "mumath": "^3.3.4"
@@ -12678,8 +12548,7 @@
     "node_modules/colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-      "dev": true
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -13004,7 +12873,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -13117,7 +12986,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -13133,8 +13002,7 @@
     "node_modules/country-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
-      "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA==",
-      "peer": true
+      "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA=="
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -13226,7 +13094,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
       "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
-      "peer": true,
       "dependencies": {
         "css-font-size-keywords": "^1.0.0",
         "css-font-stretch-keywords": "^1.0.1",
@@ -13242,32 +13109,27 @@
     "node_modules/css-font-size-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
-      "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q==",
-      "peer": true
+      "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q=="
     },
     "node_modules/css-font-stretch-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
-      "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg==",
-      "peer": true
+      "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg=="
     },
     "node_modules/css-font-style-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
-      "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg==",
-      "peer": true
+      "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg=="
     },
     "node_modules/css-font-weight-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
-      "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA==",
-      "peer": true
+      "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA=="
     },
     "node_modules/css-global-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
-      "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ==",
-      "peer": true
+      "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ=="
     },
     "node_modules/css-loader": {
       "version": "6.8.1",
@@ -13385,12 +13247,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "node_modules/css-mediaquery": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
       "dev": true
     },
     "node_modules/css-minimizer-webpack-plugin": {
@@ -14253,8 +14109,7 @@
     "node_modules/css-system-font-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
-      "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA==",
-      "peer": true
+      "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA=="
     },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
@@ -14295,8 +14150,7 @@
     "node_modules/csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
-      "peer": true
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "node_modules/cssdb": {
       "version": "7.5.4",
@@ -14604,7 +14458,6 @@
     },
     "node_modules/csstype": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cycle": {
@@ -14620,7 +14473,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "peer": true,
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -14629,20 +14481,17 @@
     "node_modules/d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "peer": true
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
     },
     "node_modules/d3-collection": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
-      "peer": true
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -14650,14 +14499,12 @@
     "node_modules/d3-dispatch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
-      "peer": true
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
     },
     "node_modules/d3-force": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
       "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
-      "peer": true,
       "dependencies": {
         "d3-collection": "1",
         "d3-dispatch": "1",
@@ -14668,14 +14515,12 @@
     "node_modules/d3-format": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
-      "peer": true
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "node_modules/d3-geo": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
       "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
-      "peer": true,
       "dependencies": {
         "d3-array": "1"
       }
@@ -14684,7 +14529,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
       "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
-      "peer": true,
       "dependencies": {
         "commander": "2",
         "d3-array": "1",
@@ -14702,14 +14546,12 @@
     "node_modules/d3-hierarchy": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
-      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==",
-      "peer": true
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -14720,20 +14562,17 @@
     "node_modules/d3-path": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "peer": true
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
     },
     "node_modules/d3-quadtree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
-      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==",
-      "peer": true
+      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
     },
     "node_modules/d3-shape": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
       "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "peer": true,
       "dependencies": {
         "d3-path": "1"
       }
@@ -14741,14 +14580,12 @@
     "node_modules/d3-time": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
-      "peer": true
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "node_modules/d3-time-format": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
       "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
-      "peer": true,
       "dependencies": {
         "d3-time": "1"
       }
@@ -14756,8 +14593,7 @@
     "node_modules/d3-timer": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
-      "peer": true
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -14984,7 +14820,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
       "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -15078,8 +14913,7 @@
     "node_modules/detect-kerning": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
-      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw==",
-      "peer": true
+      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -15244,7 +15078,6 @@
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
@@ -15375,7 +15208,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
       "integrity": "sha512-P8j3IHxcgRMcY6sDzr0QvJDLzBnJJqpTG33UZ2Pvp8rw0apCHhJCWqYprqrXjrgHnJ6tuhP1iTJSAodPDHxwkg==",
-      "peer": true,
       "dependencies": {
         "abs-svg-path": "~0.1.1",
         "normalize-svg-path": "~0.1.0"
@@ -15385,7 +15217,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
       "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -15393,8 +15224,7 @@
     "node_modules/dup": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
-      "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA==",
-      "peer": true
+      "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA=="
     },
     "node_modules/duplexer": {
       "version": "0.1.1",
@@ -15443,8 +15273,7 @@
     "node_modules/earcut": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "peer": true
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -15480,14 +15309,12 @@
     "node_modules/element-size": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
-      "integrity": "sha512-eaN+GMOq/Q+BIWy0ybsgpcYImjGIdNLyjLFJU4XsLHXYQao5jCNb36GyN6C2qwmDDYSfIBmKpPpr4VnBdLCsPQ==",
-      "peer": true
+      "integrity": "sha512-eaN+GMOq/Q+BIWy0ybsgpcYImjGIdNLyjLFJU4XsLHXYQao5jCNb36GyN6C2qwmDDYSfIBmKpPpr4VnBdLCsPQ=="
     },
     "node_modules/elementary-circuits-directed-graph": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
       "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
-      "peer": true,
       "dependencies": {
         "strongly-connected-components": "^1.0.1"
       }
@@ -15593,7 +15420,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -15754,7 +15581,6 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
       "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -15768,7 +15594,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -15785,7 +15610,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -15795,7 +15619,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -15873,7 +15696,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -17257,7 +17080,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "peer": true,
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -17265,8 +17087,7 @@
     "node_modules/ext/node_modules/type": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
-      "peer": true
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -17410,7 +17231,6 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
       "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
-      "peer": true,
       "dependencies": {
         "acorn": "^7.1.1",
         "isarray": "^2.0.1"
@@ -17460,7 +17280,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
       "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
-      "peer": true,
       "dependencies": {
         "is-string-blank": "^1.0.1"
       }
@@ -17591,7 +17410,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
       "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -17792,7 +17610,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -17863,7 +17681,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
       "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
-      "peer": true,
       "dependencies": {
         "dtype": "^2.0.0"
       }
@@ -17908,7 +17725,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
       "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
-      "peer": true,
       "dependencies": {
         "css-font": "^1.0.0"
       }
@@ -17917,7 +17733,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
       "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
-      "peer": true,
       "dependencies": {
         "css-font": "^1.2.0"
       }
@@ -18610,7 +18425,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -18619,14 +18433,12 @@
     "node_modules/from2/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "peer": true
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/from2/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -18641,7 +18453,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -18799,8 +18610,7 @@
     "node_modules/geojson-vt": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
-      "peer": true
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -18813,8 +18623,7 @@
     "node_modules/get-canvas-context": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
-      "integrity": "sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A==",
-      "peer": true
+      "integrity": "sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A=="
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.1",
@@ -18937,20 +18746,17 @@
     "node_modules/gl-mat4": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
-      "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA==",
-      "peer": true
+      "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
     },
     "node_modules/gl-matrix": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
-      "peer": true
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "node_modules/gl-text": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.3.1.tgz",
       "integrity": "sha512-/f5gcEMiZd+UTBJLTl3D+CkCB/0UFGTx3nflH8ZmyWcLkZhsZ1+Xx5YYkw2rgWAzgPeE35xCqBuHSoMKQVsR+w==",
-      "peer": true,
       "dependencies": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",
@@ -18975,7 +18781,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
       "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
-      "peer": true,
       "dependencies": {
         "is-browser": "^2.0.1",
         "is-firefox": "^1.0.3",
@@ -19116,7 +18921,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
       "integrity": "sha512-W49jIhuDtF6w+7wCMcClk27a2hq8znvHtlGnrYkSWEr8tHe9eA2dcnohlcAmxLYBSpSSdzOkRdyPTrx9fw49+A==",
-      "peer": true,
       "dependencies": {
         "glsl-token-inject-block": "^1.0.0",
         "glsl-token-string": "^1.0.1",
@@ -19127,7 +18931,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
       "integrity": "sha512-xxFNsfnhZTK9NBhzJjSBGX6IOqYpvBHxxmo+4vapiljyGNCY0Bekzn0firQkQrazK59c1hYxMDxYS8MDlhw4gA==",
-      "peer": true,
       "dependencies": {
         "resolve": "^0.6.1",
         "xtend": "^2.1.2"
@@ -19136,14 +18939,12 @@
     "node_modules/glsl-resolve/node_modules/resolve": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
-      "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==",
-      "peer": true
+      "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg=="
     },
     "node_modules/glsl-resolve/node_modules/xtend": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
       "integrity": "sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw==",
-      "peer": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -19151,14 +18952,12 @@
     "node_modules/glsl-token-assignments": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
-      "integrity": "sha512-OwXrxixCyHzzA0U2g4btSNAyB2Dx8XrztY5aVUCjRSh4/D0WoJn8Qdps7Xub3sz6zE73W3szLrmWtQ7QMpeHEQ==",
-      "peer": true
+      "integrity": "sha512-OwXrxixCyHzzA0U2g4btSNAyB2Dx8XrztY5aVUCjRSh4/D0WoJn8Qdps7Xub3sz6zE73W3szLrmWtQ7QMpeHEQ=="
     },
     "node_modules/glsl-token-defines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
       "integrity": "sha512-Vb5QMVeLjmOwvvOJuPNg3vnRlffscq2/qvIuTpMzuO/7s5kT+63iL6Dfo2FYLWbzuiycWpbC0/KV0biqFwHxaQ==",
-      "peer": true,
       "dependencies": {
         "glsl-tokenizer": "^2.0.0"
       }
@@ -19166,14 +18965,12 @@
     "node_modules/glsl-token-depth": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
-      "integrity": "sha512-eQnIBLc7vFf8axF9aoi/xW37LSWd2hCQr/3sZui8aBJnksq9C7zMeUYHVJWMhFzXrBU7fgIqni4EhXVW4/krpg==",
-      "peer": true
+      "integrity": "sha512-eQnIBLc7vFf8axF9aoi/xW37LSWd2hCQr/3sZui8aBJnksq9C7zMeUYHVJWMhFzXrBU7fgIqni4EhXVW4/krpg=="
     },
     "node_modules/glsl-token-descope": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
       "integrity": "sha512-kS2PTWkvi/YOeicVjXGgX5j7+8N7e56srNDEHDTVZ1dcESmbmpmgrnpjPcjxJjMxh56mSXYoFdZqb90gXkGjQw==",
-      "peer": true,
       "dependencies": {
         "glsl-token-assignments": "^2.0.0",
         "glsl-token-depth": "^1.1.0",
@@ -19184,38 +18981,32 @@
     "node_modules/glsl-token-inject-block": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
-      "integrity": "sha512-q/m+ukdUBuHCOtLhSr0uFb/qYQr4/oKrPSdIK2C4TD+qLaJvqM9wfXIF/OOBjuSA3pUoYHurVRNao6LTVVUPWA==",
-      "peer": true
+      "integrity": "sha512-q/m+ukdUBuHCOtLhSr0uFb/qYQr4/oKrPSdIK2C4TD+qLaJvqM9wfXIF/OOBjuSA3pUoYHurVRNao6LTVVUPWA=="
     },
     "node_modules/glsl-token-properties": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
-      "integrity": "sha512-dSeW1cOIzbuUoYH0y+nxzwK9S9O3wsjttkq5ij9ZGw0OS41BirKJzzH48VLm8qLg+au6b0sINxGC0IrGwtQUcA==",
-      "peer": true
+      "integrity": "sha512-dSeW1cOIzbuUoYH0y+nxzwK9S9O3wsjttkq5ij9ZGw0OS41BirKJzzH48VLm8qLg+au6b0sINxGC0IrGwtQUcA=="
     },
     "node_modules/glsl-token-scope": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
-      "integrity": "sha512-YKyOMk1B/tz9BwYUdfDoHvMIYTGtVv2vbDSLh94PT4+f87z21FVdou1KNKgF+nECBTo0fJ20dpm0B1vZB1Q03A==",
-      "peer": true
+      "integrity": "sha512-YKyOMk1B/tz9BwYUdfDoHvMIYTGtVv2vbDSLh94PT4+f87z21FVdou1KNKgF+nECBTo0fJ20dpm0B1vZB1Q03A=="
     },
     "node_modules/glsl-token-string": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
-      "integrity": "sha512-1mtQ47Uxd47wrovl+T6RshKGkRRCYWhnELmkEcUAPALWGTFe2XZpH3r45XAwL2B6v+l0KNsCnoaZCSnhzKEksg==",
-      "peer": true
+      "integrity": "sha512-1mtQ47Uxd47wrovl+T6RshKGkRRCYWhnELmkEcUAPALWGTFe2XZpH3r45XAwL2B6v+l0KNsCnoaZCSnhzKEksg=="
     },
     "node_modules/glsl-token-whitespace-trim": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
-      "integrity": "sha512-ZJtsPut/aDaUdLUNtmBYhaCmhIjpKNg7IgZSfX5wFReMc2vnj8zok+gB/3Quqs0TsBSX/fGnqUUYZDqyuc2xLQ==",
-      "peer": true
+      "integrity": "sha512-ZJtsPut/aDaUdLUNtmBYhaCmhIjpKNg7IgZSfX5wFReMc2vnj8zok+gB/3Quqs0TsBSX/fGnqUUYZDqyuc2xLQ=="
     },
     "node_modules/glsl-tokenizer": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
       "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
-      "peer": true,
       "dependencies": {
         "through2": "^0.6.3"
       }
@@ -19223,14 +19014,12 @@
     "node_modules/glsl-tokenizer/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "peer": true
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/glsl-tokenizer/node_modules/readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -19241,14 +19030,12 @@
     "node_modules/glsl-tokenizer/node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "peer": true
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "node_modules/glsl-tokenizer/node_modules/through2": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-      "peer": true,
       "dependencies": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
@@ -19258,7 +19045,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
       "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
-      "peer": true,
       "dependencies": {
         "bl": "^2.2.1",
         "concat-stream": "^1.5.2",
@@ -19284,7 +19070,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
       "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
-      "peer": true,
       "dependencies": {
         "glsl-inject-defines": "^1.0.1",
         "glsl-token-defines": "^1.0.0",
@@ -19302,7 +19087,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
       "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
-      "peer": true,
       "dependencies": {
         "@choojs/findup": "^0.2.0",
         "events": "^3.2.0",
@@ -19318,7 +19102,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
       "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -19327,14 +19110,12 @@
     "node_modules/glslify/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "peer": true
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/glslify/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -19349,7 +19130,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -19378,8 +19158,7 @@
     "node_modules/grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
-      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
-      "peer": true
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "node_modules/gunzip-maybe": {
       "version": "1.4.2",
@@ -19495,7 +19274,7 @@
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -19505,7 +19284,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
       "integrity": "sha512-0G6w7LnlcpyDzpeGUTuT0CEw05+QlMuGVk1IHNAlHrGJITGodjZu3x8BNDUMfKJSZXNB2ZAclqc1bvrd+uUpfg==",
-      "peer": true,
       "dependencies": {
         "is-browser": "^2.0.1"
       }
@@ -19514,7 +19292,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
       "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
-      "peer": true,
       "dependencies": {
         "is-browser": "^2.0.1"
       }
@@ -19656,7 +19433,7 @@
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
@@ -19664,7 +19441,7 @@
     },
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/hoopy": {
@@ -19738,8 +19515,7 @@
     "node_modules/hsluv": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
-      "integrity": "sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ==",
-      "peer": true
+      "integrity": "sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -20070,7 +19846,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -20085,7 +19861,7 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -20325,7 +20101,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -20383,8 +20159,7 @@
     "node_modules/is-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
-      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ==",
-      "peer": true
+      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ=="
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
@@ -20551,7 +20326,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       },
@@ -20563,7 +20337,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
       "integrity": "sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20624,7 +20397,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
       "integrity": "sha512-YeLzceuwg3K6O0MLM3UyUUjKAlyULetwryFp1mHy1I5PfArK0AEqlfa+MR4gkJjcbuJXoDJCvXbyqZVf5CR2Sg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20649,8 +20421,7 @@
     "node_modules/is-mobile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-4.0.0.tgz",
-      "integrity": "sha512-mlcHZA84t1qLSuWkt2v0I2l61PYdyQDt4aG1mLIXF5FDMm4+haBCxCPYSr/uwqQNRk1MiTizn0ypEuRAOLRAew==",
-      "peer": true
+      "integrity": "sha512-mlcHZA84t1qLSuWkt2v0I2l61PYdyQDt4aG1mLIXF5FDMm4+haBCxCPYSr/uwqQNRk1MiTizn0ypEuRAOLRAew=="
     },
     "node_modules/is-module": {
       "version": "1.0.0",
@@ -20734,7 +20505,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20852,14 +20622,12 @@
     "node_modules/is-string-blank": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
-      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw==",
-      "peer": true
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
     },
     "node_modules/is-svg-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
-      "integrity": "sha512-Lj4vePmqpPR1ZnRctHv8ltSh1OrSxHkhUkd7wi+VQdcdP15/KvQFyk7LhNuM7ZW0EVbJz8kZLVmL9quLrfq4Kg==",
-      "peer": true
+      "integrity": "sha512-Lj4vePmqpPR1ZnRctHv8ltSh1OrSxHkhUkd7wi+VQdcdP15/KvQFyk7LhNuM7ZW0EVbJz8kZLVmL9quLrfq4Kg=="
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -24202,7 +23970,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-schema": {
@@ -24267,8 +24035,7 @@
     "node_modules/kdbush": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
-      "peer": true
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -24396,7 +24163,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/load-json-file": {
@@ -24695,7 +24462,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
       "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
-      "peer": true,
       "dependencies": {
         "once": "~1.3.0"
       }
@@ -24704,7 +24470,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -24736,7 +24501,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
       "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
-      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -24782,7 +24546,6 @@
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/material-ui-confirm/-/material-ui-confirm-3.0.9.tgz",
       "integrity": "sha512-WEAEG9z4MfwojoUyQiAjrjl8378tYbGKfiwOKz3zHaQKyXcHnFktUmV7b+F+G0yVo8kYrEMk9Bw+HxhA/2Enlw==",
-      "dev": true,
       "peerDependencies": {
         "@mui/material": ">= 5.0.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -24793,7 +24556,6 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-5.0.10.tgz",
       "integrity": "sha512-gd0DI8skwCSdth/j/yndoIwNkS2eDusosTe5hyPZ3jbrMzDkbQBs+tBbwapQ9hLfgiVLwICd1mwyerUV9Y5Elw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.20.6",
         "@mui/material": "^5.0.0",
@@ -24808,7 +24570,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
       "integrity": "sha512-9W0yGtkaMAkf74XGYVy4Dqw3YUMnTNB2eeiw9aQbUl4A3KmuCEHTt2DgAB07ENzOYAjsYSAYufkAq0Zd+jU7zA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25363,7 +25124,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
       "integrity": "sha512-vpN0s+zLL2ykyyUDh+fayu9Xkor5v/zRD9jhSqjRS1cJTGS0+oakVZzNm5n19JvvEj0you+MXlYTpNxUDQUjkQ==",
-      "peer": true,
       "dependencies": {
         "mouse-event": "^1.0.0"
       }
@@ -25371,20 +25131,17 @@
     "node_modules/mouse-event": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
-      "integrity": "sha512-ItUxtL2IkeSKSp9cyaX2JLUuKk2uMoxBg4bbOWVd29+CskYJR9BGsUqtXenNzKbnDshvupjUewDIYVrOB6NmGw==",
-      "peer": true
+      "integrity": "sha512-ItUxtL2IkeSKSp9cyaX2JLUuKk2uMoxBg4bbOWVd29+CskYJR9BGsUqtXenNzKbnDshvupjUewDIYVrOB6NmGw=="
     },
     "node_modules/mouse-event-offset": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
-      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w==",
-      "peer": true
+      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w=="
     },
     "node_modules/mouse-wheel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
       "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
-      "peer": true,
       "dependencies": {
         "right-now": "^1.0.0",
         "signum": "^1.0.0",
@@ -25422,7 +25179,6 @@
       "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
       "integrity": "sha512-VAFIOG6rsxoc7q/IaY3jdjmrsuX9f15KlRLYTHmixASBZkZEKC1IFqE2BC5CdhXmK6WLM1Re33z//AGmeRI6FA==",
       "deprecated": "Redundant dependency in your project.",
-      "peer": true,
       "dependencies": {
         "almost-equal": "^1.1.0"
       }
@@ -25430,8 +25186,7 @@
     "node_modules/murmurhash-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
-      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
-      "peer": true
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
     },
     "node_modules/mutationobserver-shim": {
       "version": "0.3.7",
@@ -25581,8 +25336,7 @@
     "node_modules/native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==",
-      "peer": true
+      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -25628,7 +25382,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
       "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-      "peer": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -25645,7 +25398,6 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -25666,8 +25418,7 @@
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "peer": true
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -25820,8 +25571,7 @@
     "node_modules/normalize-svg-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
-      "integrity": "sha512-1/kmYej2iedi5+ROxkRESL/pI02pkg0OBnaR4hJkSIX6+ORzepwbuUXfrdZaPjysTsJInj0Rj5NuX027+dMBvA==",
-      "peer": true
+      "integrity": "sha512-1/kmYej2iedi5+ROxkRESL/pI02pkg0OBnaR4hJkSIX6+ORzepwbuUXfrdZaPjysTsJInj0Rj5NuX027+dMBvA=="
     },
     "node_modules/normalize-url": {
       "version": "3.3.0",
@@ -25969,7 +25719,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
       "integrity": "sha512-Dq3iuiFBkrbmuQjGFFF3zckXNCQoSD37/SdSbgcBailUx6knDvDwb5CympBgcoWHy36sfS12u74MHYkXyHq6bg==",
-      "peer": true,
       "dependencies": {
         "is-finite": "^1.0.1"
       },
@@ -26457,7 +26206,6 @@
     "node_modules/optionator": {
       "version": "0.8.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -26473,7 +26221,6 @@
     "node_modules/optionator/node_modules/levn": {
       "version": "0.3.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -26484,7 +26231,6 @@
     },
     "node_modules/optionator/node_modules/prelude-ls": {
       "version": "1.1.2",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -26492,7 +26238,6 @@
     "node_modules/optionator/node_modules/type-check": {
       "version": "0.3.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
       },
@@ -26711,7 +26456,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -26723,12 +26468,11 @@
     "node_modules/parenthesis": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
-      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==",
-      "peer": true
+      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -26747,7 +26491,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
       "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
-      "peer": true,
       "dependencies": {
         "pick-by-alias": "^1.2.0"
       }
@@ -26755,14 +26498,12 @@
     "node_modules/parse-svg-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
-      "peer": true
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
     },
     "node_modules/parse-unit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
-      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
-      "peer": true
+      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg=="
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -26868,7 +26609,7 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -26893,7 +26634,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "peer": true,
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -26921,14 +26661,12 @@
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pick-by-alias": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
-      "integrity": "sha512-ESj2+eBxhGrcA1azgHs7lARG5+5iLakc/6nlfbpjcLl00HuuUOIuORhYXN4D1HfvMSKuVtFQjAlnwi1JHEeDIw==",
-      "peer": true
+      "integrity": "sha512-ESj2+eBxhGrcA1azgHs7lARG5+5iLakc/6nlfbpjcLl00HuuUOIuORhYXN4D1HfvMSKuVtFQjAlnwi1JHEeDIw=="
     },
     "node_modules/picocolors": {
       "version": "0.2.1",
@@ -27093,7 +26831,6 @@
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.26.0.tgz",
       "integrity": "sha512-FRIi4Tek9SDZRv2y0ONuPjojkAnUFC7mIOgBeBw2qtBHYoPWGbpUqz4nWK8BoRhFYUg53lsrgGQWzntSeeX8IQ==",
-      "peer": true,
       "dependencies": {
         "@plotly/d3": "3.8.1",
         "@plotly/d3-sankey": "0.7.2",
@@ -27160,8 +26897,7 @@
     "node_modules/point-in-polygon": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
-      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
-      "peer": true
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
     },
     "node_modules/polished": {
       "version": "4.2.2",
@@ -27177,8 +26913,7 @@
     "node_modules/polybooljs": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
-      "integrity": "sha512-mKjR5nolISvF+q2BtC1fi/llpxBPTQ3wLWN8+ldzdw2Hocpc8C72ZqnamCM4Z6z+68GVVjkeM01WJegQmZ8MEQ==",
-      "peer": true
+      "integrity": "sha512-mKjR5nolISvF+q2BtC1fi/llpxBPTQ3wLWN8+ldzdw2Hocpc8C72ZqnamCM4Z6z+68GVVjkeM01WJegQmZ8MEQ=="
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
@@ -28714,8 +28449,7 @@
     "node_modules/potpack": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
-      "peer": true
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -28836,7 +28570,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
       "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
-      "peer": true,
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",
@@ -28960,8 +28693,7 @@
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "peer": true
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -29185,13 +28917,11 @@
     "node_modules/quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "peer": true
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "node_modules/raf": {
       "version": "3.4.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "performance-now": "^2.1.0"
       }
@@ -29276,7 +29006,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "dev": true,
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
@@ -29486,7 +29215,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -29499,7 +29227,6 @@
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
       "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
-      "dev": true,
       "dependencies": {
         "attr-accept": "^2.2.2",
         "file-selector": "^0.6.0",
@@ -29552,7 +29279,6 @@
       "version": "7.49.3",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.3.tgz",
       "integrity": "sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==",
-      "dev": true,
       "engines": {
         "node": ">=18",
         "pnpm": "8"
@@ -29567,14 +29293,12 @@
     },
     "node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-plotly.js": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-plotly.js/-/react-plotly.js-2.6.0.tgz",
       "integrity": "sha512-g93xcyhAVCSt9kV1svqG1clAEdL6k3U+jjuSzfTV7owaSU9Go6Ph8bl25J+jKfKvIGAEYpe4qj++WHJuc9IaeA==",
-      "peer": true,
       "dependencies": {
         "prop-types": "^15.8.1"
       },
@@ -32109,7 +31833,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-text-mask/-/react-text-mask-5.5.0.tgz",
       "integrity": "sha512-SLJlJQxa0uonMXsnXRpv5abIepGmHz77ylQcra0GNd7Jtk4Wj2Mtp85uGQHv1avba2uI8ZvRpIEQPpJKsqRGYw==",
-      "dev": true,
       "dependencies": {
         "prop-types": "^15.5.6"
       },
@@ -32119,7 +31842,6 @@
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
@@ -32530,14 +32252,12 @@
       "name": "@plotly/regl",
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
-      "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==",
-      "peer": true
+      "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw=="
     },
     "node_modules/regl-error2d": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
       "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
-      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "color-normalize": "^1.5.0",
@@ -32552,7 +32272,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.2.tgz",
       "integrity": "sha512-nmT7WWS/WxmXAQMkgaMKWXaVmwJ65KCrjbqHGOUjjqQi6shfT96YbBOvelXwO9hG7/hjvbzjtQ2UO0L3e7YaXQ==",
-      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "array-find-index": "^1.0.2",
@@ -32572,7 +32291,6 @@
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.9.tgz",
       "integrity": "sha512-PNrXs+xaCClKpiB2b3HZ2j3qXQXhC5kcTh/Nfgx9rLO0EpEhab0BSQDqAsbdbpdf+pSHSJvbgitB7ulbGeQ+Fg==",
-      "peer": true,
       "dependencies": {
         "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",
@@ -32595,7 +32313,6 @@
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
       "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
-      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "array-range": "^1.0.1",
@@ -32716,7 +32433,6 @@
     },
     "node_modules/reselect": {
       "version": "4.1.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -32759,7 +32475,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "peer": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -32899,8 +32614,7 @@
     "node_modules/right-now": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
-      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
-      "peer": true
+      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg=="
     },
     "node_modules/rimraf": {
       "version": "5.0.5",
@@ -33444,8 +33158,7 @@
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "peer": true
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/sade": {
       "version": "1.8.1",
@@ -33584,7 +33297,6 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -33835,8 +33547,7 @@
     "node_modules/shallow-copy": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-      "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw==",
-      "peer": true
+      "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -33896,8 +33607,7 @@
     "node_modules/signum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
-      "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw==",
-      "peer": true
+      "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -34113,7 +33823,7 @@
     },
     "node_modules/source-map": {
       "version": "0.5.7",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -34366,7 +34076,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
       "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
-      "peer": true,
       "dependencies": {
         "escodegen": "^1.11.1"
       }
@@ -34375,7 +34084,6 @@
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
       "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -34397,7 +34105,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -34407,7 +34114,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -34507,7 +34213,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
       "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
-      "peer": true,
       "dependencies": {
         "debug": "2"
       }
@@ -34516,7 +34221,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -34524,8 +34228,7 @@
     "node_modules/stream-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "peer": true
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/stream-shift": {
       "version": "1.0.1",
@@ -34588,7 +34291,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
       "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
-      "peer": true,
       "dependencies": {
         "parenthesis": "^3.1.5"
       }
@@ -34800,8 +34502,7 @@
     "node_modules/strongly-connected-components": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
-      "integrity": "sha512-i0TFx4wPcO0FwX+4RkLJi1MxmcTv90jNZgxMu9XRnMXMeFUY1VJlIoXpZunPUvUUqbCT1pg5PEkFqqpcaElNaA==",
-      "peer": true
+      "integrity": "sha512-i0TFx4wPcO0FwX+4RkLJi1MxmcTv90jNZgxMu9XRnMXMeFUY1VJlIoXpZunPUvUUqbCT1pg5PEkFqqpcaElNaA=="
     },
     "node_modules/style-inject": {
       "version": "0.3.0",
@@ -34882,8 +34583,7 @@
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "dev": true
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/sucrase": {
       "version": "3.32.0",
@@ -34940,7 +34640,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
       "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
-      "peer": true,
       "dependencies": {
         "kdbush": "^3.0.0"
       }
@@ -34948,12 +34647,11 @@
     "node_modules/superscript-text": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
-      "integrity": "sha512-gwu8l5MtRZ6koO0icVTlmN5pm7Dhh1+Xpe9O4x6ObMAsW+3jPbW14d1DsBq1F4wiI+WOFjXF35pslgec/G8yCQ==",
-      "peer": true
+      "integrity": "sha512-gwu8l5MtRZ6koO0icVTlmN5pm7Dhh1+Xpe9O4x6ObMAsW+3jPbW14d1DsBq1F4wiI+WOFjXF35pslgec/G8yCQ=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -35009,8 +34707,7 @@
     "node_modules/svg-arc-to-cubic-bezier": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
-      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
-      "peer": true
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
     },
     "node_modules/svg-parser": {
       "version": "2.0.4",
@@ -35021,7 +34718,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
       "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
-      "peer": true,
       "dependencies": {
         "abs-svg-path": "^0.1.1",
         "is-svg-path": "^1.0.1",
@@ -35033,7 +34729,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
       "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
-      "peer": true,
       "dependencies": {
         "svg-arc-to-cubic-bezier": "^3.0.0"
       }
@@ -35042,7 +34737,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
       "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
-      "peer": true,
       "dependencies": {
         "bitmap-sdf": "^1.0.0",
         "draw-svg-path": "^1.0.0",
@@ -35689,14 +35383,12 @@
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-      "peer": true
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-      "peer": true
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -35705,7 +35397,7 @@
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -35714,8 +35406,7 @@
     "node_modules/to-float32": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
-      "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg==",
-      "peer": true
+      "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg=="
     },
     "node_modules/to-object-path": {
       "version": "0.3.0",
@@ -35745,7 +35436,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
       "integrity": "sha512-2y3LjBeIZYL19e5gczp14/uRWFDtDUErJPVN3VU9a7SJO+RjGRtYR47aMN2bZgGlxvW4ZcEz2ddUPVHXcMfuXw==",
-      "peer": true,
       "dependencies": {
         "parse-unit": "^1.0.1"
       }
@@ -35870,7 +35560,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
       "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
-      "peer": true,
       "dependencies": {
         "commander": "2"
       },
@@ -36085,8 +35774,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -36112,8 +35800,7 @@
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "peer": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -36232,7 +35919,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
       "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
-      "peer": true,
       "dependencies": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0"
@@ -36573,8 +36259,7 @@
     "node_modules/update-diff": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
-      "integrity": "sha512-rCiBPiHxZwT4+sBhEbChzpO5hYHjm91kScWgdHf4Qeafs6Ba7MBl+d9GlGv72bcTZQO0sLmtQS1pHSWoCLtN/A==",
-      "peer": true
+      "integrity": "sha512-rCiBPiHxZwT4+sBhEbChzpO5hYHjm91kScWgdHf4Qeafs6Ba7MBl+d9GlGv72bcTZQO0sLmtQS1pHSWoCLtN/A=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -36648,10 +36333,9 @@
       }
     },
     "node_modules/use-debouncy": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/use-debouncy/-/use-debouncy-5.0.1.tgz",
-      "integrity": "sha512-Y67Ms+feWonusFVKm/AgajoyHHTmtjpC6lBaNAAK65oe1dB59G3JoQzKedFzb6DCeJm71epHBrTsNTev37YO3g==",
-      "dev": true,
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/use-debouncy/-/use-debouncy-4.6.0.tgz",
+      "integrity": "sha512-5N3n/oQYMuU3QKLXDa9p/xtdPKBcNbGQdLqJJPrkT164IMpHdke5xqoehDZCmgDciy+wJC+iqyE3g8c+k03lGg==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -36842,7 +36526,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
       "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
-      "peer": true,
       "dependencies": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
@@ -36911,14 +36594,12 @@
     "node_modules/weak-map": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
-      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
-      "peer": true
+      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
     },
     "node_modules/webgl-context": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
       "integrity": "sha512-q/fGIivtqTT7PEoF07axFIlHNk/XCPaYpq64btnepopSWvKNFkoORlQYgqDigBIuGA1ExnFd/GnSUnBNEPQY7Q==",
-      "peer": true,
       "dependencies": {
         "get-canvas-context": "^1.0.1"
       }
@@ -37522,7 +37203,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
       "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -37946,7 +37626,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
       "integrity": "sha512-sAjLZkBnsbHkHWVhrsCU5Sa/EVuf9QqgvrN8zyJ2L/F9FR9Oc6CvVK0674+PGAtmmmYQMH98tCUSO4QLQv3/TQ==",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.0"
       }
@@ -38127,7 +37806,7 @@
     },
     "node_modules/yaml": {
       "version": "1.10.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -38192,8 +37871,7 @@
     "node_modules/zxcvbn": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
-      "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==",
-      "dev": true
+      "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "5.9.0",
+  "version": "5.10.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipguk/react-ui",
-      "version": "5.9.0",
+      "version": "5.10.0-0",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@typescript-eslint/parser": "^6.17.0",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",
+        "css-mediaquery": "^0.1.2",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-standard": "^17.1.0",
@@ -13247,6 +13248,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
       "dev": true
     },
     "node_modules/css-minimizer-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "5.10.0-0",
+  "version": "5.10.0-1",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@typescript-eslint/parser": "^6.17.0",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
+    "css-mediaquery": "^0.1.2",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "5.9.0",
+  "version": "5.10.0-0",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,7 @@
     "@babel/preset-react": "^7.23.3",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
-    "@juggle/resize-observer": "^3.4.0",
-    "@mui/icons-material": "^5.15.3",
     "@mui/material": "^5.15.3",
-    "@mui/x-data-grid": "^6.18.7",
     "@playwright/test": "^1.40.1",
     "@storybook/addon-actions": "^7.6.7",
     "@storybook/addon-essentials": "^7.6.7",
@@ -63,10 +60,8 @@
     "@types/react-text-mask": "^5.4.14",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",
-    "colord": "^2.9.3",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
-    "css-mediaquery": "^0.1.2",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",
@@ -79,103 +74,46 @@
     "eslint-plugin-standard": "^5.0.0",
     "express": "^4.18.2",
     "forever": "^4.0.3",
-    "material-ui-confirm": "^3.0.9",
-    "material-ui-popup-state": "^5.0.10",
     "microbundle-crl": "^0.13.11",
     "mutationobserver-shim": "^0.3.7",
     "npm-run-all": "^4.1.5",
     "playwright": "^1.40.1",
     "prettier": "^3.1.1",
     "react": "^18.2.0",
-    "react-colorful": "^5.6.1",
-    "react-dropzone": "^14.2.3",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.49.2",
-    "react-text-mask": "^5.5.0",
     "rimraf": "^5.0.5",
     "storybook": "^7.6.7",
     "storybook-dark-mode": "^3.0.3",
     "ts-jest": "^29.1.1",
     "typescript": "^5.3.3",
-    "use-debouncy": "^5.0.1",
-    "webpack": "^5.89.0",
-    "zxcvbn": "^4.4.2"
+    "webpack": "^5.89.0"
   },
-  "peerDependencies": {
-    "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.0",
+  "dependencies": {
     "@juggle/resize-observer": "^3.4.0",
     "@mui/icons-material": "^5.14.8",
-    "@mui/material": "^5.14.8",
     "@mui/x-data-grid": "^6.10.2",
     "@types/css-mediaquery": "^0.1.2",
     "@types/plotly.js": "^2.12.26",
     "@types/react-plotly.js": "^2.6.0",
     "@types/react-text-mask": "^5.4.11",
     "colord": "^2.9.3",
-    "css-mediaquery": "^0.1.2",
     "material-ui-confirm": "^3.0.9",
     "material-ui-popup-state": "^5.0.9",
     "plotly.js": "^2.26.0",
-    "react": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-colorful": "^5.6.1",
-    "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.2",
     "react-plotly.js": "^2.6.0",
     "react-text-mask": "^5.5.0",
     "use-debouncy": "^4.4.0",
     "zxcvbn": "^4.4.2"
   },
-  "peerDependenciesMeta": {
-    "@juggle/resize-observer": {
-      "optional": true
-    },
-    "@mui/x-data-grid": {
-      "optional": true
-    },
-    "@types/css-mediaquery": {
-      "optional": true
-    },
-    "@types/plotly.js": {
-      "optional": true
-    },
-    "@types/react-plotly.js": {
-      "optional": true
-    },
-    "@types/react-text-mask": {
-      "optional": true
-    },
-    "colord": {
-      "optional": true
-    },
-    "css-mediaquery": {
-      "optional": true
-    },
-    "material-ui-confirm": {
-      "optional": true
-    },
-    "material-ui-popup-state": {
-      "optional": true
-    },
-    "react-colorful": {
-      "optional": true
-    },
-    "react-dropzone": {
-      "optional": true
-    },
-    "react-hook-form": {
-      "optional": true
-    },
-    "react-text-mask": {
-      "optional": true
-    },
-    "use-debouncy": {
-      "optional": true
-    },
-    "zxcvbn": {
-      "optional": true
-    }
+  "peerDependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.14.8",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Contributes to [TD-1555](https://sce.myjetbrains.com/youtrack/issue/TD-1555/Remove-material-ui-dropzone-dependency-from-react-ui)

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

While integrating TD-1555 in VIRTO, we noted that some apps had to install peerDependencies from react-ui that they did not necassarily need in production. e.g. VIRTO.TEST had to install react-dropzone even though it did not use any react-ui components that dependend on this, just to get the application to bundle. This became more prevalent when we stopped for installing dependencies and regenerated the package-lock.jsons for each app with a normal `npm install`.

I've changed all peerDependencies back to being dependencies in their own right. I've kept `react`, `react-dom`, `@mui/material`, `@emotion/react` and `@emotion/styled"` as peerDependencies as they are used in all of our apps already. This ensures that the correct dependencies are available for development, as well as bundling in our applications.

I also noted that `css-mediaquery` appears to be only used in testing, so I've moved it into the devDependencies section.

## Testing notes

No functionality changes. Can be tested in the corresponding VIRTO PR.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] ~Appropriate tests have been added.~
- [x] Lint and test workflows pass.
