### PR TITLE
Uncontrolled input  component updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "7.3.0-0",
+  "version": "7.3.0-1",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "7.2.0",
+  "version": "7.3.0-0",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "7.3.2",
+  "version": "7.3.0-0",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "7.3.0-1",
+  "version": "7.3.0-2",
   "description": "React UI component library for IPG web applications",
   "author": "IPG-Automotive-UK",
   "license": "MIT",

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -60,20 +60,6 @@ const Template: StoryFn<
   );
 };
 
-const UncontrolledTemplate: StoryFn<
-  AutocompleteProps<string | KeyValueOption, boolean | undefined>
-> = args => {
-  // Return the Autocomplete component with the appropriate props
-  return (
-    <Autocomplete
-      {...args}
-      onChange={(event, newValue) => {
-        action("onChange")(newValue);
-      }}
-    />
-  );
-};
-
 // Define the default story
 export const Default: StoryObj<typeof Autocomplete> = {
   args: {
@@ -100,10 +86,11 @@ export const Default: StoryObj<typeof Autocomplete> = {
   },
   render: Template
 };
-// Define the default story
+
+// Define the uncontrolled story
 export const Uncontrolled: StoryObj<typeof Autocomplete> = {
   args: {
-    // Define the default args
+    // Define the uncontrolled args
     defaultValue: "Option 4",
     disabled: false,
     error: false,
@@ -124,7 +111,7 @@ export const Uncontrolled: StoryObj<typeof Autocomplete> = {
     size: "medium",
     variant: "outlined"
   },
-  render: UncontrolledTemplate
+  render: Autocomplete
 };
 
 // Define the story for key-value options

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -60,6 +60,20 @@ const Template: StoryFn<
   );
 };
 
+const UncontrolledTemplate: StoryFn<
+  AutocompleteProps<string | KeyValueOption, boolean | undefined>
+> = args => {
+  // Return the Autocomplete component with the appropriate props
+  return (
+    <Autocomplete
+      {...args}
+      onChange={(event, newValue) => {
+        action("onChange")(newValue);
+      }}
+    />
+  );
+};
+
 // Define the default story
 export const Default: StoryObj<typeof Autocomplete> = {
   args: {
@@ -85,6 +99,32 @@ export const Default: StoryObj<typeof Autocomplete> = {
     variant: "outlined"
   },
   render: Template
+};
+// Define the default story
+export const Uncontrolled: StoryObj<typeof Autocomplete> = {
+  args: {
+    // Define the default args
+    defaultValue: "Option 4",
+    disabled: false,
+    error: false,
+    helperText: "Helper Text",
+    label: "Select options",
+    limitTags: -1,
+    margin: "normal",
+    multiple: false,
+    options: [
+      "Option 1",
+      "Option 2",
+      "Option 3",
+      "Option 4",
+      "Option 5",
+      "Option 6"
+    ],
+    required: false,
+    size: "medium",
+    variant: "outlined"
+  },
+  render: UncontrolledTemplate
 };
 
 // Define the story for key-value options

--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -54,6 +54,7 @@ const Template: StoryFn<
         updateArgs({ value: newValue });
         action("onChange")(newValue);
       }}
+      onBlur={event => action("onBlur")}
       value={theValue}
       multiple={multiple}
     />
@@ -99,6 +100,7 @@ export const Uncontrolled: StoryObj<typeof Autocomplete> = {
     limitTags: -1,
     margin: "normal",
     multiple: false,
+    onBlur: action("onBlur"),
     options: [
       "Option 1",
       "Option 2",

--- a/src/Autocomplete/Autocomplete.test.tsx
+++ b/src/Autocomplete/Autocomplete.test.tsx
@@ -202,4 +202,21 @@ describe("Select", () => {
 
     expect(input).toHaveValue("option-one");
   });
+
+  it("can use an onBlur callback", async () => {
+    const onBlur = vi.fn();
+
+    render(
+      <Autocomplete
+        multiple={false}
+        options={keyValueOptions}
+        onBlur={onBlur}
+        label="Select an option"
+      />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /open/i }));
+    await userEvent.tab();
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/Autocomplete/Autocomplete.test.tsx
+++ b/src/Autocomplete/Autocomplete.test.tsx
@@ -188,4 +188,18 @@ describe("Select", () => {
       expect.anything()
     );
   });
+
+  it("textfield default value", () => {
+    const { getByRole } = render(
+      <Autocomplete
+        defaultValue={"option-one"}
+        options={["optione-one", "option-two", "option-three"]}
+        label="Select an option"
+      />
+    );
+
+    const input = getByRole("combobox") as HTMLInputElement;
+
+    expect(input).toHaveValue("option-one");
+  });
 });

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -30,6 +30,7 @@ export default function Autocomplete<
   margin = "normal",
   multiple,
   name,
+  onBlur,
   onChange,
   options,
   required = false,
@@ -43,6 +44,7 @@ export default function Autocomplete<
       disableCloseOnSelect={disableCloseOnSelect}
       limitTags={limitTags}
       multiple={multiple}
