### PR TITLE
Fix ImageUploader container's wrong spelled CSS property

### DIFF
--- a/src/ImageUploader/ImageUploader.tsx
+++ b/src/ImageUploader/ImageUploader.tsx
@@ -98,7 +98,7 @@ export default function ImageUploader({
           },
           justifyContent: "center",
           p: 2,
-          pointerEvenets: selectedFiles.length > 0 ? "none" : "auto"
+          pointerEvents: selectedFiles.length > 0 ? "none" : "auto"
         })}
       >
         <input {...getInputProps()} />


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-2765](https://sce.myjetbrains.com/youtrack/issue/TD-2765/Fix-ImageUploader-containers-wrong-spelled-CSS-property)

## Changes

- `pointerEvenets` to `pointerEvents` to restrict user to click on seleced image to upload new one


## Dependencies

## UI/UX


## Testing notes

- Check user is able to upload new image only after deleting uploaded one by clicking on delete button

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] ~Branch has been run in docker.~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] ~Appropriate tests have been added.~
- [ ] Lint and test workflows pass.
