### PR TITLE
Add --test flag for building storybook for playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "storybook:serve:start": "pm2 delete storybook -s 2> /dev/null || true && pm2 start ./serve-storybook.js --name storybook",
     "storybook:serve:stop": "pm2 delete storybook",
     "test": "run-s test:unit test:lint test:playwright",
-    "test:playwright": "npm run storybook:build && npm run storybook:serve:start && npx playwright test && npm run storybook:serve:stop",
+    "test:playwright": "npm run storybook:build -- --test && npm run storybook:serve:start && npx playwright test && npm run storybook:serve:stop",
     "pretest:playwright": "npx playwright install --with-deps",
     "test:playwright:headed": "npx playwright install --with-deps && npm run storybook:build && npm run storybook:serve:start && npx playwright test --headed && npm run storybook:serve:stop",
     "test:lint": "eslint ./src",


### PR DESCRIPTION
## Changes

Adds the `--test` flag when building storybook for playwright. This is a small performance improvement which skips unnecessary addons such as building the documentation. [reference](https://arc.net/l/quote/xthrtmnp)

## Testing notes

Green build should be enough.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] ~Appropriate tests have been added.~
- [ ] Lint and test workflows pass.
