### PR TITLE
Bugfix - Fix console error from spreading key prop

### DIFF
--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -108,7 +108,7 @@ function Option<
   // handle key value options rendering
   if (isKeyValueOption(option)) {
     return (
-      <Box component="li" {...props}>
+      <Box component="li" {...props} key={option.key}>
         <Box
           sx={{
             alignItems: "center",
@@ -146,7 +146,7 @@ function Option<
 
   // handle string options rendering
   return (
-    <Box component="li" {...props}>
+    <Box component="li" {...props} key={option}>
       <Box
         sx={{
           alignItems: "center",


### PR DESCRIPTION
## Changes

There is a console error around the spreading of a key prop with Autocomplete options. I believe this was an existing defect. I have resolved it by ensuring the key prop is placed on the option after spreading the props.

- Added the key to the option list whether rendering object data or a string.

## Testing notes

- Trigger the dropdown list on each Autocomplete story and check there are no console errors

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
