### PR TITLE
VE-78 NumberField Full Width Inconsistencies

### DIFF
--- a/src/NumberField/NumberField.tsx
+++ b/src/NumberField/NumberField.tsx
@@ -24,6 +24,7 @@ export default function NumberField(props: NumberFieldProps) {
   return (
     <TextField
       {...rest}
+      fullWidth
       margin={margin}
       variant={variant}
       InputLabelProps={{ shrink: true }}
@@ -45,7 +46,10 @@ export default function NumberField(props: NumberFieldProps) {
               "& input::-webkit-clear-button, & input::-webkit-outer-spin-button, & input::-webkit-inner-spin-button":
                 { display: "none" }
             }
-          : {}
+          : {
+              "& input::-webkit-outer-spin-button, & input::-webkit-inner-spin-button":
+                { opacity: 1 }
+            }
       }
       type="number"
     />


### PR DESCRIPTION
Closes [VE-78](https://sce.myjetbrains.com/youtrack/issue/VE-78/NumberField-width-inconsistency)

## Changes
Ensure by default the NumberField is full width. Ensure the number stepper is always visible

This ensures consistency in our forms and across browsers. Making the stepper always visible on chrome brings it in line with other browsers and gives more visual emphasis about the field type now the label is always shrunk

- Use the full width prop. Prop can be overridden
- Add style to ensure stepper opacity is always 1 when stepper is enabled=

## Testing notes

NumberField should adopt the full width of the story container. Stepper should always be visible if it hasn't been disabled.


## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
