### PR TITLE
Bug - TD-2849 Fix Breadcrumb and Numberfield visual defect

### DIFF
--- a/src/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 export const Default: StoryFn<BreadcrumbsProps> = args => {
   return (
-    <Breadcrumbs>
+    <Breadcrumbs {...args}>
       <Link href="">Home</Link>
       <Link href="">Garden</Link>
       <Typography>Shops</Typography>
@@ -21,13 +21,14 @@ export const Default: StoryFn<BreadcrumbsProps> = args => {
 
 export const OverflowEllipses: StoryFn<BreadcrumbsProps> = args => {
   return (
-    <Breadcrumbs>
-      <Link href="">Painting was a hobby when I was little</Link>
-      <Link href="">I didn't know I had any talent</Link>
+    <Breadcrumbs {...args}>
+      <Link href="">Item 1</Link>
+      <Link href="">Item 2</Link>
       <Link href="">Talent is just a pursued interest</Link>
       <Link href="">Anybody can do what I do</Link>
       <Typography>
-        Just go back and put one little more happy tree in there
+        Just go back and put one little more happy tree in there Just go back
+        and put one little more happy tree in there
       </Typography>
     </Breadcrumbs>
   );

--- a/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/Breadcrumbs/Breadcrumbs.tsx
@@ -18,6 +18,19 @@ function Breadcrumbs({
   separator = <NavigateNextIcon fontSize="small" />,
   ...rest
 }: BreadcrumbsProps) {
+  /**
+   *  Map children and wrap the final item in a truncated tooltip with separators
+   */
+  const mappedChildren = Children.map(children, (child, i) =>
+    child && isValidElement(child) ? (
+      Children.count(children) === i + 1 ? (
+        <TruncatedTooltip>{child}</TruncatedTooltip>
+      ) : (
+        child
+      )
+    ) : null
+  );
+
   return (
     <MuiBreadcrumbs
       aria-label="breadcrumbs"
@@ -36,6 +49,10 @@ function Breadcrumbs({
             textDecoration: "none"
             // Ensure children of block level elements are inline for ellipsis rendering
           },
+          "&:last-child": {
+            flexShrink: 1
+          },
+          flexShrink: 0,
           overflow: "hidden"
         },
         [`& .${breadcrumbsClasses.li}:last-child *`]: {
@@ -48,13 +65,7 @@ function Breadcrumbs({
       }}
       {...rest}
     >
-      {children
-        ? Children.map(children, child =>
-            child && isValidElement(child) ? (
-              <TruncatedTooltip>{child}</TruncatedTooltip>
-            ) : null
-          )
-        : null}
+      {children ? mappedChildren : null}
     </MuiBreadcrumbs>
   );
 }

--- a/src/NumberField/NumberField.tsx
+++ b/src/NumberField/NumberField.tsx
@@ -11,6 +11,7 @@ export default function NumberField(props: NumberFieldProps) {
   // Spread the rest of the mui component props
   const {
     endAdornment,
+    margin = "normal",
     startAdornment,
     stepper = true,
     variant = "outlined",
@@ -23,6 +24,7 @@ export default function NumberField(props: NumberFieldProps) {
   return (
     <TextField
       {...rest}
+      margin={margin}
       variant={variant}
       InputProps={{
         ...(endAdornment && {


### PR DESCRIPTION
Closes [TD-2849](https://sce.myjetbrains.com/youtrack/issue/TD-2849/RUI-BreadCrumbs-truncating-all-list-elements) & [TD-2850](https://sce.myjetbrains.com/youtrack/issue/VE-74/Style-and-spacing-issues-around-NumberFields-in-8.0.0-pre-release)

## Changes

Changes breadcrumbs so only the final item is truncated and wrapped in a tooltip. Restores the default "normal" margin to NumberFields

- Update component to only use the truncated tooltip on the final item
- Update styles to prevent all other items from shrinking
- Add "normal" prop as default to NumberField

## UI/UX
<img width="424" alt="Screenshot 2024-06-28 at 11 37 17" src="https://github.com/IPG-Automotive-UK/react-ui/assets/143453762/4bb47f28-7747-4bb3-84dc-ac0a11b0683a">

## Testing notes

Check the story to ensure only one the last breadcrumb is truncated. Check that the NumberField has a margin by default in storybook.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
