### PR TITLE
NoWrapTypography sx prop does not work

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "microbundle-crl watch --no-compress --format modern,cjs --jsxFragment React.Fragment",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
-    "storybook:serve:start": "pm2 delete storybook -s || : && pm2 start ./serve-storybook.js --name storybook",
+    "storybook:serve:start": "pm2 delete storybook -s 2> /dev/null || true && pm2 start ./serve-storybook.js --name storybook",
     "storybook:serve:stop": "pm2 delete storybook",
     "test": "run-s test:unit test:lint test:playwright",
     "test:playwright": "npm run storybook:build && npm run storybook:serve:start && npx playwright test && npm run storybook:serve:stop",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "microbundle-crl watch --no-compress --format modern,cjs --jsxFragment React.Fragment",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
-    "storybook:serve:start": "pm2 start ./serve-storybook.js --name storybook",
+    "storybook:serve:start": "pm2 delete storybook -s || : && pm2 start ./serve-storybook.js --name storybook",
     "storybook:serve:stop": "pm2 delete storybook",
     "test": "run-s test:unit test:lint test:playwright",
     "test:playwright": "npm run storybook:build && npm run storybook:serve:start && npx playwright test && npm run storybook:serve:stop",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
       use: { ...devices["Desktop Safari"] }
     }
   ],
-  reporter: "html",
+  reporter: [["html", { open: "never" }]],
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   testDir: "./src",

--- a/src/NoWrapTypography/NoWrapTypography.stories.tsx
+++ b/src/NoWrapTypography/NoWrapTypography.stories.tsx
@@ -35,7 +35,7 @@ export const Default: {
 } = {
   args: {
     children: "text that is too long to fit in the box",
-    sx: { fontSize: "16px", maxWidth: "250px" }
+    sx: { fontSize: "18px", maxWidth: "250px" }
   },
 
   render: Template

--- a/src/NoWrapTypography/NoWrapTypography.stories.tsx
+++ b/src/NoWrapTypography/NoWrapTypography.stories.tsx
@@ -29,10 +29,13 @@ const Template: StoryFn<NoWrapTypographyProps> = props => {
   );
 };
 
-export const Default = {
+export const Default: {
+  args: NoWrapTypographyProps;
+  render: StoryFn<NoWrapTypographyProps>;
+} = {
   args: {
     children: "text that is too long to fit in the box",
-    sx: { fontSize: "18px", maxWidth: "250px" }
+    sx: { fontSize: "16px", maxWidth: "250px" }
   },
 
   render: Template

--- a/src/NoWrapTypography/NoWrapTypography.stories.tsx
+++ b/src/NoWrapTypography/NoWrapTypography.stories.tsx
@@ -35,7 +35,8 @@ export const Default: {
 } = {
   args: {
     children: "text that is too long to fit in the box",
-    sx: { fontSize: "18px", maxWidth: "250px" }
+    sx: { maxWidth: "250px" },
+    variant: "body1"
   },
 
   render: Template

--- a/src/NoWrapTypography/NoWrapTypography.test.tsx
+++ b/src/NoWrapTypography/NoWrapTypography.test.tsx
@@ -1,0 +1,14 @@
+import { describe, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import NoWrapTypography from "./NoWrapTypography";
+import React from "react";
+
+describe("NoWrapTypography", () => {
+  test("can pass 'sx' prop", () => {
+    render(
+      <NoWrapTypography sx={{ color: "red" }}>Some text</NoWrapTypography>
+    );
+    expect(screen.getByText("Some text")).toHaveStyle("color: rgb(255, 0, 0)");
+  });
+});

--- a/src/NoWrapTypography/NoWrapTypography.tsx
+++ b/src/NoWrapTypography/NoWrapTypography.tsx
@@ -39,7 +39,7 @@ export default function NoWrapTypography({
           textOverflow: "ellipsis",
           whiteSpace: "nowrap",
           wordBreak: "break-all",
-          ...(Array.isArray(sx) ? sx : [sx])
+          ...sx
         }}
         variant={variant}
       >

--- a/src/NoWrapTypography/NoWrapTypography.tsx
+++ b/src/NoWrapTypography/NoWrapTypography.tsx
@@ -33,14 +33,17 @@ export default function NoWrapTypography({
       <Typography
         noWrap
         component="p" // forces a block element
-        sx={{
-          hyphens: "auto",
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-          wordBreak: "break-all",
-          ...sx
-        }}
+        sx={[
+          {
+            hyphens: "auto",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            wordBreak: "break-all"
+          },
+          // You cannot spread `sx` directly because `SxProps` (typeof sx) can be an array.
+          ...(Array.isArray(sx) ? sx : [sx])
+        ]}
         variant={variant}
       >
         {children}


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->


## Changes

This PR fixes the with the sx property which was not being applied to the component correctly. 

It also solves some usability issues with playwright tests e.g. if a test is force exited and `pm2` does not correctly teardown storybook, then subsequent test runs will work where they errored before.

## Dependencies

N/A

## UI/UX

N/A

## Testing notes

- Make sure you can edit `sx` prop in storybook and it applies correctly. A vitest test has been added to confirm this,

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] ~Branch has been run in docker.~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
