### PR TITLE
Remove extra bottom padding and border from TableCard component

### DIFF
--- a/src/Card/TableCard/TableCard.jsx
+++ b/src/Card/TableCard/TableCard.jsx
@@ -30,13 +30,26 @@ function TableCard({ action = null, tableContent = [], title = "Table" }) {
         }
         action={action}
       />
-      <CardContent sx={{ padding: 0 }}>
+      <CardContent sx={{ padding: 0, paddingBottom: "0 !important" }}>
         <TableContainer component={Box}>
           <Table size="small">
             <TableBody>
               {tableContent.map((row, index) => (
-                <TableRow key={index}>
-                  <TableCell sx={{ width: 100 }}>{row[0]}</TableCell>
+                <TableRow
+                  key={index}
+                  sx={{
+                    "&:last-child td": {
+                      border: 0
+                    }
+                  }}
+                >
+                  <TableCell
+                    sx={{
+                      width: 100
+                    }}
+                  >
+                    {row[0]}
+                  </TableCell>
                   <TableCell
                     sx={{
                       overflowWrap: "anywhere",

--- a/src/Card/TableCard/TableCard.jsx
+++ b/src/Card/TableCard/TableCard.jsx
@@ -39,7 +39,7 @@ function TableCard({ action = null, tableContent = [], title = "Table" }) {
                   key={index}
                   sx={{
                     "&:last-child td": {
-                      border: 0
+                      borderBottom: 0
                     }
                   }}
                 >


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Contributes to [TD-2464](https://sce.myjetbrains.com/youtrack/issue/TD-2464/Create-the-overview-page)

## Changes

Making this change to address a comment on a common issue [here ](https://github.com/IPG-Automotive-UK/virto/pull/535#issuecomment-1934689650)

- Removig extra space and last border

## UI/UX

Before
![Screenshot (317)](https://github.com/IPG-Automotive-UK/react-ui/assets/56511816/4021fa84-5d03-45b1-9403-4a534ee1d051)

After
![Screenshot (318)](https://github.com/IPG-Automotive-UK/react-ui/assets/56511816/d4595ef0-5371-4bc5-9f51-770a33070d49)


## Testing notes

1. Check there is no extra space visible after last row in the Table Card

- [x] Reviewed my own code-diff.
- [x] ~Branch has been run in docker.~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] ~Appropriate tests have been added.~
- [x] Lint and test workflows pass.
