### PR TITLE
TreeViewList - No search results message implementation 

### DIFF
--- a/src/TreeViewList/TreeViewList.spec.tsx
+++ b/src/TreeViewList/TreeViewList.spec.tsx
@@ -269,3 +269,28 @@ test("should expand selected node", async ({ page }) => {
       .getByText("Mass", { exact: true })
   ).toBeVisible();
 });
+
+test("should show no search results message when no search results are found", async ({
+  page
+}) => {
+  // Navigate to the story
+  await page.goto(
+    "http://localhost:6006/?path=/story/lists-treeviewlist--with-search"
+  );
+
+  // Wait for the iframe to be attached in the DOM.
+  await page.waitForSelector('iframe[title="storybook-preview-iframe"]');
+
+  // Fill the search field with a search term that will not return any results
+  await page
+    .frameLocator('iframe[title="storybook-preview-iframe"]')
+    .getByPlaceholder("Search")
+    .fill("xx");
+
+  // Expect the no search results message to contain the correct text
+  await expect(
+    page
+      .frameLocator('iframe[title="storybook-preview-iframe"]')
+      .getByTestId("none-selected")
+  ).toContainText("No search results.");
+});

--- a/src/TreeViewList/TreeViewList.tsx
+++ b/src/TreeViewList/TreeViewList.tsx
@@ -1,4 +1,4 @@
-import { Box, Tooltip, debounce } from "@mui/material";
+import { Box, Tooltip, Typography, debounce } from "@mui/material";
 import React, { useCallback, useEffect, useState } from "react";
 import { TreeItem, TreeView } from "@mui/x-tree-view";
 import { TreeNodeItem, TreeViewListProps } from "./TreeViewList.types";
@@ -275,6 +275,14 @@ const TreeViewList = ({
             }}
           >
             {renderTree(treeDisplayItems)}
+            {treeDisplayItems.length === 0 && (
+              <Typography
+                data-testid="none-selected"
+                sx={{ color: theme => theme.palette.grey[500], pl: 0.5 }}
+              >
+                No search results.
+              </Typography>
+            )}
           </TreeView>
         </Box>
       </Box>


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Contributes to TD-2030

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

This PR has the following changes:

- Added a conditional rendering block in `TreeViewList.tsx` that checks if `treeDisplayItems.length` is 0, which indicates no search results.
- If there are no search results, a `Typography` component is rendered with the text "No search results.".

**Note**:
_Previously the message was "No parameters available" however since this Tree is now a separate component, the Tree can contain any type of data not just parameters, so we will use a generic message now._

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->

_Before searching:_
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/1b0406cd-871f-4e15-8e1a-1c756791f7a5)

_After searching:_
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/707bbe93-defd-47a3-8ca5-e903ac5dc932)


## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

1. Navigate to the storybook page for the TreeViewList component with search functionality - **With Search**
2. Fill the search field with a search term that that will not return any results (e.g. xx)
3. Check that the "No search results" message is displayed 

Note:
This UI has been approved by @Sowbhagya-ipg already.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
