### PR TITLE
Deprecate string[] syntax for acceptedFiles

### DIFF
--- a/src/FileUploader/FileUploader.stories.tsx
+++ b/src/FileUploader/FileUploader.stories.tsx
@@ -46,7 +46,6 @@ export default meta;
 type Story = StoryObj<typeof FileUploader>;
 export const Default: Story = {
   args: {
-    acceptedFiles: [],
     dropzoneText: "Drag & drop a file here or click",
     filesLimit: 1,
     isValidating: false,
@@ -67,6 +66,9 @@ export const Default: Story = {
 export const WithSingleFileSelected: Story = {
   args: {
     ...Default.args,
+    acceptedFiles: {
+      "application/zip": [".zip"]
+    },
     selectedFiles: [
       {
         data: "",
@@ -82,6 +84,9 @@ export const WithSingleFileSelected: Story = {
 export const WithSingleFileSelectedAndId: Story = {
   args: {
     ...Default.args,
+    acceptedFiles: {
+      "application/zip": [".zip"]
+    },
     selectedFiles: [
       {
         data: "",

--- a/src/FileUploader/FileUploader.tsx
+++ b/src/FileUploader/FileUploader.tsx
@@ -30,16 +30,6 @@ export default function FileUploader({
   titleVariant,
   subText
 }: FileUploaderProps) {
-  // handle acceptedFiles format
-  // react-dropzone accepts an object of mime types as keys and an array of file extensions as values https://react-dropzone.js.org/#!/Dropzone
-  // in the past we accepted an array of mimetypes/ file extensions, so we need to handle both formats for now
-  // TODO: remove support for array of mimetypes/ file extensions
-  if (Array.isArray(acceptedFiles)) {
-    acceptedFiles = {
-      "": acceptedFiles // this will result in a console warning when the filepicker is launched, and won't restrict the accepted file types in the file picker. react-dropzone will still validate correctly on selection though.
-    };
-  }
-
   // useUploader is a custom hook that handles the logic for uploading files
   const {
     getRootProps,

--- a/src/FileUploader/FileUploader.types.ts
+++ b/src/FileUploader/FileUploader.types.ts
@@ -6,7 +6,7 @@ export type FileUploaderProps = {
   /**
    *  List of file types to accept.
    */
-  acceptedFiles?: string[] | Accept;
+  acceptedFiles?: Accept;
   /**
    * If true, the dropzone will be in the error state. When false, the dropzone will be in the default state and internal validation will still be applied. i.e. the dropzone will still reject files that do not meet the acceptedFiles or maxFileSize criteria.
    */

--- a/src/Uploader/useUploader.ts
+++ b/src/Uploader/useUploader.ts
@@ -7,7 +7,7 @@ import { readAsDataURL } from "../utils/readAsDataURL";
 
 /**
  * Hook to handle file selection logic for uploaders. It is a wrapper around react-dropzone.
- * @param acceptedFiles - Array of allowed file types
+ * @param acceptedFiles - Definition of acceptable file mime types and extensions
  * @param maxFileSize - Maximum allowed file size in bytes
  * @param multiple - Whether multiple files can be selected
  * @param filesLimit - Maximum number of files that can be selected
@@ -42,10 +42,10 @@ export default function useUploader({
   }, [rejectionMessage]);
 
   // handle file drops by reading them as data URLs, and adding them to the selected files
-  const onDropAccepted = async (acceptedFiles: File[]) => {
+  const onDropAccepted = async (droppedFiles: File[]) => {
     // append preview data to file
     const fileWithPreview = await Promise.all(
-      acceptedFiles.map(async f => ({
+      droppedFiles.map(async f => ({
         data: await readAsDataURL(f),
         file: f
       }))


### PR DESCRIPTION
## Changes

Breaking change.

Deprecates the old syntax for the `acceptedFiles` property of the `<FileUploader />` component.

The old syntax allowed a string[] of file extensions to be passed. Newer versions of the underlying react-dropzone dependency no longer support this instead opting to match the standard syntax defined [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/showOpenFilePicker#specifications) and [here](https://react-dropzone.js.org/#!/Dropzone). This newer syntax required that mime-types are present, and takes the form of an object of mime-types vs. extensions.

Instead of 
```ts
{
   acceptedFiles: [".txt", ".csv"]
}
```

the correct syntax would now be
```ts
{
   acceptedFiles: {
      "text/plain": [".txt"],
      "text/csv": [".csv"]
   }
}
```

For a while we've been supporting both syntaxes, with the caveat that the string[] results in console warnings.
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/27866636/dfb6f08e-fbeb-4a61-ad43-57f7e7416995)

We will no longer support this.

The `<ImageUploader />` component has always used the updated syntax correctly.

## Testing notes

No functional change. We should see no console warnings like the screenshot above. 

## Release notes
- Deprecated the `string[]` syntax for the `acceptedFiles` property of the `<FileUploader />` component. This results in console.warnings due to unknown mime-types. See the [documentation](https://react-dropzone.js.org/#!/Dropzone) for the `accept` property in react-dropzone for more detail.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] ~Branch has been run in docker.~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] ~Appropriate tests have been added.~
- [x] Lint and test workflows pass.
