### PR TITLE
Enhancement - Red asterisk

### DIFF
--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -59,6 +59,13 @@ const defaultTheme: ThemeOptions = {
         }
       }
     },
+    MuiFormLabel: {
+      styleOverrides: {
+        asterisk: {
+          color: "#d32f2f"
+        }
+      }
+    },
     MuiTooltip: {
       styleOverrides: {
         tooltip: {


### PR DESCRIPTION
## Changes

This ensures that required asterisks on fields are rendered in red across the apps. The colour is the same in both light and dark mode and matches the default mui error colour.

- The asterisk was themed in the theme provider 

## UI/UX

![Screenshot 2024-06-11 at 17 32 07](https://github.com/IPG-Automotive-UK/react-ui/assets/143453762/c8d3eb20-d7de-46de-b6d0-4e2ac97c848c)

![Screenshot 2024-06-11 at 17 32 16](https://github.com/IPG-Automotive-UK/react-ui/assets/143453762/00b31ce7-5b69-4dc4-bc65-b49747523156)


## Testing notes

This should be viewable in the TextField multiline story or if a required prop is placed on any MUI input field.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
