### PR TITLE
TD-2716 TabPanel - Add functionality to allow custom button in tab

### DIFF
--- a/src/TabPanel/TabPanel.spec.tsx
+++ b/src/TabPanel/TabPanel.spec.tsx
@@ -59,6 +59,43 @@ test("should switch content when tabs are clicked", async ({ page }) => {
 });
 
 /**
+ * Test to verify the aria-label attribute based on the variant prop.
+ */
+test("should set the aria-label attribute based on the variant prop", async ({
+  page
+}) => {
+  // Go to the default variant page
+  await page.goto(
+    "http://localhost:6006/?path=/story/layout-tabpanel--default"
+  );
+  await page.waitForSelector('iframe[title="storybook-preview-iframe"]');
+
+  // Verify 'full width tabs' aria-label on default variant
+  const fullWidthFrame = page.frameLocator(
+    'iframe[title="storybook-preview-iframe"]'
+  );
+  await expect(fullWidthFrame.locator('[role="tablist"]')).toHaveAttribute(
+    "aria-label",
+    "full width tabs"
+  );
+
+  // Go to the standard variant page
+  await page.goto(
+    "http://localhost:6006/?path=/story/layout-tabpanel--standard"
+  );
+  await page.waitForSelector('iframe[title="storybook-preview-iframe"]');
+
+  // Verify 'standard width tabs' aria-label on standard variant
+  const standardWidthFrame = page.frameLocator(
+    'iframe[title="storybook-preview-iframe"]'
+  );
+  await expect(standardWidthFrame.locator('[role="tablist"]')).toHaveAttribute(
+    "aria-label",
+    "standard width tabs"
+  );
+});
+
+/**
  * Test to check custom children are rendered correctly.
  */
 test("should render custom children", async ({ page }) => {

--- a/src/TabPanel/TabPanel.spec.tsx
+++ b/src/TabPanel/TabPanel.spec.tsx
@@ -57,3 +57,19 @@ test("should switch content when tabs are clicked", async ({ page }) => {
       .first()
   ).not.toBeVisible();
 });
+
+/**
+ * Test to check custom children are rendered correctly.
+ */
+test("should render custom children", async ({ page }) => {
+  await page.goto(
+    "http://localhost:6006/?path=/story/layout-tabpanel--custom-children"
+  );
+
+  // Verify that the custom children are rendered, in this case a ADD TO DOWNLOAD button
+  await expect(
+    page
+      .frameLocator('iframe[title="storybook-preview-iframe"]')
+      .getByRole("button", { name: "ADD TO DOWNLOAD" })
+  ).toBeVisible();
+});

--- a/src/TabPanel/TabPanel.stories.tsx
+++ b/src/TabPanel/TabPanel.stories.tsx
@@ -1,4 +1,4 @@
-import { Box, TextField } from "@mui/material";
+import { Box, Button, TextField } from "@mui/material";
 import { Meta, StoryFn } from "@storybook/react";
 
 import React from "react";
@@ -85,6 +85,122 @@ export const Default = {
         </Box>
       </Box>
     ]
+  },
+  render: Template
+};
+
+// Standard
+export const Standard = {
+  args: {
+    children: [
+      <Box data-label="Select Vehicle" key="1">
+        <Box sx={{ display: "flex", flexDirection: "row" }}>
+          <TextField
+            label="Project Code*"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+          <TextField
+            label="Model Year"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+        </Box>
+        <Box sx={{ display: "flex", flexDirection: "row" }}>
+          <TextField
+            label="Variant"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+        </Box>
+      </Box>,
+      <Box data-label="Select Part" key="2">
+        <Box sx={{ display: "flex" }}>
+          <TextField
+            label="Part Name*"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+        </Box>
+        <Box sx={{ display: "flex" }}>
+          <TextField
+            label="Part Number*"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+        </Box>
+      </Box>
+    ],
+    variant: "standard"
+  },
+  render: Template
+};
+
+// Custom Children
+export const CustomChildren = {
+  args: {
+    children: [
+      <Box data-label="Select Vehicle" key="1">
+        <Box sx={{ display: "flex", flexDirection: "row" }}>
+          <TextField
+            label="Project Code*"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+          <TextField
+            label="Model Year"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+        </Box>
+        <Box sx={{ display: "flex", flexDirection: "row" }}>
+          <TextField
+            label="Variant"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+        </Box>
+      </Box>,
+      <Box data-label="Select Part" key="2">
+        <Box sx={{ display: "flex" }}>
+          <TextField
+            label="Part Name*"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+        </Box>
+        <Box sx={{ display: "flex" }}>
+          <TextField
+            label="Part Number*"
+            variant="outlined"
+            margin="normal"
+            sx={{ ml: 1 }}
+          />
+        </Box>
+      </Box>
+    ],
+    customChildren: (
+      <>
+        <Box flexGrow={1} />
+        <Button
+          color="primary"
+          sx={{ color: "#003063", minWidth: "100px" }}
+          onClick={() => {}}
+        >
+          ADD TO DOWNLOAD
+        </Button>
+      </>
+    ),
+    variant: "standard"
   },
   render: Template
 };

