### PR TITLE
TD-1854 Open current app link in the current tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "7.0.3-0",
+  "version": "7.0.3-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipguk/react-ui",
-      "version": "7.0.3-0",
+      "version": "7.0.3-1",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "7.0.2",
+  "version": "7.0.3-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ipguk/react-ui",
-      "version": "7.0.2",
+      "version": "7.0.3-0",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "7.0.3-0",
+  "version": "7.0.3-1",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "7.0.2",
+  "version": "7.0.3-0",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/src/AppLauncher/AppLauncher.tsx
+++ b/src/AppLauncher/AppLauncher.tsx
@@ -128,7 +128,9 @@ function AppLauncher({
               key={app.name}
               component="a"
               href={app.url}
-              target="_blank"
+              target={
+                window.location.href.startsWith(app.url) ? "self" : "_blank"
+              }
               data-testid={app.name}
               sx={theme => ({
                 "&:hover": {

--- a/src/AppLauncher/AppLauncher.tsx
+++ b/src/AppLauncher/AppLauncher.tsx
@@ -128,9 +128,7 @@ function AppLauncher({
               key={app.name}
               component="a"
               href={app.url}
-              target={
-                window.location.href.startsWith(app.url) ? "self" : "_blank"
-              }
+              target={window.location.href.startsWith(app.url) ? "" : "_blank"}
               data-testid={app.name}
               sx={theme => ({
                 "&:hover": {


### PR DESCRIPTION
Contributes to [TD-1854](https://sce.myjetbrains.com/youtrack/issue/TD-1854/Suppress-new-VIRTO-tab-opening-when-switching-apps)

## Changes

Updated the AppLauncher component so that links to the current app I am in open in the current tab and new apps open in a new tab. Previously all links opened in a new tab but it was requested from @Sowbhagya-ipg that links to the current app should just do a page reload in the current window.

For example here I am currently in SCENE so clicking the SCENE app menu item should reload in the current window.

We did also discuss the idea of removing links for the current app I am in but it was decided instead to keep showing them but reload in the current window rather than new window.

<img width="296" alt="image" src="https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/65ad1280-7336-4a60-802f-03ffb4c1b721">


## Dependencies

N/A

## UI/UX

N/A

## Testing notes

I've released a pre-release and integrated it in to VIRTO as that's the easiest way to test this behaviour which relies on the URL. You can use the deploy preview [here](http://k8s-deploypr-apigatew-4ef71a0284-622295924.eu-west-2.elb.amazonaws.com/) to test the behaviour in one of the apps. For example, open VIRTO.SCENE then use the app launcher component and click on SCENE. You should get a page refresh in the current tab. Then click another app and it should open in a new window.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Appropriate tests have been added. N/A
- [x] Lint and test workflows pass.
