### PR TITLE
VE- 49 React UI updates for x tree view and vi test imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@types/react-text-mask": "^5.4.14",
     "colord": "^2.9.3",
     "konva": "^9.3.11",
-    "material-ui-confirm": "3.0.16",
+    "material-ui-confirm": "3.0.12",
     "material-ui-popup-state": "^5.1.2",
     "plotly.js": "^2.33.0",
     "prop-types": "^15.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ dependencies:
     specifier: ^9.3.11
     version: 9.3.11
   material-ui-confirm:
-    specifier: 3.0.16
-    version: 3.0.16(@mui/material@5.15.19)(react-dom@18.3.1)(react@18.3.1)
+    specifier: 3.0.12
+    version: 3.0.12(@mui/material@5.15.19)(react-dom@18.3.1)(react@18.3.1)
   material-ui-popup-state:
     specifier: ^5.1.2
     version: 5.1.2(@mui/material@5.15.19)(react@18.3.1)
@@ -9712,8 +9712,8 @@ packages:
       react: 18.3.1
     dev: true
 
-  /material-ui-confirm@3.0.16(@mui/material@5.15.19)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-aJoa/FM/U/86qztoljlk8FWmjSJbAMzDWCdWbDqU5WwB0WzcWPyGrhBvIqihR9uKdHKBf1YrvMjn68uOrfsXAg==}
+  /material-ui-confirm@3.0.12(@mui/material@5.15.19)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-qyWxEy2LfoV/j+eywqIPg11RUaynyfhwe4hYEqFxDnpK9kZy8ef8xo7moF74pW95spF/I5VhOJgpPKd/WT9tEA==}
     peerDependencies:
       '@mui/material': '>= 5.0.0'
       react: ^17.0.0 || ^18.0.0

--- a/src/ActionDialog/ActionDialog.test.tsx
+++ b/src/ActionDialog/ActionDialog.test.tsx
@@ -1,9 +1,11 @@
+import "@testing-library/jest-dom/vitest";
+
+import { describe, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import ActionDialog from "./ActionDialog";
 import React from "react";
 import { Typography } from "@mui/material";
-import { vi } from "vitest";
 
 // a set of default inputs so that tests can change what theyre testing
 const defaultInputs = {

--- a/src/Autocomplete/Autocomplete.test.tsx
+++ b/src/Autocomplete/Autocomplete.test.tsx
@@ -1,3 +1,6 @@
+import "@testing-library/jest-dom/vitest";
+
+import { describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 
 import Autocomplete from ".";

--- a/src/ImageUploader/ImageUploader.test.tsx
+++ b/src/ImageUploader/ImageUploader.test.tsx
@@ -1,3 +1,6 @@
+import "@testing-library/jest-dom/vitest";
+
+import { describe, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import { FileWithData } from "../Uploader/Uploader.types";

--- a/src/TreeViewList/TreeViewList.tsx
+++ b/src/TreeViewList/TreeViewList.tsx
@@ -1,6 +1,6 @@
 import { Box, Tooltip, Typography, debounce } from "@mui/material";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { TreeItem, TreeView } from "@mui/x-tree-view";
+import { SimpleTreeView, TreeItem } from "@mui/x-tree-view";
 import { TreeNodeItem, TreeViewListProps } from "./TreeViewList.types";
 
 import AddIcon from "@mui/icons-material/Add";
@@ -234,6 +234,7 @@ const TreeViewList = ({
           <Box
             sx={theme => ({
               background: theme.palette.background.paper,
+              marginRight: 0.2,
               position: "sticky",
               top: 0,
               zIndex: 2
@@ -263,32 +264,33 @@ const TreeViewList = ({
           </Box>
         </Box>
         <Box sx={{ flexGrow: 1, overflowY: "auto" }}>
-          <TreeView
+          <SimpleTreeView
             sx={{
               "& .css-9l5vo-MuiCollapse-wrapperInner": {
                 width: boxWidth <= 280 ? "auto" : "100%"
               }
             }}
-            defaultCollapseIcon={<RemoveIcon />}
-            defaultExpandIcon={<AddIcon />}
-            expanded={expandedNodes}
-            selected={currentSelection}
-            onNodeSelect={(event, nodeId) => {
-              const node = getNodeById(treeDisplayItems, nodeId);
-              const isChild = Boolean(
-                node && (!node.children || node.children.length === 0)
-              );
-              if (onNodeSelect) {
-                const nodeDetails = { isChild };
-                // update the selected node when a node is selected and it is a child
-                if (isChild) {
-                  setCurrentSelection(nodeId);
-                  setSelectedNode(nodeId);
+            slots={{ collapseIcon: RemoveIcon, expandIcon: AddIcon }}
+            expandedItems={expandedNodes}
+            selectedItems={currentSelection}
+            onSelectedItemsChange={(event, nodeId) => {
+              if (nodeId) {
+                const node = getNodeById(treeDisplayItems, nodeId);
+                const isChild = Boolean(
+                  node && (!node.children || node.children.length === 0)
+                );
+                if (onNodeSelect) {
+                  const nodeDetails = { isChild };
+                  // update the selected node when a node is selected and it is a child
+                  if (isChild) {
+                    setCurrentSelection(nodeId);
+                    setSelectedNode(nodeId);
+                  }
+                  onNodeSelect(event, nodeId, nodeDetails);
                 }
-                onNodeSelect(event, nodeId, nodeDetails);
               }
             }}
-            onNodeToggle={(event, nodeId) => {
+            onExpandedItemsChange={(event, nodeId) => {
               // reset the selected node when a node is toggled
               setSelectedNode("");
               // update the user expanded nodes when a node is toggled
@@ -319,7 +321,7 @@ const TreeViewList = ({
                 No data is available.
               </Typography>
             )}
-          </TreeView>
+          </SimpleTreeView>
         </Box>
       </Box>
     </>
@@ -379,6 +381,7 @@ const TooltipTreeItem = (
     >
       <TreeItem
         {...rest}
+        itemId={props.nodeId}
         sx={theme => ({
           color: theme.palette.text.primary,
           paddingY: "5px"


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [VE-49](https://sce.myjetbrains.com/youtrack/issue/VE-49)

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

This PR addresses the following issues:

1. Typescript errors for vi tests - added missing imports which fixed the errors
2. `TreeViewList` - x-tree-view latest dependency update to v7 had breaking changes, these changes are made here
     - Migration notes: https://mui.com/x/migration/migration-tree-view-v6
3. `material-ui-confirm` - had [breaking changes](https://github.com/IPG-Automotive-UK/react-ui/pull/879), reverted back to previous version,  release v8.0.0 will address these

## Dependencies

<!-- Does this branch need to be tested alongside branches from other apps? -->
<!-- Does this branch need to be merged after another Pull Request? -->

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

- Should no longer see errors in vi test files
- TreeViewList should continue to function as intended without any changes to UI or behavior 

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Appropriate tests have been added.
- [x] Lint and test workflows pass.
