### PR TITLE
TD-2555 - Wizard title margin reduced

### DIFF
--- a/src/Wizard/Wizard.tsx
+++ b/src/Wizard/Wizard.tsx
@@ -25,7 +25,7 @@ export default function Wizard({ title, children, maxWidth }: WizardProps) {
             sx={{
               fontWeight: 700,
               maxWidth: theme => theme?.layout?.content?.maxWidth,
-              mb: 3,
+              mb: 2,
               mt: 1,
               mx: "auto",
               width: "100%"


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Contributes to [TD-2555](https://sce.myjetbrains.com/youtrack/issue/TD-2555/Create-Wizard-Layout)

In this [PR](https://github.com/IPG-Automotive-UK/virto/pull/632#issuecomment-2009111776) @Sowbhagya-ipg noticed that the spacing of title and wizard steppers is wrong and this affects all apps. This PR is to fix this.

## Changes

- Reduced wizard title margin to 16px

## UI/UX

Before
![Screenshot (417)](https://github.com/IPG-Automotive-UK/react-ui/assets/56511816/f45533cf-b8a5-4015-b1c3-eabd0d4ebf9a)

After
![Screenshot (418)](https://github.com/IPG-Automotive-UK/react-ui/assets/56511816/f21b9c14-ec9e-4f30-8452-dc9cf049f4ec)

## Testing notes

- Check the title margin is redued to 16px

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] ~Branch has been run in docker.~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] ~Appropriate tests have been added.~
- [ ] Lint and test workflows pass.
