### PR TITLE
TD-2813 VersionChip component

### DIFF
--- a/src/VersionChip/VersionChip.stories.tsx
+++ b/src/VersionChip/VersionChip.stories.tsx
@@ -19,7 +19,39 @@ const Template: StoryFn<VersionChipProps> = args => {
 
 export const Default = {
   args: {
+    selected: false,
+    version: "1.0",
+    versionType: "major"
+  },
 
+  render: Template
+};
+
+export const MinorVersion = {
+  args: {
+    selected: false,
+    version: "1.1",
+    versionType: "minor"
+  },
+
+  render: Template
+};
+
+export const MajorVersionSelected = {
+  args: {
+    selected: true,
+    version: "2.0",
+    versionType: "major"
+  },
+
+  render: Template
+};
+
+export const MinorVersionSelected = {
+  args: {
+    selected: true,
+    version: "2.3",
+    versionType: "minor"
   },
 
   render: Template

--- a/src/VersionChip/VersionChip.stories.tsx
+++ b/src/VersionChip/VersionChip.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryFn } from "@storybook/react";
+
+import React from "react";
+import VersionChip from "./VersionChip";
+import { VersionChipProps } from "./VersionChip.types";
+
+/**
+ * Story metadata
+ */
+const meta: Meta<typeof VersionChip> = {
+  component: VersionChip,
+  title: "General/VersionChip"
+};
+export default meta;
+
+const Template: StoryFn<VersionChipProps> = args => {
+  return <VersionChip {...args} />;
+};
+
+export const Default = {
+  args: {
+
+  },
+
+  render: Template
+};

--- a/src/VersionChip/VersionChip.test.tsx
+++ b/src/VersionChip/VersionChip.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import React from "react";
+import VersionChip from "./VersionChip";
+
+describe("VersionChip", () => {
+  // test that the version chip renders
+  it("renders VersionChip", () => {
+    render(<VersionChip version="1.0" versionType="major"></VersionChip>);
+    expect(screen.getByText("1.0")).toBeInTheDocument();
+  });
+  // check major version has correct svg
+  it("renders major svg", () => {
+    render(<VersionChip version="1.0" versionType="major"></VersionChip>);
+    expect(screen.getByTestId("LayersIcon")).toBeInTheDocument();
+  });
+  // check minor version has correct svg
+  it("renders minor svg", () => {
+    render(<VersionChip version="1.0" versionType="minor"></VersionChip>);
+    expect(screen.getByTestId("AccountTreeIcon")).toBeInTheDocument();
+  });
+});

--- a/src/VersionChip/VersionChip.tsx
+++ b/src/VersionChip/VersionChip.tsx
@@ -1,0 +1,6 @@
+import { Chip } from "@mui/material";
+import { VersionChipProps } from "./VersionChip.types";
+
+const VersionChip = () => {}
+
+export default {VersionChip}

--- a/src/VersionChip/VersionChip.tsx
+++ b/src/VersionChip/VersionChip.tsx
@@ -1,6 +1,55 @@
-import { Chip } from "@mui/material";
+import { AccountTree, Layers } from "@mui/icons-material";
+import { Chip, alpha, chipClasses, useTheme } from "@mui/material";
+
+import React from "react";
 import { VersionChipProps } from "./VersionChip.types";
 
-const VersionChip = () => {}
+const VersionChip = ({
+  versionType,
+  version,
+  selected = false
+}: VersionChipProps) => {
+  // text and color for selected chip is a different category based on light vs. dark mode
+  const theme = useTheme();
+  const selectedColor =
+    theme.palette.mode === "dark"
+      ? theme.palette.primary.light
+      : theme.palette.primary.dark;
+  return (
+    <Chip
+      icon={versionType === "major" ? <Layers /> : <AccountTree />}
+      label={version}
+      variant="filled"
+      sx={{
+        [`& .${chipClasses.icon}`]: {
+          color: theme =>
+            selected ? selectedColor : theme.palette.text.primary,
+          height: 14,
+          m: "0",
+          width: 14
+        },
+        [`& .${chipClasses.label}`]: {
+          color: theme =>
+            selected ? selectedColor : theme.palette.text.primary,
+          p: "0"
+        },
+        backgroundColor: theme =>
+          selected
+            ? alpha(theme.palette.info.main, 0.12)
+            : theme.palette.background.default,
+        border: theme =>
+          selected
+            ? `1px solid ${theme.palette.primary.light}`
+            : `1px solid ${theme.palette.divider}`,
+        gap: "2px",
+        height: 24,
+        justifyContent: "center",
+        minWidth: 62,
+        px: "12px",
+        py: "4px"
+      }}
+    />
+  );
+};
 
-export default {VersionChip}
+export default VersionChip;

--- a/src/VersionChip/VersionChip.types.tsx
+++ b/src/VersionChip/VersionChip.types.tsx
@@ -1,14 +1,14 @@
 export type VersionChipProps = {
-    /**
-     * The version change type.
-     */
-    versionType: "major" | "minor";
-    /**
-     * The version number in a format `major.minor`.
-     */
-    version: string;
-    /**
-     * Flag denoting wether version is selected.
-     */
-    selected: boolean
-}
+  /**
+   * The version change type.
+   */
+  versionType: "major" | "minor";
+  /**
+   * The version number in a format "major.minor".
+   */
+  version: string;
+  /**
+   * Flag denoting wether version is selected. Default is 'false'.
+   */
+  selected?: boolean;
+};

