### PR TITLE
Enhancement - Add href support to FileDetails download button

### DIFF
--- a/src/CardContent/FileDetails/FileDetails.stories.tsx
+++ b/src/CardContent/FileDetails/FileDetails.stories.tsx
@@ -90,7 +90,7 @@ export const WithFiles = {
 export const DownloadWithHref = {
   args: {
     downloadButtonText: "Download All Files",
-    downloadHref: "/somepath/path/file",
+    downloadLinkHref: "/somepath/path/file",
     fileTitle: "Files",
     files: [
       {

--- a/src/CardContent/FileDetails/FileDetails.stories.tsx
+++ b/src/CardContent/FileDetails/FileDetails.stories.tsx
@@ -86,3 +86,30 @@ export const WithFiles = {
 
   render: Template
 };
+
+export const DownloadWithHref = {
+  args: {
+    downloadButtonText: "Download All Files",
+    downloadHref: "/somepath/path/file",
+    fileTitle: "Files",
+    files: [
+      {
+        files: [{ filename: "roadFile.rd5", path: "/somepath/path/file" }],
+        header: "Road Files"
+      },
+      {
+        files: [
+          { filename: "roadInfographic1.png", path: "/somepath/path/file" },
+          {
+            filename: "someOtherRoadInfographic.gif",
+            path: "/somepath/path/file"
+          },
+          { filename: "coolRoadInfographic.jpg", path: "/somepath/path/file" }
+        ],
+        header: "Road Infographics"
+      }
+    ]
+  },
+
+  render: Template
+};

--- a/src/CardContent/FileDetails/FileDetails.test.tsx
+++ b/src/CardContent/FileDetails/FileDetails.test.tsx
@@ -251,4 +251,48 @@ describe("FileDetails", () => {
     // expect download button to be disabled
     expect(screen.getByText("Download Search Files")).toBeDisabled();
   });
+
+  it("passes through an href to the download button if provided", () => {
+    const files = [
+      {
+        files: [
+          {
+            filename: "file1",
+            path: "path1"
+          },
+          {
+            filename: "file2",
+            path: "path2"
+          }
+        ],
+        header: "header1"
+      },
+      {
+        files: [
+          {
+            filename: "file3",
+            path: "path3"
+          },
+          {
+            filename: "file4",
+            path: "path4"
+          }
+        ],
+        header: "header2"
+      }
+    ];
+
+    render(
+      <FileDetails
+        fileTitle="file card title"
+        downloadButtonText="Download File"
+        downloadHref="some/path/to/a/download"
+        files={files}
+      />
+    );
+    expect(screen.getByRole("link", { name: "Download File" })).toHaveAttribute(
+      "href",
+      "some/path/to/a/download"
+    );
+  });
 });

--- a/src/CardContent/FileDetails/FileDetails.test.tsx
+++ b/src/CardContent/FileDetails/FileDetails.test.tsx
@@ -286,7 +286,7 @@ describe("FileDetails", () => {
       <FileDetails
         fileTitle="file card title"
         downloadButtonText="Download File"
-        downloadHref="some/path/to/a/download"
+        downloadLinkHref="some/path/to/a/download"
         files={files}
       />
     );

--- a/src/CardContent/FileDetails/FileDetails.tsx
+++ b/src/CardContent/FileDetails/FileDetails.tsx
@@ -16,8 +16,8 @@ import SearchBar from "../../SearchBar/SearchBar";
 
 function FileDetails({
   downloadButtonText = "Download",
-  downloadHref,
-  downloadHrefTarget,
+  downloadLinkHref,
+  downloadLinkTarget,
   downloadButtonTextOnSearch = "Download Files",
   files: filesIn = [],
   fileTitle = "title",
@@ -134,13 +134,13 @@ function FileDetails({
         </Box>
         <Box>
           <Button
-            component={downloadHref ? "a" : "button"}
+            component={downloadLinkHref ? "a" : "button"}
             disabled={!files?.some(file => file.files.length)}
-            href={downloadHref}
+            href={downloadLinkHref}
             sx={{ maxWidth: "265px", mr: 2 }}
             variant="outlined"
             startIcon={<Download />}
-            target={downloadHrefTarget}
+            target={downloadLinkTarget}
             onClick={handleDownload}
           >
             {search === "" ? downloadButtonText : downloadButtonTextOnSearch}

--- a/src/CardContent/FileDetails/FileDetails.tsx
+++ b/src/CardContent/FileDetails/FileDetails.tsx
@@ -141,7 +141,7 @@ function FileDetails({
             variant="outlined"
             startIcon={<Download />}
             target={downloadLinkTarget}
-            onClick={handleDownload}
+            onClick={downloadLinkHref ? undefined : handleDownload}
           >
             {search === "" ? downloadButtonText : downloadButtonTextOnSearch}
           </Button>

--- a/src/CardContent/FileDetails/FileDetails.tsx
+++ b/src/CardContent/FileDetails/FileDetails.tsx
@@ -16,6 +16,8 @@ import SearchBar from "../../SearchBar/SearchBar";
 
 function FileDetails({
   downloadButtonText = "Download",
+  downloadHref,
+  downloadHrefTarget,
   downloadButtonTextOnSearch = "Download Files",
   files: filesIn = [],
   fileTitle = "title",
@@ -132,10 +134,13 @@ function FileDetails({
         </Box>
         <Box>
           <Button
-            disabled={!files.some(file => file.files.length)}
+            component={downloadHref ? "a" : "button"}
+            disabled={!files?.some(file => file.files.length)}
+            href={downloadHref}
             sx={{ maxWidth: "265px", mr: 2 }}
             variant="outlined"
             startIcon={<Download />}
+            target={downloadHrefTarget}
             onClick={handleDownload}
           >
             {search === "" ? downloadButtonText : downloadButtonTextOnSearch}

--- a/src/CardContent/FileDetails/FileDetails.types.ts
+++ b/src/CardContent/FileDetails/FileDetails.types.ts
@@ -12,7 +12,11 @@ export type FileDetailsProps = {
   /**
    * The download href link.
    */
-  downloadHref?: string;
+  downloadLinkHref?: string;
+  /**
+   * The download href link target attribute.
+   */
+  downloadLinkTarget?: string;
   /**
    * The fileTitle of the card.
    */
@@ -36,8 +40,4 @@ export type FileDetailsProps = {
    * An optional initial search term
    */
   search?: string;
-  /**
-   * The download link target attribute.
-   */
-  target?: string;
 };

--- a/src/CardContent/FileDetails/FileDetails.types.ts
+++ b/src/CardContent/FileDetails/FileDetails.types.ts
@@ -10,6 +10,10 @@ export type FileDetailsProps = {
    */
   downloadButtonTextOnSearch?: string;
   /**
+   * The download href link.
+   */
+  downloadHref?: string;
+  /**
    * The fileTitle of the card.
    */
   fileTitle: string;
@@ -32,4 +36,8 @@ export type FileDetailsProps = {
    * An optional initial search term
    */
   search?: string;
+  /**
+   * The download link target attribute.
+   */
+  target?: string;
 };

--- a/src/CardContent/FileDetails/FileDetails.types.ts
+++ b/src/CardContent/FileDetails/FileDetails.types.ts
@@ -1,4 +1,5 @@
 import { File } from "../../Common.types";
+import { HTMLAttributeAnchorTarget } from "react";
 
 export type FileDetailsProps = {
   /**
@@ -16,7 +17,7 @@ export type FileDetailsProps = {
   /**
    * The download href link target attribute.
    */
-  downloadLinkTarget?: string;
+  downloadLinkTarget?: HTMLAttributeAnchorTarget;
   /**
    * The fileTitle of the card.
    */


### PR DESCRIPTION
Add href and target props to FileDetails
Add story
Add test
Update types

<!-- Insert YouTrack link if relevant -->

Closes [VE-91](https://sce.myjetbrains.com/youtrack/issue/VE-91/Add-href-support-to-the-FileDetail-component)
Contributes to [TD-2863](https://sce.myjetbrains.com/youtrack/issue/TD-2863/Handle-api-errors-when-downloading-roads)

## Changes

Adds href support to the FileDetails component.

This introduces
- a downloadLinkHref prop
- a downloadLinkTarget prop
- Replaces the button with an anchor when the href is provided

## Testing notes

Check the file detail story that the button renders as an anchor and passes through the href. Ensure the other stories function with no change.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