--- a/src/TabPanel/TabPanel.tsx
+++ b/src/TabPanel/TabPanel.tsx
@@ -36,6 +36,12 @@ const TabPanel = ({
     }
   };
 
+  // map the variant to the aria label
+  const variantToAriaLabel = {
+    fullWidth: "full width tabs",
+    standard: "standard width tabs"
+  };
+
   return (
     <Box>
       <Tabs
@@ -43,7 +49,7 @@ const TabPanel = ({
         onChange={handleChange}
         indicatorColor="primary"
         variant={variant}
-        aria-label="full width tabs"
+        aria-label={variantToAriaLabel[variant]}
         sx={{ borderBottom: 1, borderColor: "divider" }}
       >
         {React.Children.map(children, (child, index) => {

--- a/src/TabPanel/TabPanel.tsx
+++ b/src/TabPanel/TabPanel.tsx
@@ -11,7 +11,13 @@ import { TabPanelProps } from "./TabPanel.types";
  * @property active - The active tab index
  * @returns The tab panel component
  */
-const TabPanel = ({ children, active, onTabChange }: TabPanelProps) => {
+const TabPanel = ({
+  children,
+  active,
+  variant = "fullWidth",
+  onTabChange,
+  customChildren
+}: TabPanelProps) => {
   // state for the active tab
   const [activeTab, setActiveTab] = useState(active ?? 0);
 
@@ -36,7 +42,7 @@ const TabPanel = ({ children, active, onTabChange }: TabPanelProps) => {
         value={activeTab}
         onChange={handleChange}
         indicatorColor="primary"
-        variant="fullWidth"
+        variant={variant}
         aria-label="full width tabs"
         sx={{ borderBottom: 1, borderColor: "divider" }}
       >
@@ -51,6 +57,7 @@ const TabPanel = ({ children, active, onTabChange }: TabPanelProps) => {
             />
           );
         })}
+        {customChildren}
       </Tabs>
       {React.Children.map(children, (child, index) => {
         if (!React.isValidElement(child)) return null;

--- a/src/TabPanel/TabPanel.types.ts
+++ b/src/TabPanel/TabPanel.types.ts
@@ -7,6 +7,10 @@ export type TabPanelProps = {
    */
   children: React.ReactNode;
   /**
+   * Custom children to be rendered in the tab panel.
+   */
+  customChildren?: React.ReactNode;
+  /**
    * The active tab index, this is the tab which is currently selected.
    */
   active: number;
@@ -14,4 +18,8 @@ export type TabPanelProps = {
    * The callback function that is called when the active tab changes.
    */
   onTabChange?: (newActiveTab: number) => void;
+  /**
+   * The variant of the tab panel. This can be either "standard" or "fullWidth".
+   */
+  variant?: "standard" | "fullWidth";
 };


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-2716](https://sce.myjetbrains.com/youtrack/issue/TD-2716)

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->


This PR introduces two new props to the TabPanel component:

variant: This prop allows the user to specify the variant of the Tabs component within the TabPanel. The variant prop is passed down to the Tabs components, allowing tabs to be styled as "fullWidth" or "standard".

customChildren: This prop allows the user to pass custom children to the TabPanel component. The customChildren prop is rendered in the TabPanel component, allowing the user to add custom content to the panel. Such as a button which is not a tab.

### **PLEASE NOTE:**

- After approval the component will be tested in VIRTO via pre-release.
- Failed end-to-end test are a known issue.

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->
_Full width variant tabs_
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/ab69acbb-423e-4386-b5b0-32b1a9894233)

_Standard variant tabs_
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/1be04a89-f839-4b6f-9c29-cc6dd6d5a71f)

_Custom Add to download button_
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/759873a9-c26b-4873-9d4c-f0c1c02f45a5)

Use case:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/d0ef7b77-5289-40f6-ade5-254b92f36839)


## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

To test the variant and customChildren props in the TabPanel component, follow these steps:

1. Testing the variant prop:

    - Open the Storybook by running `npm run storybook` in your terminal.
    - Navigate to the `TabPanel` component stories.
    - Select the standard story which has the usage of the variant prop.
    - In this story, the `TabPanel` component should display tabs with smaller width. Verify that the tabs' styles change as expected when you change the variant prop value. ["fullWidth", "standard"]

2. Testing the customChildren prop:

    - Still in the Storybook, select the custom children story which has usage of the customChildren prop.
    - In this story, the TabPanel component should display the custom content passed to the customChildren prop, which is the download button. Verify that the custom content is displayed as expected.
    - You can change the customChildren prop value in the stories code to verify that the displayed custom content changes accordingly.


## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
~~- [ ] Branch has been run in docker.~~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
