### PR TITLE
TD 2737 Create React UI Bullet Gauge component

### DIFF
--- a/src/BulletGauge/BulletGauge.spec.tsx
+++ b/src/BulletGauge/BulletGauge.spec.tsx
@@ -1,30 +1,97 @@
 import { expect, test } from "@playwright/test";
 
-/**
- * Test to check that the bullet gauge is rendered correctly.
- */
-describe("BulletGauge", () => {
-  test("should render the title", async ({ page }) => {
-    await page.goto(
-      "http://localhost:6006/?path=/story/plots-bulletgauge--default"
-    );
+import { getIframeContext } from "../utils/common";
 
-    await expect(page.getByText("Data Maturity")).toBeVisible();
-  });
+test("should render the title", async ({ page }) => {
+  await page.goto(
+    "http://localhost:6006/?path=/story/plots-bulletgauge--default"
+  );
 
-  test("should render the value", async ({ page }) => {
-    await page.goto(
-      "http://localhost:6006/?path=/story/plots-bulletgauge--default"
-    );
+  // Get the iframe context
+  const iframe = await getIframeContext(page);
 
-    await expect(page.getByText("30")).toBeVisible();
-  });
+  // Wait for elements are loaded
+  await iframe.waitForTimeout(5000);
 
-  test("should render the suffix", async ({ page }) => {
-    await page.goto(
-      "http://localhost:6006/?path=/story/plots-bulletgauge--default"
-    );
+  // Get the text content of the element with the text 'Data Maturity'
+  const titleText = await iframe.textContent("text=Data Maturity");
 
-    await expect(page.getByText("%")).toBeVisible();
-  });
+  // Check if the title is rendered
+  expect(titleText).toBeTruthy();
 });
+
+test("should render the value", async ({ page }) => {
+  await page.goto(
+    "http://localhost:6006/?path=/story/plots-bulletgauge--default"
+  );
+
+  // Get the iframe context
+  const iframe = await getIframeContext(page);
+
+  // Wait for elements are loaded
+  await iframe.waitForTimeout(5000);
+
+  // Get the text content of the element with the class 'numbers'
+  const numbersText = await iframe
+    .locator(
+      "div.plot-container.plotly svg.main-svg g.indicatorlayer g.trace g.numbers text"
+    )
+    .textContent();
+
+  // Check if the value is rendered
+  expect(numbersText).toContain("30");
+});
+
+test("should render the suffix", async ({ page }) => {
+  await page.goto(
+    "http://localhost:6006/?path=/story/plots-bulletgauge--default"
+  );
+
+  // Get the iframe context
+  const iframe = await getIframeContext(page);
+
+  // Wait for elements are loaded
+  await iframe.waitForTimeout(5000);
+
+  // Get the text content of the element with the text '%'
+  const suffixText = await iframe.textContent("text=%");
+
+  // Check if the suffix is rendered
+  expect(suffixText).toBeTruthy();
+});
+
+// Define the test cases with the value and expected color
+const testCases = [
+  { expectedColor: "rgb(211, 47, 47)", value: 29 }, // red
+  { expectedColor: "rgb(237, 108, 2)", value: 30 }, // orange
+  { expectedColor: "rgb(237, 108, 2)", value: 70 }, // orange
+  { expectedColor: "rgb(46, 125, 50)", value: 71 } // green
+];
+
+// iterate over test cases
+for (const testCase of testCases) {
+  test(`should render the gauge with correct colour for value ${testCase.value}`, async ({
+    page
+  }) => {
+    // Navigate to the specific story or dynamically set the value if possible
+    await page.goto(
+      `http://localhost:6006/?path=/story/plots-bulletgauge--default&args=value:${testCase.value}`
+    );
+
+    // Get the iframe context
+    const iframe = await getIframeContext(page);
+
+    // Wait for elements to load
+    await iframe.waitForTimeout(5000);
+
+    // Use a specific path to locate the 'value-bullet' rect in the SVG
+    const rectStyle = await iframe
+      .locator(
+        "div.plot-container.plotly svg.main-svg g.indicatorlayer g.trace g.bullet g.value-bullet > rect"
+      )
+      .getAttribute("style");
+
+    // Check if the fill color is as expected
+    expect(rectStyle).toContain(`fill: ${testCase.expectedColor};`);
+  });
+}

--- a/src/BulletGauge/BulletGauge.spec.tsx
+++ b/src/BulletGauge/BulletGauge.spec.tsx
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { getIframeContext } from "../utils/common";
 
 test("should render the title", async ({ page }) => {
+  // Navigate to the page
   await page.goto(
     "http://localhost:6006/?path=/story/plots-bulletgauge--default"
   );
@@ -43,6 +44,7 @@ test("should render the value", async ({ page }) => {
 });
 
 test("should render the suffix", async ({ page }) => {
+  // Navigate to the page
   await page.goto(
     "http://localhost:6006/?path=/story/plots-bulletgauge--default"
   );
@@ -58,6 +60,31 @@ test("should render the suffix", async ({ page }) => {
 
   // Check if the suffix is rendered
   expect(suffixText).toBeTruthy();
+});
+
+test("should cap the displayed value at 100 even if a higher value is supplied", async ({
+  page
+}) => {
+  // Navigate to the page with a BulletGauge value of 125
+  await page.goto(
+    "http://localhost:6006/?path=/story/plots-bulletgauge--default&args=value:125"
+  );
+
+  // Get the iframe context
+  const iframe = await getIframeContext(page);
+
+  // Wait for elements to load
+  await iframe.waitForTimeout(5000);
+
+  // Extract the text content of the 'numbers' element
+  const numbersText = await iframe
+    .locator(
+      "div.plot-container.plotly svg.main-svg g.indicatorlayer g.trace g.numbers text"
+    )
+    .textContent();
+
+  // Verify that the displayed value is capped at 100
+  expect(numbersText).toContain("100");
 });
 
 // Define the test cases with the value and expected color

--- a/src/BulletGauge/BulletGauge.spec.tsx
+++ b/src/BulletGauge/BulletGauge.spec.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Test to check that the bullet gauge is rendered correctly.
+ */
+describe("BulletGauge", () => {
+  test("should render the title", async ({ page }) => {
+    await page.goto(
+      "http://localhost:6006/?path=/story/plots-bulletgauge--default"
+    );
+
+    await expect(page.getByText("Data Maturity")).toBeVisible();
+  });
+
+  test("should render the value", async ({ page }) => {
+    await page.goto(
+      "http://localhost:6006/?path=/story/plots-bulletgauge--default"
+    );
+
+    await expect(page.getByText("30")).toBeVisible();
+  });
+
+  test("should render the suffix", async ({ page }) => {
+    await page.goto(
+      "http://localhost:6006/?path=/story/plots-bulletgauge--default"
+    );
+
+    await expect(page.getByText("%")).toBeVisible();
+  });
+});

--- a/src/BulletGauge/BulletGauge.stories.tsx
+++ b/src/BulletGauge/BulletGauge.stories.tsx
@@ -30,7 +30,6 @@ const Template: StoryFn<BulletGaugeProps> = args => {
 // Default
 export const Default = {
   args: {
-    markers: false,
     suffix: "%",
     title: "Data Maturity",
     value: 30
@@ -41,7 +40,6 @@ export const Default = {
 // High
 export const High = {
   args: {
-    markers: false,
     suffix: "%",
     title: "Progress",
     value: 99
@@ -52,7 +50,6 @@ export const High = {
 // Low
 export const Low = {
   args: {
-    markers: false,
     suffix: "%",
     title: "Progress",
     value: 5

--- a/src/BulletGauge/BulletGauge.stories.tsx
+++ b/src/BulletGauge/BulletGauge.stories.tsx
@@ -1,0 +1,61 @@
+import { Meta, StoryFn } from "@storybook/react";
+
+import BulletGauge from "./BulletGauge";
+import { BulletGaugeProps } from "./BulletGauge.types";
+import React from "react";
+import { useArgs } from "@storybook/preview-api";
+
+/**
+ * Story metadata
+ */
+const meta: Meta<typeof BulletGauge> = {
+  component: BulletGauge,
+  title: "Plots/BulletGauge"
+};
+export default meta;
+
+// Story Template
+const Template: StoryFn<BulletGaugeProps> = args => {
+  // useArgs is a hook that returns the current state of the args object
+  const [{ value }, updateArgs] = useArgs<BulletGaugeProps>();
+
+  // update the args object with the new markers value
+  React.useEffect(() => {
+    updateArgs({ value });
+  }, [value, updateArgs]);
+
+  return <BulletGauge {...args} />;
+};
+
+// Default
+export const Default = {
+  args: {
+    markers: false,
+    suffix: "%",
+    title: "Data Maturity",
+    value: 30
+  },
+  render: Template
+};
+
+// High
+export const High = {
+  args: {
+    markers: false,
+    suffix: "%",
+    title: "Progress",
+    value: 99
+  },
+  render: Template
+};
+
+// Low
+export const Low = {
+  args: {
+    markers: false,
+    suffix: "%",
+    title: "Progress",
+    value: 5
+  },
+  render: Template
+};

--- a/src/BulletGauge/BulletGauge.tsx
+++ b/src/BulletGauge/BulletGauge.tsx
@@ -1,0 +1,73 @@
+import { BulletGaugeProps } from "./BulletGauge.types";
+import Plotly from "react-plotly.js";
+import React from "react";
+import { useTheme } from "@mui/material";
+
+const BulletGauge = ({ title, value, suffix }: BulletGaugeProps) => {
+  // theme hook
+  const theme = useTheme();
+
+  return (
+    <Plotly
+      data={[
+        {
+          domain: { x: [0, 1], y: [0, 1] },
+          gauge: {
+            axis: {
+              range: [null, 100],
+              tickfont: {
+                color: "white",
+                size: 12
+              }
+            },
+            bar: {
+              color: value < 30 ? "#f44336" : value > 70 ? "#4caf50" : "#ff9800"
+            },
+            shape: "bullet"
+          },
+          mode: "gauge+number",
+          number: {
+            font: {
+              color: theme.palette.mode === "light" ? "" : "white",
+              size: 20
+            },
+            suffix: suffix || ""
+          },
+          type: "indicator",
+          value
+        }
+      ]}
+      layout={{
+        font: {
+          size: 16
+        },
+        height: 80,
+        margin: { b: 25, l: 8, r: 0, t: 25 },
+        paper_bgcolor: "rgba(0,0,0,0)",
+        plot_bgcolor: "rgba(0,0,0,0)",
+        title: {
+          font: {
+            color:
+              theme.palette.mode === "light" ? "rgba(0, 0, 0, 0.54)" : "white",
+            size: 12
+          },
+          pad: {
+            l: 8,
+            t: 3
+          },
+          text: title,
+          x: 0,
+          xanchor: "left",
+          y: 1,
+          yanchor: "top"
+        },
+        width: 300
+      }}
+      config={{
+        displayModeBar: false
+      }}
+    />
+  );
+};
+
+export default BulletGauge;

--- a/src/BulletGauge/BulletGauge.tsx
+++ b/src/BulletGauge/BulletGauge.tsx
@@ -3,6 +3,9 @@ import Plotly from "react-plotly.js";
 import React from "react";
 import { useTheme } from "@mui/material";
 
+/**
+ * This component displays a bullet gauge progress indicator.
+ */
 const BulletGauge = ({ title, value, suffix }: BulletGaugeProps) => {
   // theme hook
   const theme = useTheme();

--- a/src/BulletGauge/BulletGauge.tsx
+++ b/src/BulletGauge/BulletGauge.tsx
@@ -7,6 +7,9 @@ const BulletGauge = ({ title, value, suffix }: BulletGaugeProps) => {
   // theme hook
   const theme = useTheme();
 
+  // Limit value to 100
+  const limitedValue = Math.min(value, 100);
+
   return (
     <Plotly
       data={[
@@ -22,7 +25,7 @@ const BulletGauge = ({ title, value, suffix }: BulletGaugeProps) => {
             },
             bar: {
               color:
-                value < 30
+                limitedValue < 30
                   ? theme.palette.error.main
                   : value > 70
                     ? theme.palette.success.main
@@ -39,7 +42,7 @@ const BulletGauge = ({ title, value, suffix }: BulletGaugeProps) => {
             suffix: suffix || ""
           },
           type: "indicator",
-          value
+          value: limitedValue
         }
       ]}
       layout={{

--- a/src/BulletGauge/BulletGauge.tsx
+++ b/src/BulletGauge/BulletGauge.tsx
@@ -21,7 +21,12 @@ const BulletGauge = ({ title, value, suffix }: BulletGaugeProps) => {
               }
             },
             bar: {
-              color: value < 30 ? "#f44336" : value > 70 ? "#4caf50" : "#ff9800"
+              color:
+                value < 30
+                  ? theme.palette.error.main
+                  : value > 70
+                    ? theme.palette.success.main
+                    : theme.palette.warning.main
             },
             shape: "bullet"
           },

--- a/src/BulletGauge/BulletGauge.tsx
+++ b/src/BulletGauge/BulletGauge.tsx
@@ -16,7 +16,7 @@ const BulletGauge = ({ title, value, suffix }: BulletGaugeProps) => {
             axis: {
               range: [null, 100],
               tickfont: {
-                color: "white",
+                color: theme.palette.mode === "light" ? "black" : "white",
                 size: 12
               }
             },
@@ -28,7 +28,7 @@ const BulletGauge = ({ title, value, suffix }: BulletGaugeProps) => {
           mode: "gauge+number",
           number: {
             font: {
-              color: theme.palette.mode === "light" ? "" : "white",
+              color: theme.palette.mode === "light" ? "black" : "white",
               size: 20
             },
             suffix: suffix || ""

--- a/src/BulletGauge/BulletGauge.types.ts
+++ b/src/BulletGauge/BulletGauge.types.ts
@@ -3,7 +3,7 @@
  */
 export type BulletGaugeProps = {
   /**
-   * The value to be displayed on the gauge. The color of the gauge changes based on this value:
+   * The value to be displayed on the gauge. The maximum value is 100. The color of the gauge changes based on this value:
    * - Less than 30: Red
    * - Between 30 and 70: Orange
    * - Greater than 70: Green

--- a/src/BulletGauge/BulletGauge.types.ts
+++ b/src/BulletGauge/BulletGauge.types.ts
@@ -1,0 +1,17 @@
+/**
+ * This type defines the props for the BulletGauge component.
+ */
+export type BulletGaugeProps = {
+  /*
+    The value to be displayed on the gauge.
+  */
+  value: number;
+  /*
+    Title of the plot
+  */
+  title?: string;
+  /*
+    The suffix to be displayed after the value.
+  */
+  suffix?: string;
+};

--- a/src/BulletGauge/BulletGauge.types.ts
+++ b/src/BulletGauge/BulletGauge.types.ts
@@ -3,7 +3,10 @@
  */
 export type BulletGaugeProps = {
   /**
-   * The value to be displayed on the gauge.
+   * The value to be displayed on the gauge. The color of the gauge changes based on this value:
+   * - Less than 30: Red
+   * - Between 30 and 70: Orange
+   * - Greater than 70: Green
    */
   value: number;
   /**

--- a/src/BulletGauge/BulletGauge.types.ts
+++ b/src/BulletGauge/BulletGauge.types.ts
@@ -2,16 +2,16 @@
  * This type defines the props for the BulletGauge component.
  */
 export type BulletGaugeProps = {
-  /*
-    The value to be displayed on the gauge.
-  */
+  /**
+   * The value to be displayed on the gauge.
+   */
   value: number;
-  /*
-    Title of the plot
-  */
+  /**
+   * Title of the plot
+   */
   title?: string;
-  /*
-    The suffix to be displayed after the value.
-  */
+  /**
+   * The suffix to be displayed after the value.
+   */
   suffix?: string;
 };

--- a/src/BulletGauge/BulletGaugeClientOnly.tsx
+++ b/src/BulletGauge/BulletGaugeClientOnly.tsx
@@ -1,0 +1,19 @@
+import React, { Suspense, lazy } from "react";
+
+import { BulletGaugeProps } from "./BulletGauge.types";
+import ClientOnly from "../ClientOnly";
+
+const LazyImportedBulletGauge = lazy(() => import("./BulletGauge"));
+
+/**
+ * BulletGauge component wrapped in ClientOnly for use with server side rendering.
+ */
+export default function BulletGaugeClientOnly(props: BulletGaugeProps) {
+  return (
+    <ClientOnly>
+      <Suspense fallback={<span>Loading...</span>}>
+        <LazyImportedBulletGauge {...props} />
+      </Suspense>
+    </ClientOnly>
+  );
+}

--- a/src/BulletGauge/index.ts
+++ b/src/BulletGauge/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./BulletGauge";
+export type { BulletGaugeProps } from "./BulletGauge.types";

--- a/src/BulletGauge/index.ts
+++ b/src/BulletGauge/index.ts
@@ -1,2 +1,9 @@
-export { default } from "./BulletGauge";
+/**
+ * Export the default export from the BulletGaugeClientOnly module.
+ */
+export { default } from "./BulletGaugeClientOnly";
+
+/**
+ * Export the BulletGaugeProps type from the BulletGauge.types module.
+ */
 export type { BulletGaugeProps } from "./BulletGauge.types";

--- a/src/LinePlot/LinePlot.types.ts
+++ b/src/LinePlot/LinePlot.types.ts
@@ -1,4 +1,4 @@
-export interface LinePlotProps {
+export type LinePlotProps = {
   /*
     markers is a boolean that determines whether or not the points are marked.
   */
@@ -27,4 +27,4 @@ export interface LinePlotProps {
     Label for the Y axis.
   */
   ylabel: string;
-}
+};

--- a/src/LinePlot/LinePlot.types.ts
+++ b/src/LinePlot/LinePlot.types.ts
@@ -1,30 +1,33 @@
+/**
+ * This type defines the props for the LinePlot component.
+ */
 export type LinePlotProps = {
-  /*
-    markers is a boolean that determines whether or not the points are marked.
-  */
+  /**
+   * markers is a boolean that determines whether or not the points are marked.
+   */
   markers?: boolean;
-  /*
-    showTitle is a boolean that determines whether or not the title is shown on main view.
-  */
+  /**
+   *  showTitle is a boolean that determines whether or not the title is shown on main view.
+   */
   showTitle?: boolean;
-  /*
-    Title of the plot
-  */
+  /**
+   *  Title of the plot
+   */
   title?: string;
-  /*
-    Arrays of numbers that represent the X coordinates of the points to be plotted.
-  */
+  /**
+   *  Arrays of numbers that represent the X coordinates of the points to be plotted.
+   */
   xdata: number[];
-  /*
-    Label for the X axis.
-  */
+  /**
+   ** Label for the X axis.
+   */
   xlabel: string;
-  /*
-    Arrays of numbers that represent the Y coordinates of the points to be plotted.
-  */
+  /**
+   * Arrays of numbers that represent the Y coordinates of the points to be plotted.
+   */
   ydata: number[];
-  /*
-    Label for the Y axis.
-  */
+  /**
+   * Label for the Y axis.
+   */
   ylabel: string;
 };

--- a/src/SurfacePlot/SurfacePlot.types.ts
+++ b/src/SurfacePlot/SurfacePlot.types.ts
@@ -1,6 +1,6 @@
 // Surface3D.types.ts
 
-export interface SurfacePlotProps {
+export type SurfacePlotProps = {
   /*
       markers is a boolean that determines whether or not the points are marked.
     */
@@ -37,4 +37,4 @@ export interface SurfacePlotProps {
       Label for the Z axis.
     */
   zlabel: string;
-}
+};

--- a/src/SurfacePlot/SurfacePlot.types.ts
+++ b/src/SurfacePlot/SurfacePlot.types.ts
@@ -1,40 +1,41 @@
-// Surface3D.types.ts
-
+/**
+ * This type defines the props for the SurfacePlot component.
+ */
 export type SurfacePlotProps = {
-  /*
-      markers is a boolean that determines whether or not the points are marked.
-    */
+  /**
+   * markers is a boolean that determines whether or not the points are marked.
+   */
   markers?: boolean;
-  /*
-      showTitle is a boolean that determines whether or not the title is shown on the main view.
-    */
+  /**
+   * showTitle is a boolean that determines whether or not the title is shown on the main view.
+   */
   showTitle?: boolean;
-  /*
-      Title of the plot.
-    */
+  /**
+   * Title of the plot.
+   */
   title?: string;
-  /*
-      Arrays of numbers that represent the X coordinates of the points to be plotted.
-    */
+  /**
+   * Arrays of numbers that represent the X coordinates of the points to be plotted.
+   */
   xdata: number[];
-  /*
-      Label for the X axis.
-    */
+  /**
+   * Label for the X axis.
+   */
   xlabel: string;
-  /*
-      Arrays of numbers that represent the Y coordinates of the points to be plotted.
-    */
+  /**
+   * Arrays of numbers that represent the Y coordinates of the points to be plotted.
+   */
   ydata: number[];
-  /*
-      Label for the Y axis.
-    */
+  /**
+   * Label for the Y axis.
+   */
   ylabel: string;
-  /*
-      2D array of numbers that represent the Z coordinates of the points to be plotted.
-    */
+  /**
+   * 2D array of numbers that represent the Z coordinates of the points to be plotted.
+   */
   zdata: number[][];
-  /*
-      Label for the Z axis.
-    */
+  /**
+   * Label for the Z axis.
+   */
   zlabel: string;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export {
 export { default as TabPanel, type TabPanelProps } from "./TabPanel";
 export { default as LinePlot, type LinePlotProps } from "./LinePlot";
 export { default as SurfacePlot, type SurfacePlotProps } from "./SurfacePlot";
+export { default as BulletGauge, type BulletGaugeProps } from "./BulletGauge";
 export { default as Loading, type LoadingProps } from "./Loading";
 export { default as LoginForm, type LoginFormProps } from "./LoginForm";
 export { default as ModelButton, type ModelButtonProps } from "./ModelButton";

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,4 +1,5 @@
 import { KeyValueOption } from "../Common.types";
+import { Page } from "@playwright/test";
 
 // This function is used to check if an object is of type KeyValueOption
 export function isKeyValueOption(obj: unknown): obj is KeyValueOption {
@@ -11,4 +12,16 @@ export function uniqueSortedArray(array: string[], sortOrder?: "asc" | "desc") {
   return uniqueArray.sort((a, b) =>
     sortOrder === "asc" ? a.localeCompare(b) : b.localeCompare(a)
   );
+}
+
+// Helper function to wait for the iframe and switch to its context
+export async function getIframeContext(page: Page) {
+  const iframeElement = await page.waitForSelector(
+    'iframe[title="storybook-preview-iframe"]'
+  );
+  const iframe = await iframeElement.contentFrame();
+  if (!iframe) {
+    throw new Error("Unable to find or access the iframe content.");
+  }
+  return iframe;
 }


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-2737](https://sce.myjetbrains.com/youtrack/issue/TD-2737)
Contributes to [TD-2030](https://sce.myjetbrains.com/youtrack/issue/TD-2030)

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

This PR introduces a new `BulletGauge` component. This component is a gauge chart that can be used to represent data in a compact, linear format. It's particularly useful for comparing the measure of a primary metric against one or more other metrics.

Features:

- The gauge is rendered using the `react-plotly.js` library.
- The color of the gauge bar changes based on the value: red for values less than 30, green for values greater than 70, and orange for values in between.
- The component accepts title, value, and suffix as props.

Other changes:

- `SurfacePlot` and `LinePlot`
  - Changed interface to type
  - Updated JSDoc comments format as they weren't showing in Docs on storybook



## Dependencies

<!-- Does this branch need to be tested alongside branches from other apps? -->
<!-- Does this branch need to be merged after another Pull Request? -->

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->

Light mode:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/1def5caf-c041-42c6-8432-c8f36da5fab6)

Dark mode:
![image](https://github.com/IPG-Automotive-UK/react-ui/assets/143519265/cb2e687d-f9fe-4468-ad44-386250470f52)

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

_Use case for this component would be VIRTO.DATA > Search > Details_ 

- Visual testing should be performed to ensure the component looks as expected in both light and dark modes.

- Use storybook to change prop values of value and suffix and see changes reflected. 

- Check changes based on the value: red for values less than 30, green for values greater than 70, and orange for values in between.

As playwright test scripts have been removed recently, to run the playwright tests locally you can add the scripts back in:
```
 "test:playwright": "pnpm exec playwright install --with-deps && pnpm run storybook:build && pnpm run storybook:serve:start && pnpm exec playwright test && pnpm run storybook:serve:stop",
 "test:playwright:headed": "pnpm exec playwright install --with-deps && pnpm run storybook:build && pnpm run storybook:serve:start && pnpm exec playwright test --headed && pnpm run storybook:serve:stop",
```

Then run:
`pnpm run test:playwright`
    

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
~~- [ ] Branch has been run in docker.~~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
