### PR TITLE
Add inputValue prop to Autocomplete

### DIFF
--- a/src/Autocomplete/Autocomplete.stories.tsx
+++ b/src/Autocomplete/Autocomplete.stories.tsx
@@ -94,6 +94,7 @@ const defaultArgs: Story["args"] = {
   disabled: false,
   error: false,
   helperText: "Helper Text",
+  inputValue: undefined,
   label: "Select options",
   limitTags: -1,
   margin: "normal",
@@ -183,6 +184,7 @@ export const ReadOnly: Story = {
     // Define the read-only story args
     ...defaultArgs,
     defaultValue: "Option 4",
+    inputValue: "Option 4",
     readOnly: true,
     required: true
   },

--- a/src/Autocomplete/Autocomplete.test.tsx
+++ b/src/Autocomplete/Autocomplete.test.tsx
@@ -206,6 +206,20 @@ describe("Select", () => {
     expect(input).toHaveValue("option-one");
   });
 
+  it("textfield input value", () => {
+    const { getByRole } = render(
+      <Autocomplete
+        inputValue={"option-one"}
+        options={[]}
+        label="Select an option"
+      />
+    );
+
+    const input = getByRole("combobox") as HTMLInputElement;
+
+    expect(input).toHaveValue("option-one");
+  });
+
   it("can use an onBlur callback", async () => {
     const onBlur = vi.fn();
 

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -27,6 +27,7 @@ export default function Autocomplete<
   disabled = false,
   error = false,
   helperText,
+  inputValue,
   label,
   limitTags = -1,
   margin = "normal",
@@ -48,6 +49,7 @@ export default function Autocomplete<
       defaultValue={defaultValue}
       disableClearable={disableClearable}
       disableCloseOnSelect={disableCloseOnSelect}
+      inputValue={inputValue}
       limitTags={limitTags}
       multiple={multiple}
       onBlur={onBlur}

--- a/src/Autocomplete/Autocomplete.types.ts
+++ b/src/Autocomplete/Autocomplete.types.ts
@@ -19,6 +19,7 @@ export type AutocompleteProps<
   | "defaultValue"
   | "disabled"
   | "disableClearable"
+  | "inputValue"
   | "size"
   | "limitTags"
   | "disableCloseOnSelect"


### PR DESCRIPTION
Contributes to [VE-22](https://sce.myjetbrains.com/youtrack/issue/VE-22/Complete-end-to-end-creation-of-a-vehicle)

## Changes

Add access to the inputValue prop on Autocomplete.

This allows you to update the display value without encountering controlled to uncontrolled errors. This will be used in tandem with the defaultValue to update, display and pass a given value without controlling the component.

- Add the inputValue prop
- Add the prop to storybook
- Add a test

## Testing notes

Update the inputValue prop on the read only story and ensure text updates in the field.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
