### PR TITLE
TD-2438 file picker validation state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "5.10.0",
+  "version": "5.10.1-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipguk/react-ui",
-      "version": "5.10.0",
+      "version": "5.10.1-0",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "5.10.0",
+  "version": "5.10.1-0",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/src/FileUploader/FileUploader.stories.tsx
+++ b/src/FileUploader/FileUploader.stories.tsx
@@ -49,6 +49,7 @@ export const Default: Story = {
     acceptedFiles: [],
     dropzoneText: "Drag & drop a file here or click",
     filesLimit: 1,
+    isValidating: false,
     maxFileSize: 1000000000,
     multiple: false,
     onAdd: () => {},
@@ -94,5 +95,25 @@ export const WithMultipleFilesSelected: Story = {
         file: new File([""], "CarMaker.zip")
       }
     ]
+  }
+};
+
+/**
+ * Story which shows the uploader in validation mode with single select
+ */
+export const ValidatingSingleFile: Story = {
+  args: {
+    ...WithSingleFileSelected.args,
+    isValidating: true
+  }
+};
+
+/**
+ * Story which shows the uploader in validation mode with multiple select
+ */
+export const ValidatingMultipleFiles: Story = {
+  args: {
+    ...WithMultipleFilesSelected.args,
+    isValidating: true
   }
 };

--- a/src/FileUploader/FileUploader.test.tsx
+++ b/src/FileUploader/FileUploader.test.tsx
@@ -40,10 +40,20 @@ describe("FileUploader", () => {
     const deleteButton = screen.getByRole("button", { name: /delete/i });
     expect(deleteButton).toBeInTheDocument();
   });
