### PR TITLE
Remove playwright install from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ COPY package.json pnpm-lock.yaml ./
 # install react-ui dependencies
 RUN pnpm install
 
-# install playwright dependencies - this is also done when we run the tests but we do ahead of time so it's cached and doesn't need to run again if src files in the next layer change
-RUN pnpm exec playwright install --with-deps
-
 # copy all other files to the container (note that ./src files are excluded in .dockerignore as we mount those at runtime with a volume so we can access any updated snapshot artifacts)
 WORKDIR /usr/src/react-ui
 COPY . .


### PR DESCRIPTION
## Changes

Whilst doing other tasks I noticed we are still installing playwright in our Dockerfile used for tests but we no longer run the Playwright tests as of https://github.com/IPG-Automotive-UK/react-ui/pull/861. This step can take around a minute so I've removed it which will speed up all future test action runs.

You can see the time saved by comparing this action run with a previous one.

<img width="1602" alt="image" src="https://github.com/IPG-Automotive-UK/react-ui/assets/8976377/b388869b-af89-4221-8f6d-9f527b87f7a4">


## Dependencies

N/A

## UI/UX

N/A

## Testing notes

Nothing to test. As long as the GitHub action tests still pass then we're all good.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added. (N/A)
- [x] Lint and test workflows pass.
