### PR TITLE
Default to not showing a button on LoadErrorMessage 404

### DIFF
--- a/src/LoadErrorMessage/LoadErrorMessage.tsx
+++ b/src/LoadErrorMessage/LoadErrorMessage.tsx
@@ -146,7 +146,6 @@ const LoadErrorMessage = ({
 };
 
 LoadErrorMessage.default404Props = {
-  actionButtonText: "Go back",
   contactTeam: "none",
   image: "virto-shrugging",
   message:


### PR DESCRIPTION
Contributes to feedback left [here](https://github.com/IPG-Automotive-UK/virto/pull/551#issuecomment-1971293743)

## Changes

The default props for a 404 LoadErrorMessage should not show a Go Back button.

> I talked it through with @Sowbhagya-ipg and we agreed to remove the button for 404. It doesn't do anything that the user can't already do in the browser better. We should only use the button to provide value to the user, e.g. page specific context - go to fleet overview if prototype not found.

Release notes (patch):
- `LoadErrorMessage` default properties for a 404 error no longer show a "Go Back" button.

## UI/UX

![image](https://github.com/IPG-Automotive-UK/react-ui/assets/27866636/fac574fe-a836-49dd-94c8-6c7303fa6738)
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/27866636/9bb1b082-edf5-44d6-affc-ef5a5dc9712c)

## Testing notes

Can check in the 404 story as per screenshots above.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] ~Appropriate tests have been added.~ N/A
- [x] Lint and test workflows pass.
