### PR TITLE
File uploader title and delete icon alignment

### DIFF
--- a/src/Uploader/UploaderHeader.tsx
+++ b/src/Uploader/UploaderHeader.tsx
@@ -39,7 +39,7 @@ export default function UploaderHeader({
     };
   } else if (titleVariant === "body") {
     titleTypographyProps = {
-      variant: "body2"
+      variant: "body1"
     };
   }
 
@@ -48,7 +48,7 @@ export default function UploaderHeader({
       gap={2}
       flexDirection="row"
       justifyContent="space-between"
-      alignItems="flex-end"
+      alignItems="center"
       mb={1}
       minHeight="40px"
     >

--- a/src/Uploader/UploaderHeader.tsx
+++ b/src/Uploader/UploaderHeader.tsx
@@ -49,7 +49,7 @@ export default function UploaderHeader({
       flexDirection="row"
       justifyContent="space-between"
       alignItems="center"
-      mb={1}
+      mb={0.5}
       minHeight="40px"
     >
       <Box>
@@ -74,8 +74,8 @@ export default function UploaderHeader({
         </Typography>
       </Box>
       {showDelete ? (
-        <IconButton aria-label="DeleteIcon" onClick={onDelete}>
-          <DeleteIcon color="error" />
+        <IconButton aria-label="DeleteIcon" onClick={onDelete} size="small">
+          <DeleteIcon color="error" fontSize="small" />
         </IconButton>
       ) : null}
     </Stack>


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-2734](https://sce.myjetbrains.com/youtrack/issue/TD-2734/Align-FileUploader-title-and-delete-icon-centrally)

FIxing this [PR ](https://github.com/IPG-Automotive-UK/virto/pull/710#issuecomment-2102283563) feedback

## Changes

- Changed titleVariant body font size `body2` to `body1` as per figma
- Making uploader title and delete icon vertically central aligned


## UI/UX
@Sowbhagya-ipg 
Figma https://www.figma.com/file/0CVK945S1cs1ku0sUXcgv7/VIRTO.SCENE?type=design&node-id=2875-43915&mode=design&t=PVp626pSIo13y12G-0
Before
![Screenshot (454)](https://github.com/IPG-Automotive-UK/react-ui/assets/56511816/b8631fae-77f3-4b8b-a4f2-9ab543269d43)

After
![Screenshot (452)](https://github.com/IPG-Automotive-UK/react-ui/assets/56511816/0568cb9d-4e74-4822-b693-4804f6191ac8)


## Testing notes

- Check the file uploader font size is 16px if titleVariant is `body`
- Check title and delete icon vertically central aligned

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] ~Branch has been run in docker.~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] ~Appropriate tests have been added.~
- [x] Lint and test workflows pass.
