### PR TITLE
Add deploy-previews and persistent deployment using Chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -31,3 +31,4 @@ jobs:
           #👇 Chromatic projectToken,
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          buildScriptName: "storybook:build"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: 'Chromatic Publish'
+
+# Event for the workflow
+on: push
+
+# List of jobs
+jobs:
+  test:
+    # Operating System
+    runs-on: ubuntu-latest
+    # Job steps
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+      #👇 Adds Chromatic as a step in the workflow
+      - uses: chromaui/action@v1
+        # Options required for Chromatic's GitHub Action
+        with:
+          #👇 Chromatic projectToken,
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ coverage
 /playwright-report/
 /playwright/.cache/
 /test-artifacts/
+*.log

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > React UI component library for IPG web applications
 
-[![Storybook](https://raw.githubusercontent.com/storybookjs/brand/master/badge/badge-storybook.svg)](https://main--666c1309face6e7c27f20e04.chromatic.com/)[![NPM](https://img.shields.io/npm/v/@ipguk/react-ui.svg)](https://www.npmjs.com/package/@ipguk/react-ui) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![Build Status](https://github.com/IPG-Automotive-UK/react-ui/workflows/Tests/badge.svg)](https://github.com/IPG-Automotive-UK/react-ui/actions)
+[![Storybook](https://raw.githubusercontent.com/storybookjs/brand/master/badge/badge-storybook.svg)](https://main--666c1309face6e7c27f20e04.chromatic.com/) [![NPM](https://img.shields.io/npm/v/@ipguk/react-ui.svg)](https://www.npmjs.com/package/@ipguk/react-ui) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![Build Status](https://github.com/IPG-Automotive-UK/react-ui/workflows/Tests/badge.svg)](https://github.com/IPG-Automotive-UK/react-ui/actions)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > React UI component library for IPG web applications
 
-[![NPM](https://img.shields.io/npm/v/@ipguk/react-ui.svg)](https://www.npmjs.com/package/@ipguk/react-ui) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![Build Status](https://github.com/IPG-Automotive-UK/react-ui/workflows/Tests/badge.svg)](https://github.com/IPG-Automotive-UK/react-ui/actions)
+[![Storybook](https://raw.githubusercontent.com/storybookjs/brand/master/badge/badge-storybook.svg)](https://main--666c1309face6e7c27f20e04.chromatic.com/)[![NPM](https://img.shields.io/npm/v/@ipguk/react-ui.svg)](https://www.npmjs.com/package/@ipguk/react-ui) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![Build Status](https://github.com/IPG-Automotive-UK/react-ui/workflows/Tests/badge.svg)](https://github.com/IPG-Automotive-UK/react-ui/actions)
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,14 @@
   "name": "@ipguk/react-ui",
   "version": "7.9.0",
   "description": "React UI component library for IPG web applications",
-  "author": "IPG-Automotive-UK",
+  "author": {
+    "name": "IPG-Automotive-UK"
+  },
   "license": "MIT",
-  "repository": "IPG-Automotive-UK/react-ui",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/IPG-Automotive-UK/react-ui.git"
+  },
   "main": "dist/index",
   "engines": {
     "node": ">=10"
@@ -24,7 +29,8 @@
     "test:lint": "eslint ./src",
     "test:unit": "vitest --run --coverage",
     "test:watch": "vitest",
-    "type-check": "tsc --noEmit --skipLibCheck"
+    "type-check": "tsc --noEmit --skipLibCheck",
+    "chromatic": "npx chromatic --project-token=chpt_f8c356de5be8281 --build-script-name=storybook:build"
   },
   "devDependencies": {
     "@emotion/react": "^11.11.4",
@@ -58,6 +64,7 @@
     "@typescript-eslint/parser": "^7.11.0",
     "@vitejs/plugin-react": "^4.3.0",
     "@vitest/coverage-v8": "^1.6.0",
+    "chromatic": "^11.5.4",
     "colord": "^2.9.3",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
@@ -124,5 +131,9 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/IPG-Automotive-UK/react-ui/issues"
+  },
+  "homepage": "https://github.com/IPG-Automotive-UK/react-ui#readme"
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "test:lint": "eslint ./src",
     "test:unit": "vitest --run --coverage",
     "test:watch": "vitest",
-    "type-check": "tsc --noEmit --skipLibCheck",
-    "chromatic": "npx chromatic --project-token=chpt_f8c356de5be8281 --build-script-name=storybook:build"
+    "type-check": "tsc --noEmit --skipLibCheck"
   },
   "devDependencies": {
     "@emotion/react": "^11.11.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ devDependencies:
   '@vitest/coverage-v8':
     specifier: ^1.6.0
     version: 1.6.0(vitest@1.6.0)
+  chromatic:
+    specifier: ^11.5.4
+    version: 11.5.4
   copyfiles:
     specifier: ^2.4.1
     version: 2.4.1
@@ -5649,6 +5652,19 @@ packages:
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+    dev: true
+
+  /chromatic@11.5.4:
+    resolution: {integrity: sha512-+J+CopeUSyGUIQJsU6X7CfvSmeVBs0j6LZ9AgF4+XTjI4pFmUiUXsTc00rH9x9W1jCppOaqDXv2kqJJXGDK3mA==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
     dev: true
 
   /ci-info@3.9.0:

--- a/src/Card/DetailCard/DetailCard.stories.tsx
+++ b/src/Card/DetailCard/DetailCard.stories.tsx
@@ -332,7 +332,7 @@ export const ScenarioExample = {
         name: "Test Label 3"
       }
     ],
-    media: "https://picsum.photos/400/200",
+    media: "https://picsum.photos/id/191/400/200",
     subtitle: "Uploaded 2 hours ago by Jega Sriskantha ",
     title: "Expressway_3Lanes "
   },

--- a/src/Card/DetailCard/DetailCard.test.tsx
+++ b/src/Card/DetailCard/DetailCard.test.tsx
@@ -60,7 +60,10 @@ describe("DetailCard", () => {
   // test that image is rendered in detail card
   it("renders image", () => {
     render(
-      <FileCard {...defaultInputs} media="https://picsum.photos/400/200" />
+      <FileCard
+        {...defaultInputs}
+        media="https://picsum.photos/id/191/400/200"
+      />
     );
     // expect image to be in the document
     expect(screen.getByRole("img")).toBeInTheDocument();

--- a/src/Card/SummaryCard/SummaryCard.stories.tsx
+++ b/src/Card/SummaryCard/SummaryCard.stories.tsx
@@ -232,7 +232,7 @@ export const ScenarioExample = {
       </TableContainer>
     ),
     labels,
-    media: "https://picsum.photos/400/200",
+    media: "https://picsum.photos/id/191/400/200",
     moreCardActions: MoreActions,
     moreOptionsPopover: MoreOptions,
     subtitle: "Uploaded 32 minutes ago by Jega Sriskantha ",


### PR DESCRIPTION
## Changes

We've talked for a while that it would be a good idea to host the storybook environment somewhere so that it is quickly accessible, as well as having "deploy-previews" for react-ui PRs so that UI/UX designers can gain easy access.

This PR enables that by using the Chromatic (creators of storybook) hosting free tier to do so. There are no limits to how many iterations of storybook we can push to Chromatic. 

Their paid features include visual regression testing, UI reviews etc. which we could investigate in the future. For now I have disabled this functionality so that we get hosting and deploy previews only.

I've followed the recommended deployment practices which is to generate previews on push. This means we can access deployments using either of the following url syntaxes:

```
https://<branch>--<appid>.chromatic.com
https://<commithash>--<appid>.chromatic.com
```

## Testing notes

You can see the actions below that ran. 

<img width="671" alt="image" src="https://github.com/IPG-Automotive-UK/react-ui/assets/27866636/553e0ae5-0d5c-448f-8328-e49571cc5009">

Clicking the details link for the "Publish Storybook" action takes you to the deployed storybook.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Lint and test workflows pass.
