### PR TITLE
TreeViewList - expand search items

### DIFF
--- a/src/TreeViewList/TreeViewList.spec.tsx
+++ b/src/TreeViewList/TreeViewList.spec.tsx
@@ -135,3 +135,49 @@ test("should hide child when is collapsed", async ({ page }) => {
       .getByText("GearSpred", { exact: true })
   ).toBeHidden();
 });
+
+test("should expand the parent and child nodes that match the search term", async ({
+  page
+}) => {
+  await page.goto(
+    "http://localhost:6006/?path=/story/lists-treeviewlist--default&args=expandSearchTerm:true;searchTerm:ratio"
+  );
+  await expect(
+    page
+      .frameLocator('iframe[title="storybook-preview-iframe"]')
+      .getByText("BRK")
+  ).toBeVisible();
+  await expect(
+    page
+      .frameLocator('iframe[title="storybook-preview-iframe"]')
+      .getByText("Pedal")
+  ).toBeVisible();
+  await expect(
+    page
+      .frameLocator('iframe[title="storybook-preview-iframe"]')
+      .getByText("Ratio", { exact: true })
+  ).toBeVisible();
+});
+
+test("should not expand the child nodes when expand for search is not enabled", async ({
+  page
+}) => {
+  await page.goto(
+    "http://localhost:6006/?path=/story/lists-treeviewlist--default&args=expandSearchTerm:false;searchTerm:ratio"
+  );
+  await expect(
+    page
+      .frameLocator('iframe[title="storybook-preview-iframe"]')
+      .getByText("BRK")
+  ).toBeVisible();
+  await expect(
+    page
+      .frameLocator('iframe[title="storybook-preview-iframe"]')
+      .getByText("Pedal")
+  ).toBeHidden();
+  await expect(
+    page
+      .frameLocator('iframe[title="storybook-preview-iframe"]')
+      .getByText("Ratio", { exact: true })
+  ).toBeHidden();
+});

--- a/src/TreeViewList/TreeViewList.stories.tsx
+++ b/src/TreeViewList/TreeViewList.stories.tsx
@@ -36,6 +36,12 @@ export const Default = {
                   }
                 ],
                 name: "HydESPModel"
+              },
+              {
+                name: "BoreTravel",
+                options: [],
+                tooltip:
+                  "Piston travel to close compensation bore inside master cylinder. Parameter needed for CarMaker hydraulic ESC (Name: 'MC.xCompBore')."
               }
             ],
             name: "MCbooster"

--- a/src/TreeViewList/TreeViewList.types.ts
+++ b/src/TreeViewList/TreeViewList.types.ts
@@ -28,6 +28,11 @@ export type TreeViewListProps<T> = {
   searchTerm?: string;
 
   /**
+   * Flag indicating whether the search term should be expanded in the tree view list. This is optional.
+   */
+  expandSearchTerm?: boolean;
+
+  /**
    * The IDs of the items that should be expanded by default. This is optional.
    */
   defaultExpanded?: string[];


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

This PR introduces the functionality which expands out the items in the tree which matches the search term.

- A new flag has been added `expandSearchTerm` which can be used to control the use the functionality e.g when false items would not be expanded on search
- When enabled the `searchTerm` is used to search through a tree structure and return an array of node IDs that match a given search term. This allows users to easily find and navigate to items in the tree.
- The search is case-insensitive, meaning it will match nodes regardless of whether the search term is in upper case, lower case, or a mix.
- If a child node matches the search term, the function ensures that its parent node is also included in the result so that the parent is also visible. 

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->

![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/5d461e75-6747-4955-912f-8a15344a07ae)

![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/cb7f6b21-35bd-41d0-84e8-b45b40a3b4ff)

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

You can test by using the searchTerm input field in the controls of storybook.

_Note: expandSearchTerm to control usage and also a reload is required when the flag is changed_

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