+      onBlur={onBlur}
       onChange={onChange}
       options={options}
       getOptionLabel={option =>

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -20,6 +20,7 @@ export default function Autocomplete<
   Value extends KeyValueOption | string,
   Multiple extends boolean | undefined
 >({
+  defaultValue,
   disableCloseOnSelect = false,
   disabled = false,
   error = false,
@@ -37,6 +38,7 @@ export default function Autocomplete<
 }: AutocompleteProps<Value, Multiple>) {
   return (
     <MuiAutocomplete
+      defaultValue={defaultValue}
       disableCloseOnSelect={disableCloseOnSelect}
       limitTags={limitTags}
       multiple={multiple}

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -29,6 +29,7 @@ export default function Autocomplete<
   limitTags = -1,
   margin = "normal",
   multiple,
+  name,
   onChange,
   options,
   required = false,
@@ -53,6 +54,7 @@ export default function Autocomplete<
           label={label}
           error={error}
           helperText={helperText}
+          name={name}
           margin={margin}
           required={required}
           variant={variant}

--- a/src/Autocomplete/Autocomplete.types.ts
+++ b/src/Autocomplete/Autocomplete.types.ts
@@ -25,6 +25,7 @@ export type AutocompleteProps<
     | "size"
     | "helperText"
     | "margin"
+    | "name"
     | "variant"
     | "required"
     | "label"

--- a/src/Autocomplete/Autocomplete.types.ts
+++ b/src/Autocomplete/Autocomplete.types.ts
@@ -14,6 +14,7 @@ export type AutocompleteProps<
   | "onChange"
   | "options"
   | "value"
+  | "defaultValue"
   | "disabled"
   | "size"
   | "limitTags"

--- a/src/Autocomplete/Autocomplete.types.ts
+++ b/src/Autocomplete/Autocomplete.types.ts
@@ -11,6 +11,7 @@ export type AutocompleteProps<
 > = Pick<
   MuiAutocompleteProps<Value, Multiple, false, false>,
   | "multiple"
+  | "onBlur"
   | "onChange"
   | "options"
   | "value"

--- a/src/Checkbox/Checkbox.jsx
+++ b/src/Checkbox/Checkbox.jsx
@@ -49,6 +49,10 @@ Checkbox.propTypes = {
    */
   checked: PropTypes.bool,
   /**
+   * The default value of the input.
+   */
+  defaultChecked: PropTypes.bool,
+  /**
    * If true, the component is disabled.
    */
   disabled: PropTypes.bool,
@@ -56,6 +60,10 @@ Checkbox.propTypes = {
    * Text to be used alongside checkbox.
    */
   label: PropTypes.string,
+  /**
+   * The name of the input.
+   */
+  name: PropTypes.string,
   /**
    * Callback fired when the state is changed.
    *

--- a/src/Checkbox/Checkbox.jsx
+++ b/src/Checkbox/Checkbox.jsx
@@ -1,18 +1,22 @@
 import * as React from "react";
+
 import {
   FormControlLabel,
   FormGroup,
   Checkbox as MuiCheckbox
 } from "@mui/material";
+
 import PropTypes from "prop-types";
 
 /**
  * Checkbox component
  */
 export default function Checkbox({
-  checked = false,
+  checked,
+  defaultChecked,
   disabled = false,
   label = "",
+  name,
   onChange = () => {},
   size = "medium",
   style = {}
@@ -25,7 +29,9 @@ export default function Checkbox({
           <MuiCheckbox
             sx={{ ...style, pointerEvents: "auto" }}
             checked={checked}
+            defaultChecked={defaultChecked}
             disabled={disabled}
+            name={name}
             onChange={onChange}
             size={size}
           />

--- a/src/Checkbox/Checkbox.stories.jsx
+++ b/src/Checkbox/Checkbox.stories.jsx
@@ -19,19 +19,6 @@ const Template = args => {
   return <Checkbox {...args} checked={checked} onChange={onChange} />;
 };
 
-const UncontrolledTemplate = args => {
-  const onChange = event => {
-    action("onChange")(event);
-  };
-  return (
-    <Checkbox
-      {...args}
-      defaultChecked={args.defaultChecked}
-      onChange={onChange}
-    />
-  );
-};
-
 export const Default = {
   args: {
     checked: false,
@@ -53,7 +40,7 @@ export const Uncontrolled = {
     style: {}
   },
 
-  render: UncontrolledTemplate
+  render: Checkbox
 };
 
 export const styledCheckbox = {

--- a/src/Checkbox/Checkbox.stories.jsx
+++ b/src/Checkbox/Checkbox.stories.jsx
@@ -19,6 +19,19 @@ const Template = args => {
   return <Checkbox {...args} checked={checked} onChange={onChange} />;
 };
 
+const UncontrolledTemplate = args => {
+  const onChange = event => {
+    action("onChange")(event);
+  };
+  return (
+    <Checkbox
+      {...args}
+      defaultChecked={args.defaultChecked}
+      onChange={onChange}
+    />
+  );
+};
+
 export const Default = {
   args: {
     checked: false,
@@ -29,6 +42,18 @@ export const Default = {
   },
 
   render: Template
+};
+
+export const Uncontrolled = {
+  args: {
+    defaultChecked: true,
+    disabled: false,
+    label: "Uncontrolled",
+    size: "medium",
+    style: {}
+  },
+
+  render: UncontrolledTemplate
 };
 
 export const styledCheckbox = {

--- a/src/Checkbox/Checkbox.test.jsx
+++ b/src/Checkbox/Checkbox.test.jsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from "@testing-library/react";
+
 import Checkbox from "./Checkbox";
 import React from "react";
 
@@ -16,6 +17,13 @@ describe("Checkbox", () => {
     );
     const checkboxInput = container.querySelector("input");
     fireEvent.change(checkboxInput, { target: { checked: true } });
+    expect(checkboxInput.checked).toBeTruthy();
+  });
+  test("can default checkbox", () => {
+    const { container } = render(
+      <Checkbox defaultChecked={true} label="This is a test" />
+    );
+    const checkboxInput = container.querySelector("input");
     expect(checkboxInput.checked).toBeTruthy();
   });
 });

--- a/src/Checkbox/Checkbox.test.jsx
+++ b/src/Checkbox/Checkbox.test.jsx
@@ -17,13 +17,13 @@ describe("Checkbox", () => {
     );
     const checkboxInput = container.querySelector("input");
     fireEvent.change(checkboxInput, { target: { checked: true } });
-    expect(checkboxInput.checked).toBeTruthy();
+    expect(checkboxInput.checked).toBe(true);
   });
   test("can default checkbox", () => {
     const { container } = render(
       <Checkbox defaultChecked={true} label="This is a test" />
     );
     const checkboxInput = container.querySelector("input");
-    expect(checkboxInput.checked).toBeTruthy();
+    expect(checkboxInput.checked).toBe(true);
   });
 });

--- a/src/Checkbox/index.ts
+++ b/src/Checkbox/index.ts
@@ -1,7 +1,7 @@
 import Checkbox from "./Checkbox";
 
 /**
- * Checkbox component props
+ * Prop type for checkboxes
  */
 export type CheckboxProps = {
   /**

--- a/src/Checkbox/index.ts
+++ b/src/Checkbox/index.ts
@@ -2,8 +2,10 @@ import Checkbox from "./Checkbox";
 
 export type CheckboxProps = {
   checked?: boolean;
+  defaultChecked?: boolean;
   disabled?: boolean;
   label?: string;
+  name?: string;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   size?: "small" | "medium";
   style?: React.CSSProperties;

--- a/src/Checkbox/index.ts
+++ b/src/Checkbox/index.ts
@@ -1,13 +1,41 @@
 import Checkbox from "./Checkbox";
 
+/**
+ * Checkbox component props
+ */
 export type CheckboxProps = {
+  /**
+   * Is the checkbox checked by the user
+   */
   checked?: boolean;
+  /**
+   * Is the checkbox checked by default
+   */
   defaultChecked?: boolean;
+  /**
+   * Is the checkbox disabled
+   */
   disabled?: boolean;
+  /**
+   * The checkbox label
+   */
   label?: string;
+  /**
+   * The name of the checkbox
+   */
   name?: string;
+  /**
+   * Function to call when the checkbox changes
+   * @param event - the event that triggered the change
+   */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  /**
+   * The size of the checkbox
+   */
   size?: "small" | "medium";
+  /**
+   * The style of the checkbox
+   */
   style?: React.CSSProperties;
 };
 

--- a/src/LabelSelector/LabelSelector.d.ts
+++ b/src/LabelSelector/LabelSelector.d.ts
@@ -1,3 +1,4 @@
+import { BaseSyntheticEvent } from "react";
 import type { Label } from "./Label.types";
 
 export type LabelSelectorProps = {
@@ -5,9 +6,13 @@ export type LabelSelectorProps = {
   autocompleteLabel?: string;
   deleteEnabled?: boolean;
   editEnabled?: boolean;
+  error?: boolean;
+  helperText?: string;
   limitTags?: number;
   multiple?: boolean;
+  name?: string;
   nameMaxLength?: number;
+  onBlur?: (event: BaseSyntheticEvent) => void;
   onChange?: (selectedLabels: Label[]) => void;
   onDelete?: (deletedLabel: Label) => void;
   onEdit?: (editedLabel: Label) => void;

--- a/src/LabelSelector/LabelSelector.jsx
+++ b/src/LabelSelector/LabelSelector.jsx
@@ -88,10 +88,14 @@ function LabelSelector({
   addEnabled = false,
   autocompleteLabel = "",
   deleteEnabled = false,
+  error = false,
   editEnabled = false,
+  helperText,
   limitTags = -1,
   nameMaxLength = 50,
   multiple = true,
+  name,
+  onBlur = () => {},
   onChange = () => {},
   onDelete = () => {},
   onEdit = () => {},
@@ -167,10 +171,18 @@ function LabelSelector({
         disableCloseOnSelect
         limitTags={limitTags}
         multiple={multiple}
+        onBlur={onBlur}
         onChange={(_e, selectedValues) => onChange(selectedValues)}
         options={options}
         renderInput={params => (
-          <TextField {...params} label={autocompleteLabel} variant="outlined" />
+          <TextField
+            {...params}
+            error={error}
+            helperText={helperText}
+            name={name}
+            label={autocompleteLabel}
+            variant="outlined"
+          />
         )}
         filterOptions={(options, params) => {
           const filtered = filter(options, params);
@@ -318,6 +330,17 @@ LabelSelector.propTypes = {
    */
   editEnabled: PropTypes.bool,
   /**
+   * If true, the label selector will display an error state.
+   * @default false
+   * @type {boolean}
+   */
+  error: PropTypes.bool,
+  /**
+   * The helper text content.
+   * @type {string}
+   */
+  helperText: PropTypes.string,
+  /**
    * The maximum number of tags that will be visible when not focused.
    * Set -1 to disable the limit
    * @default -1
@@ -334,11 +357,29 @@ LabelSelector.propTypes = {
    */
   multiple: PropTypes.bool,
   /**
+   * The name of the input.
+   * @type {string}
+   */
+  name: PropTypes.string,
+  /**
    * The maximum length of a label name.
    * @default 50
    * @type {number}
    */
   nameMaxLength: PropTypes.number,
+  /**
+   * Callback fired when the input is blurred.
+   *
+   * **Signature**
+   * ```
+   * function(event: object) => void
+   * ```
+   *
+   * _event_: The event source of the callback.
+   * @default () => {}
+   * @type {function}
+   */
+  onBlur: PropTypes.func,
   /**
    * Callback fired when the value is changed.
    *

--- a/src/LabelSelector/LabelSelector.jsx
+++ b/src/LabelSelector/LabelSelector.jsx
@@ -253,7 +253,7 @@ function LabelSelector({
         noOptionsText="No labels found"
         getOptionLabel={option => option.name}
         isOptionEqualToValue={(option, value) => {
-          return option._id === value._id ?? false;
+          return option._id === value._id;
         }}
         value={value || null}
       />

--- a/src/LabelSelector/LabelSelector.stories.jsx
+++ b/src/LabelSelector/LabelSelector.stories.jsx
@@ -19,12 +19,14 @@ const Template = args => {
     <Box maxWidth={300}>
       <LabelSelector
         {...args}
+        onBlur={action("onBlur")}
         onChange={selectedValues => {
           setValue(selectedValues);
 
           // fire action
           action("onChange")(selectedValues);
         }}
+        name="label-selector"
         options={options}
         value={value}
         onNew={newLabel => {
@@ -88,6 +90,7 @@ export const Default = {
     limitTags: -1,
     multiple: true,
     nameMaxLength: 50,
+    onBlur: () => {},
     onChange: () => {},
     onDelete: () => {},
     onEdit: () => {},
@@ -117,6 +120,16 @@ export const WithLabelOptions = {
         name: "a really looooooooooooooooooong string"
       }
     ]
+  },
+
+  render: Template
+};
+
+export const WithErrorAndHelperText = {
+  args: {
+    ...Default.args,
+    error: true,
+    helperText: "A label is required"
   },
 
   render: Template

--- a/src/LabelSelector/LabelSelector.test.jsx
+++ b/src/LabelSelector/LabelSelector.test.jsx
@@ -270,4 +270,26 @@ describe("LabelSelector", () => {
     // expect the add button to be disabled
     expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
   });
+
+  // It renders with an error and helper text
+  it("renders with an error and helper text", () => {
+    const options = [
+      { _id: 1, color: "#005FA8", description: "first label", name: "label 1" }
+    ];
+
+    // render the label selector
+    render(
+      <LabelSelector
+        error={true}
+        helperText="Label is required"
+        options={options}
+        value={options}
+      />
+    );
+
+    const helperText = screen.getByText("Label is required");
+    // check that the helper text is being rendered correctly
+    expect(helperText).toBeInTheDocument();
+    expect(helperText).toHaveClass("Mui-error");
+  });
 });

--- a/src/NumberField/NumberField.jsx
+++ b/src/NumberField/NumberField.jsx
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
  * Number fields let users enter and edit numbers.
  */
 export default function NumberField({
+  defaultValue,
   disabled = false,
   endAdornment = null,
   error = false,
@@ -15,6 +16,8 @@ export default function NumberField({
   margin = "normal",
   max = +Infinity,
   min = -Infinity,
+  name,
+  onBlur = () => {},
   onChange = () => {},
   placeholder,
   required = false,
@@ -81,6 +84,7 @@ export default function NumberField({
 
   return (
     <TextField
+      defaultValue={defaultValue}
       data-testid="NumberField"
       disabled={disabled}
       error={!isValid || error}
@@ -88,6 +92,8 @@ export default function NumberField({
       helperText={validationText || helperText}
       label={label}
       margin={margin}
+      name={name}
+      onBlur={onBlur}
       onChange={handleChange}
       placeholder={placeholder}
       required={required}
@@ -178,6 +184,10 @@ const isStep = (value, step) => {
 // prop types
 NumberField.propTypes = {
   /**
+   * The default value of the input.
+   */
+  defaultValue: PropTypes.number,
+  /**
    * If true, the label, input and helper text should be displayed in a disabled state.
    * @default false
    */
@@ -215,6 +225,14 @@ NumberField.propTypes = {
    * if the stepper is enabled this will be the minimum value of the stepper.
    */
   min: PropTypes.number,
+  /**
+   * Name of the input.
+   */
+  name: PropTypes.string,
+  /**
+   * Callback fired when the value is changed.
+   */
+  onBlur: PropTypes.func,
   /**
    * Callback fired when the value is changed.
    *

--- a/src/NumberField/NumberField.jsx
+++ b/src/NumberField/NumberField.jsx
@@ -231,6 +231,11 @@ NumberField.propTypes = {
   name: PropTypes.string,
   /**
    * Callback fired when the value is changed.
+   *
+   * **Signature**
+   * ```
+   * function(event: SyntheticBaseEvent) => void
+   * ```
    */
   onBlur: PropTypes.func,
   /**

--- a/src/NumberField/NumberField.stories.jsx
+++ b/src/NumberField/NumberField.stories.jsx
@@ -17,7 +17,7 @@ const Template = args => {
     action("onChange")(event, event.target.value);
   };
   const onBlur = event => {
-    action("onBlur")(event);
+    action("onBlur");
   };
   return (
     <NumberField {...args} onBlur={onBlur} onChange={onChange} value={value} />

--- a/src/NumberField/NumberField.stories.jsx
+++ b/src/NumberField/NumberField.stories.jsx
@@ -16,7 +16,12 @@ const Template = args => {
     setValue(value);
     action("onChange")(event, event.target.value);
   };
-  return <NumberField {...args} onChange={onChange} value={value} />;
+  const onBlur = event => {
+    action("onBlur")(event);
+  };
+  return (
+    <NumberField {...args} onBlur={onBlur} onChange={onChange} value={value} />
+  );
 };
 
 export const Default = {
@@ -34,6 +39,23 @@ export const Default = {
   },
 
   render: Template
+};
+
+export const Uncontrolled = {
+  args: {
+    disabled: false,
+    error: false,
+    helperText: "What Number are you going to type?",
+    label: "Enter a Number",
+    margin: "normal",
+    onBlur: action("onBlur"),
+    required: false,
+    showMinMaxErrorMessage: true,
+    size: "medium",
+    stepper: true,
+    variant: "outlined"
+  },
+  render: NumberField
 };
 
 export const StartAdornment = {

--- a/src/NumberField/NumberField.test.jsx
+++ b/src/NumberField/NumberField.test.jsx
@@ -1,6 +1,7 @@
+import { render, screen } from "@testing-library/react";
+
 import NumberField from ".";
 import React from "react";
-import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 /**
@@ -227,5 +228,15 @@ describe("NumberField", () => {
     // there should be no helper text (which parents the error message)
     const errorBase = container.querySelector(".MuiFormHelperText-root");
     expect(errorBase).toBe(null);
+  });
+
+  test("can use an onBlur callback", async () => {
+    const onBlur = vi.fn();
+    const { container } = render(<NumberField onBlur={onBlur} />);
+    const inputBase = container.querySelector(".MuiInputBase-input");
+
+    await userEvent.click(inputBase);
+    await userEvent.tab();
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/NumberField/index.ts
+++ b/src/NumberField/index.ts
@@ -2,6 +2,7 @@ import NumberField from "./NumberField";
 import type { TextFieldProps } from "@mui/material";
 
 export type NumberFieldProps = {
+  defaultValue?: number;
   disabled?: boolean;
   endAdornment?: string;
   error?: boolean;
@@ -10,6 +11,8 @@ export type NumberFieldProps = {
   margin?: "none" | "dense" | "normal";
   max?: number;
   min?: number;
+  name?: string;
+  onBlur?: () => {};
   onChange?: TextFieldProps["onChange"];
   placeholder?: number;
   required?: boolean;

--- a/src/NumberField/index.ts
+++ b/src/NumberField/index.ts
@@ -12,7 +12,7 @@ export type NumberFieldProps = {
   max?: number;
   min?: number;
   name?: string;
-  onBlur?: () => {};
+  onBlur?: TextFieldProps["onBlur"];
   onChange?: TextFieldProps["onChange"];
   placeholder?: number;
   required?: boolean;

--- a/src/RadioButtons/RadioButtons.jsx
+++ b/src/RadioButtons/RadioButtons.jsx
@@ -55,6 +55,10 @@ export default function RadioButtons({
 
 RadioButtons.propTypes = {
   /**
+   * The default value of the radio buttons group.
+   */
+  defaultValue: PropTypes.string,
+  /**
    * If true, the radio buttons group will be disabled.
    */
   disabled: PropTypes.bool,
@@ -62,6 +66,10 @@ RadioButtons.propTypes = {
    * The position of the label.
    */
   labelPlacement: PropTypes.oneOf(["start", "end", "top", "bottom"]),
+  /**
+   * The name of the radio buttons group and each radio.
+   */
+  name: PropTypes.string,
   /**
    * Callback fired when the radio button is selected.
    *

--- a/src/RadioButtons/RadioButtons.jsx
+++ b/src/RadioButtons/RadioButtons.jsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import {
   FormControl,
   FormControlLabel,
@@ -6,14 +7,17 @@ import {
   Radio,
   RadioGroup
 } from "@mui/material";
+
 import PropTypes from "prop-types";
 
 /**
  * Radio buttons group component
  */
 export default function RadioButtons({
+  defaultValue,
   disabled = false,
   labelPlacement = "end",
+  name,
   onChange = () => {},
   options = [],
   style = {},
@@ -29,6 +33,8 @@ export default function RadioButtons({
       <RadioGroup
         sx={style}
         aria-label={title}
+        defaultValue={defaultValue}
+        name={name}
         onChange={onChange}
         row={row}
         value={value}
@@ -36,7 +42,7 @@ export default function RadioButtons({
         {options.map((item, index) => (
           <FormControlLabel
             key={index}
-            control={<Radio size={size} />}
+            control={<Radio name={name} size={size} />}
             label={item}
             value={item}
             labelPlacement={labelPlacement}

--- a/src/RadioButtons/RadioButtons.stories.jsx
+++ b/src/RadioButtons/RadioButtons.stories.jsx
@@ -25,6 +25,21 @@ const Template = args => {
   );
 };
 
+const UncontrolledTemplate = args => {
+  const onChange = (event, value) => {
+    action("onChange")(event, value);
+  };
+  return (
+    <div>
+      <RadioButtons
+        {...args}
+        onChange={onChange}
+        defaultValue={args.defaultValue}
+      />
+    </div>
+  );
+};
+
 export const Default = {
   args: {
     disabled: false,
@@ -38,4 +53,20 @@ export const Default = {
   },
 
   render: Template
+};
+
+export const Uncontrolled = {
+  args: {
+    defaultValue: "Option C",
+    disabled: false,
+    labelPlacement: "end",
+    name: "radio",
+    options: ["Option A", "Option B", "Option C"],
+    row: false,
+    size: "medium",
+    style: {},
+    title: "This is an example"
+  },
+
+  render: UncontrolledTemplate
 };

--- a/src/RadioButtons/RadioButtons.stories.jsx
+++ b/src/RadioButtons/RadioButtons.stories.jsx
@@ -25,21 +25,6 @@ const Template = args => {
   );
 };
 
-const UncontrolledTemplate = args => {
-  const onChange = (event, value) => {
-    action("onChange")(event, value);
-  };
-  return (
-    <div>
-      <RadioButtons
-        {...args}
-        onChange={onChange}
-        defaultValue={args.defaultValue}
-      />
-    </div>
-  );
-};
-
 export const Default = {
   args: {
     disabled: false,
@@ -68,5 +53,5 @@ export const Uncontrolled = {
     title: "This is an example"
   },
 
-  render: UncontrolledTemplate
+  render: RadioButtons
 };

--- a/src/RadioButtons/RadioButtons.test.jsx
+++ b/src/RadioButtons/RadioButtons.test.jsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from "@testing-library/react";
+
 import RadioButtons from "./RadioButtons";
 import React from "react";
 
@@ -21,5 +22,18 @@ describe("RadioButtons", () => {
     const radioInput = container.querySelector("input");
     fireEvent.change(radioInput, { target: { value: thisValue } });
     expect(radioInput.value).toBe(thisValue);
+  });
+  test("can set a name and default value", () => {
+    const thisValue = options[2];
+    const { container } = render(
+      <RadioButtons
+        defaultValue={thisValue}
+        name="uncontrolled"
+        options={options}
+        title="Test"
+      />
+    );
+    const radioInput = container.querySelectorAll(`input[name="uncontrolled"]`);
+    expect(radioInput[2]).toBeChecked();
   });
 });

--- a/src/RadioButtons/index.ts
+++ b/src/RadioButtons/index.ts
@@ -2,17 +2,53 @@ import type { RadioGroupProps, SxProps, Theme } from "@mui/material";
 
 import RadioButtons from "./RadioButtons";
 
+/**
+ * Prop type for radio buttons
+ */
 export type RadioButtonsProps = {
+  /**
+   * The default value of the radio buttons
+   */
   defaultValue?: string;
+  /**
+   * Is the radio button group disabled
+   */
   disabled?: boolean;
+  /**
+   * The label placement for each radio
+   */
   labelPlacement?: "end" | "start" | "top" | "bottom";
+  /**
+   * The name of the radio button group and each radio button
+   */
   name?: string;
+  /**
+   * Function to call when the radio button group changes
+   */
   onChange?: RadioGroupProps["onChange"];
+  /**
+   * The options for the radio buttons
+   */
   options?: string[];
+  /**
+   * Should the radio buttons be displayed in a row
+   */
   row?: boolean;
+  /**
+   * The size of the radio buttons
+   */
   size?: "small" | "medium";
+  /**
+   * The style of the radio buttons
+   */
   style?: SxProps<Theme>;
+  /**
+   * The title of the radio buttons
+   */
   title?: string;
+  /**
+   * The value of the radio buttons
+   */
   value?: string;
 };
 

--- a/src/RadioButtons/index.ts
+++ b/src/RadioButtons/index.ts
@@ -3,8 +3,10 @@ import type { RadioGroupProps, SxProps, Theme } from "@mui/material";
 import RadioButtons from "./RadioButtons";
 
 export type RadioButtonsProps = {
+  defaultValue?: string;
   disabled?: boolean;
   labelPlacement?: "end" | "start" | "top" | "bottom";
+  name?: string;
   onChange?: RadioGroupProps["onChange"];
   options?: string[];
   row?: boolean;

--- a/src/SwitchField/SwitchField.jsx
+++ b/src/SwitchField/SwitchField.jsx
@@ -70,6 +70,10 @@ FormSwitch.propTypes = {
    */
   checked: PropTypes.bool,
   /**
+   * The default value of the input.
+   */
+  defaultChecked: PropTypes.bool,
+  /**
    * If true, the switch will be disabled.
    */
   disabled: PropTypes.bool,
@@ -81,6 +85,10 @@ FormSwitch.propTypes = {
    * The label content.
    */
   label: PropTypes.string,
+  /**
+   * The name of the input.
+   */
+  name: PropTypes.string,
   /**
    * Callback fired when the state is changed.
    *

--- a/src/SwitchField/SwitchField.jsx
+++ b/src/SwitchField/SwitchField.jsx
@@ -7,6 +7,7 @@ import {
   Switch,
   Typography
 } from "@mui/material";
+
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -15,6 +16,7 @@ import React from "react";
  */
 export default function FormSwitch({
   checked,
+  defaultChecked,
   disabled = false,
   helperText,
   label,
@@ -33,7 +35,12 @@ export default function FormSwitch({
         >
           <Stack alignItems="center" component="label" direction="row">
             <SwitchOptionLabel disabled={disabled} label={options[0]} />
-            <Switch checked={checked} onChange={onChange} size={size} />
+            <Switch
+              checked={checked}
+              defaultChecked={defaultChecked}
+              onChange={onChange}
+              size={size}
+            />
             <SwitchOptionLabel disabled={disabled} label={options[1]} />
           </Stack>
         </Typography>

--- a/src/SwitchField/SwitchField.jsx
+++ b/src/SwitchField/SwitchField.jsx
@@ -68,7 +68,7 @@ FormSwitch.propTypes = {
   /**
    * If true, the component is checked.
    */
-  checked: PropTypes.bool.isRequired,
+  checked: PropTypes.bool,
   /**
    * If true, the switch will be disabled.
    */
@@ -91,7 +91,7 @@ FormSwitch.propTypes = {
    *
    * _event_: The event source of the callback. You can pull out the new checked state by accessing event.target.checked (boolean).
    */
-  onChange: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
   /**
    * Options to display either side of the switch. Must be an array of length 2, with type string.
    */

--- a/src/SwitchField/SwitchField.jsx
+++ b/src/SwitchField/SwitchField.jsx
@@ -20,6 +20,7 @@ export default function FormSwitch({
   disabled = false,
   helperText,
   label,
+  name,
   onChange,
   options,
   size = "medium"
@@ -38,6 +39,7 @@ export default function FormSwitch({
             <Switch
               checked={checked}
               defaultChecked={defaultChecked}
+              name={name}
               onChange={onChange}
               size={size}
             />

--- a/src/SwitchField/SwitchField.stories.jsx
+++ b/src/SwitchField/SwitchField.stories.jsx
@@ -8,7 +8,7 @@ export default {
 };
 
 const Template = args => {
-  const [checked, setChecked] = React.useState(false);
+  const [checked, setChecked] = React.useState(undefined);
 
   React.useEffect(() => {
     setChecked(args.checked);
@@ -18,8 +18,21 @@ const Template = args => {
     <SwitchField
       {...args}
       checked={checked}
+      defaultChecked={args.defaultChecked}
       onChange={(...args) => {
         setChecked(!checked);
+        action("onChange")(...args);
+      }}
+    />
+  );
+};
+
+const UncontrolledTemplate = args => {
+  return (
+    <SwitchField
+      {...args}
+      defaultChecked={args.defaultChecked}
+      onChange={(...args) => {
         action("onChange")(...args);
       }}
     />
@@ -29,6 +42,7 @@ const Template = args => {
 export const Default = {
   args: {
     checked: false,
+    defaultChecked: false,
     helperText: "Maybe you need some help?",
     label: "Make a choice",
     options: ["Choice A", "Choice B"],
@@ -36,6 +50,18 @@ export const Default = {
   },
 
   render: Template
+};
+
+export const Uncontrolled = {
+  args: {
+    defaultChecked: true,
+    helperText: "Maybe you need some help?",
+    label: "Make a choice",
+    options: ["Choice A", "Choice B"],
+    size: "medium"
+  },
+
+  render: UncontrolledTemplate
 };
 
 export const Disabled = {

--- a/src/SwitchField/SwitchField.stories.jsx
+++ b/src/SwitchField/SwitchField.stories.jsx
@@ -57,6 +57,7 @@ export const Uncontrolled = {
     defaultChecked: true,
     helperText: "Maybe you need some help?",
     label: "Make a choice",
+    name: "switch",
     options: ["Choice A", "Choice B"],
     size: "medium"
   },

--- a/src/SwitchField/SwitchField.stories.jsx
+++ b/src/SwitchField/SwitchField.stories.jsx
@@ -27,18 +27,6 @@ const Template = args => {
   );
 };
 
-const UncontrolledTemplate = args => {
-  return (
-    <SwitchField
-      {...args}
-      defaultChecked={args.defaultChecked}
-      onChange={(...args) => {
-        action("onChange")(...args);
-      }}
-    />
-  );
-};
-
 export const Default = {
   args: {
     checked: false,
@@ -62,7 +50,7 @@ export const Uncontrolled = {
     size: "medium"
   },
 
-  render: UncontrolledTemplate
+  render: SwitchField
 };
 
 export const Disabled = {

--- a/src/SwitchField/SwitchField.test.jsx
+++ b/src/SwitchField/SwitchField.test.jsx
@@ -18,18 +18,12 @@ describe("SwitchField", () => {
     await user.click(screen.getByRole("checkbox"));
     expect(onChange).toHaveReturnedWith(expected);
   });
-  it("can be uncontrolled and have a defaultChecked prop", async () => {
-    const user = userEvent.setup();
-    const onChange = vi.fn(event => event.target.checked);
-    render(
-      <SwitchField
-        defaultChecked={true}
-        options={["Option A", "Option B"]}
-        onChange={onChange}
-      />
+  it("can be uncontrolled and have a defaultChecked prop", () => {
+    const { container } = render(
+      <SwitchField defaultChecked={true} options={["Option A", "Option B"]} />
     );
-    await user.click(screen.getByRole("checkbox"));
-    expect(onChange).toHaveReturnedWith(false);
+    const switchInput = container.querySelector("input");
+    expect(switchInput.checked).toBeTruthy();
   });
   it("renders helper text when provided", () => {
     render(

--- a/src/SwitchField/SwitchField.test.jsx
+++ b/src/SwitchField/SwitchField.test.jsx
@@ -18,6 +18,19 @@ describe("SwitchField", () => {
     await user.click(screen.getByRole("checkbox"));
     expect(onChange).toHaveReturnedWith(expected);
   });
+  it("can be uncontrolled and have a defaultChecked prop", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn(event => event.target.checked);
+    render(
+      <SwitchField
+        defaultChecked={true}
+        options={["Option A", "Option B"]}
+        onChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole("checkbox"));
+    expect(onChange).toHaveReturnedWith(false);
+  });
   it("renders helper text when provided", () => {
     render(
       <SwitchField

--- a/src/SwitchField/SwitchField.test.jsx
+++ b/src/SwitchField/SwitchField.test.jsx
@@ -23,7 +23,7 @@ describe("SwitchField", () => {
       <SwitchField defaultChecked={true} options={["Option A", "Option B"]} />
     );
     const switchInput = container.querySelector("input");
-    expect(switchInput.checked).toBeTruthy();
+    expect(switchInput.checked).toBe(true);
   });
   it("renders helper text when provided", () => {
     render(

--- a/src/SwitchField/index.ts
+++ b/src/SwitchField/index.ts
@@ -1,15 +1,45 @@
 import SwitchField from "./SwitchField";
 import type { SwitchProps } from "@mui/material";
 
+/**
+ * Prop type for switch fields
+ */
 export type SwitchFieldProps = {
+  /**
+   * Is the switch checked by the user
+   */
   checked?: boolean;
+  /**
+   * Is the switch checked by default
+   */
   defaultChecked?: boolean;
+  /**
+   * Is the switch disabled
+   */
   disabled?: boolean;
+  /**
+   * The helper text for the switch
+   */
   helperText?: string;
+  /**
+   * The label for the switch
+   */
   label?: string;
+  /**
+   * The name of the switch
+   */
   name?: string;
+  /**
+   * Function to call when the switch changes
+   */
   onChange: SwitchProps["onChange"];
+  /**
+   * The two toggle options for the switch
+   */
   options?: [string, string];
+  /**
+   * The size of the switch
+   */
   size?: "small" | "medium";
 };
 

--- a/src/SwitchField/index.ts
+++ b/src/SwitchField/index.ts
@@ -32,7 +32,7 @@ export type SwitchFieldProps = {
   /**
    * Function to call when the switch changes
    */
-  onChange: SwitchProps["onChange"];
+  onChange?: SwitchProps["onChange"];
   /**
    * The two toggle options for the switch
    */

--- a/src/SwitchField/index.ts
+++ b/src/SwitchField/index.ts
@@ -3,6 +3,7 @@ import type { SwitchProps } from "@mui/material";
 
 export type SwitchFieldProps = {
   checked?: boolean;
+  defaultChecked?: boolean;
   disabled?: boolean;
   helperText?: string;
   label?: string;

--- a/src/SwitchField/index.ts
+++ b/src/SwitchField/index.ts
@@ -7,6 +7,7 @@ export type SwitchFieldProps = {
   disabled?: boolean;
   helperText?: string;
   label?: string;
+  name?: string;
   onChange: SwitchProps["onChange"];
   options?: [string, string];
   size?: "small" | "medium";

--- a/src/TextField/TextField.stories.tsx
+++ b/src/TextField/TextField.stories.tsx
@@ -31,6 +31,10 @@ const Template: StoryFn<TextFieldProps> = args => {
   );
 };
 
+const UncontrolledTemplate: StoryFn<TextFieldProps> = args => {
+  return <TextField {...args} defaultValue={args.defaultValue} />;
+};
+
 // masked input to be in the form of 225/60R16
 const MaskedTextField = React.forwardRef((props, ref) => (
   <MaskedInput
@@ -83,6 +87,22 @@ export const Default = {
   },
 
   render: Template
+};
+
+export const UncontrolledDefault = {
+  args: {
+    defaultValue: "Uncontrolled",
+    disabled: false,
+    helperText: "What are you going to type?",
+    isFieldMasked: false,
+    label: "Enter some text here",
+    margin: "normal",
+    required: false,
+    size: "medium",
+    variant: "outlined"
+  },
+
+  render: UncontrolledTemplate
 };
 
 export const TextFieldWithMaskEnabled = {

--- a/src/TextField/TextField.stories.tsx
+++ b/src/TextField/TextField.stories.tsx
@@ -26,13 +26,20 @@ const Template: StoryFn<TextFieldProps> = args => {
     setError(event.target.value.indexOf("_") > 0);
     action("onChange")(event, event.target.value);
   };
-  return (
-    <TextField {...args} onChange={onChange} value={value} error={error} />
-  );
-};
 
-const UncontrolledTemplate: StoryFn<TextFieldProps> = args => {
-  return <TextField {...args} defaultValue={args.defaultValue} />;
+  const onBlur = () => {
+    action("onBlur")();
+  };
+
+  return (
+    <TextField
+      {...args}
+      onBlur={onBlur}
+      onChange={onChange}
+      value={value}
+      error={error}
+    />
+  );
 };
 
 // masked input to be in the form of 225/60R16
@@ -97,12 +104,13 @@ export const UncontrolledDefault = {
     isFieldMasked: false,
     label: "Enter some text here",
     margin: "normal",
+    onBlur: action("onBlur"),
     required: false,
     size: "medium",
     variant: "outlined"
   },
 
-  render: UncontrolledTemplate
+  render: TextField
 };
 
 export const TextFieldWithMaskEnabled = {

--- a/src/TextField/TextField.test.tsx
+++ b/src/TextField/TextField.test.tsx
@@ -30,6 +30,13 @@ describe("TextField", () => {
     inputBase.value && expect(inputBase.value).toBe("Hello World");
   });
 
+  test("textfield default value", () => {
+    const { getByRole } = render(<TextField defaultValue="uncontrolled" />);
+    const input = getByRole("textbox") as HTMLInputElement;
+
+    expect(input).toHaveValue("uncontrolled");
+  });
+
   test("shows error state", () => {
     const { container } = render(<TextField error />);
     const inputBase = container.querySelector(".MuiInputBase-root");

--- a/src/TextField/TextField.test.tsx
+++ b/src/TextField/TextField.test.tsx
@@ -106,4 +106,14 @@ Line 5`
 
     expect(textarea).toHaveValue(`Line 1\nLine 2\nLine 3\nLine 4\nLine 5`);
   });
+
+  it("can use an onBlur callback", async () => {
+    const onBlur = vi.fn();
+
+    render(<TextField onBlur={onBlur} />);
+
+    await userEvent.click(screen.getByRole("textbox"));
+    await userEvent.tab();
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -17,6 +17,7 @@ MaskedTextField.displayName = "MaskedTextField";
  * TextField components are used for collecting user provided information as a string.
  */
 export default function TextField({
+  defaultValue,
   disabled = false,
   error = false,
   InputProps = { inputComponent: MaskedTextField },
@@ -26,6 +27,7 @@ export default function TextField({
   multiline = false,
   minRows = 2,
   maxRows = 4,
+  name,
   onChange = () => {},
   placeholder,
   required = false,
@@ -38,6 +40,7 @@ export default function TextField({
   return (
     <MuiTextField
       data-testid="text-field"
+      defaultValue={defaultValue}
       disabled={disabled}
       error={error}
       fullWidth
@@ -47,6 +50,7 @@ export default function TextField({
       multiline={multiline}
       minRows={multiline ? minRows : undefined}
       maxRows={multiline ? maxRows : undefined}
+      name={name}
       onChange={onChange}
       placeholder={placeholder}
       InputProps={!isFieldMasked ? undefined : InputProps}

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -28,6 +28,7 @@ export default function TextField({
   minRows = 2,
   maxRows = 4,
   name,
+  onBlur = () => {},
   onChange = () => {},
   placeholder,
   required = false,
@@ -51,6 +52,7 @@ export default function TextField({
       minRows={multiline ? minRows : undefined}
       maxRows={multiline ? maxRows : undefined}
       name={name}
+      onBlur={onBlur}
       onChange={onChange}
       placeholder={placeholder}
       InputProps={!isFieldMasked ? undefined : InputProps}

--- a/src/TextField/TextField.types.ts
+++ b/src/TextField/TextField.types.ts
@@ -28,6 +28,10 @@ export type TextFieldProps = {
    */
   isFieldMasked?: boolean;
   /**
+   * Callback fired on blur.
+   */
+  onBlur?: () => void;
+  /**
    * Callback fired when the value changes.
    */
   onChange?: (

--- a/src/TextField/TextField.types.ts
+++ b/src/TextField/TextField.types.ts
@@ -1,5 +1,9 @@
 export type TextFieldProps = {
   /**
+   * Default value for uncontrolled use
+   */
+  defaultValue?: string;
+  /**
    * If true, the component is disabled.
    */
   disabled?: boolean;
@@ -15,6 +19,10 @@ export type TextFieldProps = {
    * If true, multiline will be enabled.
    */
   multiline?: boolean;
+  /**
+   * Field name
+   */
+  name?: string;
   /**
    * If true, text field will be masked.
    */


### PR DESCRIPTION
Closes TD-2588

## Changes

Add props to RUI components to make inputs optionally controlled or uncontrolled.

This pull request will allow us to use each input in an uncontrolled manner for new validated form components. The name field allows the validation library to manage the input fields.

- Add defaultValues/defaultChecked and a name prop to the following components
- Checkbox
- RadioGroup
- TextField
- Switch
- Autocomplete

## UI/UX

No changes

## Testing notes

View the uncontrolled stories in storybook. All components should function as normal and the initial render should render the defaultValue.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