+  test("hide delete button when validating", () => {
+    render(<FileUploader selectedFiles={singleFile} isValidating={true} />);
+    const deleteButton = screen.queryByRole("button", { name: /delete/i });
+    expect(deleteButton).not.toBeInTheDocument();
+  });
   test("updates dropzone text in single select mode", () => {
     render(<FileUploader selectedFiles={singleFile} />);
     const dropzoneElement = screen.getByTestId("dropzone-base");
     expect(dropzoneElement).toHaveTextContent("IPGAutomotive.zip");
+  });
+  test("updates dropzone text when validating single select", () => {
+    render(<FileUploader selectedFiles={singleFile} isValidating />);
+    const dropzoneElement = screen.getByTestId("dropzone-base");
+    expect(dropzoneElement).toHaveTextContent("Validating Selection");
   });
   test("mutiple file selected", () => {
     const { container } = render(
@@ -61,5 +71,30 @@ describe("FileUploader", () => {
     expect(chips.length).toBe(2);
     expect(chips[0]).toHaveTextContent("IPGAutomotive.zip");
     expect(chips[1]).toHaveTextContent("CarMaker.zip");
+  });
+  test("chips disabled when validating", () => {
+    const { container } = render(
+      <FileUploader
+        selectedFiles={multipleFiles}
+        multiple={true}
+        dropzoneText={"Drag & drop file(s) here or click"}
+        isValidating={true}
+      />
+    );
+    const chips = container.querySelectorAll(".MuiChip-root");
+    expect(chips[0]).toHaveClass("Mui-disabled");
+    expect(chips[1]).toHaveClass("Mui-disabled");
+  });
+  test("updates dropzone text when validating multi select", () => {
+    render(
+      <FileUploader
+        selectedFiles={multipleFiles}
+        multiple={true}
+        dropzoneText={"Drag & drop file(s) here or click"}
+        isValidating={true}
+      />
+    );
+    const dropzoneElement = screen.getByTestId("dropzone-base");
+    expect(dropzoneElement).toHaveTextContent("Validating Selection");
   });
 });

--- a/src/FileUploader/FileUploader.tsx
+++ b/src/FileUploader/FileUploader.tsx
@@ -1,4 +1,12 @@
-import { Box, Chip, Grid, Stack, Typography, alpha } from "@mui/material";
+import {
+  Box,
+  Chip,
+  Grid,
+  LinearProgress,
+  Stack,
+  Typography,
+  alpha
+} from "@mui/material";
 
 import FileUploadIcon from "@mui/icons-material/FileUpload";
 import { FileUploaderProps } from "./FileUploader.types";
@@ -10,6 +18,7 @@ export default function FileUploader({
   acceptedFiles,
   dropzoneText = "Drag & drop a file here or click",
   filesLimit = 1,
+  isValidating = false,
   maxFileSize = Infinity,
   multiple = false,
   onAdd,
@@ -58,7 +67,7 @@ export default function FileUploader({
         titleVariant={titleVariant}
         subText={subText}
         required={required}
-        showDelete={!multiple && selectedFiles.length === 1}
+        showDelete={!isValidating && !multiple && selectedFiles.length === 1}
         onDelete={() => handleDelete(selectedFiles[0])}
       />
       <Box
@@ -106,23 +115,39 @@ export default function FileUploader({
           height: "70px",
           justifyContent: "center",
           p: 2,
-          pointerEvenets: selectedFiles.length > 0 ? "none" : "auto"
+          pointerEvents:
+            isValidating || (!multiple && selectedFiles.length === 1)
+              ? "none"
+              : "auto"
         })}
       >
         <input {...getInputProps()} />
-        {!multiple && selectedFiles.length === 1 ? (
-          <Stack className="dropzoneSingleFile">
-            <Typography fontSize="15px">
-              {selectedFiles[0].file.name}
+        {isValidating ? (
+          <Stack className="dropzoneText">
+            <Typography fontSize="14px">
+              {multiple ? `Validating Selection(s)` : `Validating Selection`}
             </Typography>
+            <Box width={200}>
+              <LinearProgress />
+            </Box>
           </Stack>
         ) : (
-          <Stack className="dropzoneText">
-            <FileUploadIcon />
-            <Typography fontSize="15px">
-              {rejectionMessage ?? dropzoneText}
-            </Typography>
-          </Stack>
+          <>
+            {!multiple && selectedFiles.length === 1 ? (
+              <Stack className="dropzoneSingleFile">
+                <Typography fontSize="15px">
+                  {selectedFiles[0].file.name}
+                </Typography>
+              </Stack>
+            ) : (
+              <Stack className="dropzoneText">
+                <FileUploadIcon />
+                <Typography fontSize="15px">
+                  {rejectionMessage ?? dropzoneText}
+                </Typography>
+              </Stack>
+            )}
+          </>
         )}
       </Box>
       {multiple && selectedFiles.length > 0 ? (
@@ -131,6 +156,7 @@ export default function FileUploader({
             return (
               <Grid item={true} key={`${thisFile.file?.name ?? "file"}-${i}`}>
                 <Chip
+                  disabled={isValidating}
                   variant="outlined"
                   label={thisFile.file.name}
                   onDelete={() => handleDelete(thisFile)}

--- a/src/FileUploader/FileUploader.types.ts
+++ b/src/FileUploader/FileUploader.types.ts
@@ -16,6 +16,10 @@ export type FileUploaderProps = {
    */
   filesLimit?: number;
   /**
+   * Whether the component is in the validating state with the loading indicator and selection disabled.
+   */
+  isValidating?: boolean;
+  /**
    * Maximum file size (in bytes) that the dropzone will accept.
    */
   maxFileSize?: number;


### PR DESCRIPTION
Contributes to [TD-2438](https://sce.myjetbrains.com/youtrack/issue/TD-2438/Cannot-manually-upload-vehicle-projects)

## Changes

This PR adds validation pending state to the file uploader component. This is a new `isValidating` boolean prop which defaults to false. When set to true the component switches to a pending state where no new selections or deselections are possible. This will be used in applications that require additional file validation steps outside of the component.

In doing this I also fixed a typo with pointerEvents prop and added missing logic for multiple which got missed during https://github.com/IPG-Automotive-UK/react-ui/pull/802

## Dependencies

N/A

## UI/UX

@Sowbhagya-ipg was involved in the design of this new state and has seen the new behaviour shown below.

Single select

https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/fe57ac36-8885-45f1-ade6-510fba3d3e87


Multi select with existing selections

https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/40c214fe-69bf-449c-b5dd-2e0dee5bb239


## Testing notes

* Check storybook (2 new stories added)
* New unit tests added

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker. N/A
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