--- a/src/VersionChip/VersionChip.types.tsx
+++ b/src/VersionChip/VersionChip.types.tsx
@@ -1,0 +1,14 @@
+export type VersionChipProps = {
+    /**
+     * The version change type.
+     */
+    versionType: "major" | "minor";
+    /**
+     * The version number in a format `major.minor`.
+     */
+    version: string;
+    /**
+     * Flag denoting wether version is selected.
+     */
+    selected: boolean
+}

--- a/src/VersionChip/index.ts
+++ b/src/VersionChip/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./VersionChip"
-export type {VersionChipProps} from "./VersionChip.types"
+export { default } from "./VersionChip";
+export type { VersionChipProps } from "./VersionChip.types";

--- a/src/VersionChip/index.ts
+++ b/src/VersionChip/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./VersionChip"
+export type {VersionChipProps} from "./VersionChip.types"

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export {
   default as FeedbackForm,
   type FeedbackFormProps
 } from "./FeedbackForm";
+export {default as VersionChip, type VersionChipProps} from "./VersionChip";
 export {
   default as FileUploader,
   type FileUploaderProps


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-2813](https://sce.myjetbrains.com/youtrack/issue/TD-2813) VersionChip component
Contributes to [TD-2784](https://sce.myjetbrains.com/youtrack/issue/TD-2784) Create Versions tab for road details

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

Introduces VersionChip component to RUI.

- Created VersionChip component that displays version name, separate icon for minor vs major, if selected adopts different colour scheme.
- Created storybook page to display VersionChip component and its different configurations
- Included vi-test test to test the VersionChip component.

Maybe a short description of what is not included and will come in future work where appropriate.

## Dependencies

<!-- Does this branch need to be tested alongside branches from other apps? -->
<!-- Does this branch need to be merged after another Pull Request? -->

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->
>[!NOTE]
>The VersionChip component colours differ from Figma, because the palette is not updated in VIRTO and RUI. The palette keys, however, match between Figma and the implementation of the component in RUI.

## Author checklist before assigning a reviewer

- [ ] Reviewed my own code-diff.
- [ ] Branch has been run in docker.
- [ ] PR assigned to me or an appropriate delegate.
- [ ] Relevant labels added to the PR.
- [ ] Appropriate tests have been added.
- [ ] Lint and test workflows pass.
