### PR TITLE
Bug - VE-75 NumberField label overlap

### DIFF
--- a/src/NumberField/NumberField.tsx
+++ b/src/NumberField/NumberField.tsx
@@ -26,6 +26,7 @@ export default function NumberField(props: NumberFieldProps) {
       {...rest}
       margin={margin}
       variant={variant}
+      InputLabelProps={{ shrink: true }}
       InputProps={{
         ...(endAdornment && {
           endAdornment: (


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [VE-75](https://sce.myjetbrains.com/youtrack/issue/VE-75/NumberField-defect-non-chromium-browsers)

## Changes

This ensures that the NumberField label is always collapsed to prevent an overlap bug.

In non chromium browser, letters are not blocked from being entered on the NumberField. This exposes a MUI defect that allows the label to overlap the letters in the number input on blur.

- This pr uses the shrink boolean on InputLabelProps to prevent the label overlap bug on non chromium browsers

## UI/UX

Old: 
<img width="290" alt="Screenshot 2024-07-01 at 16 06 53" src="https://github.com/IPG-Automotive-UK/react-ui/assets/143453762/7efce48b-6d49-48f4-9998-de88a11c98c4">

New:
<img width="300" alt="Screenshot 2024-07-01 at 15 55 41" src="https://github.com/IPG-Automotive-UK/react-ui/assets/143453762/b698c4dc-4e1e-460f-8b27-1eefe407b71c">

This has been approved by @Sowbhagya-ipg 

## Testing notes

View in storybook and check that the label is always shrunk.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Lint and test workflows pass.
