### PR TITLE
TD -2915 Update wizard title prop to support element

### DIFF
--- a/src/Wizard/Wizard.stories.tsx
+++ b/src/Wizard/Wizard.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryFn } from "@storybook/react";
+import { Stack, Typography } from "@mui/material";
 
 import React from "react";
+import VersionChip from "../VersionChip/VersionChip";
 import Wizard from "./Wizard";
 import { Default as WizardActions } from "./WizardActions/WizardActions.stories";
 import { Default as WizardContent } from "./WizardContent/WizardContent.stories";
@@ -42,10 +44,44 @@ export const Default = {
   render: Template
 };
 
-export const WithTitle = {
+export const WithTitleTypeString = {
   args: {
     ...Default.args,
     title: "Wizard Title"
+  },
+
+  render: Template
+};
+
+export const WithTitleTypeElement = {
+  args: {
+    ...Default.args,
+    title: (
+      <Stack
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexDirection: "row",
+          gap: 1,
+          maxWidth: theme => theme?.layout?.content?.maxWidth,
+          mb: 2,
+          mt: 1,
+          mx: "auto",
+          width: "100%"
+        }}
+      >
+        <Typography
+          variant="h5"
+          color="textPrimary"
+          sx={{
+            fontWeight: 700
+          }}
+        >
+          Wizard Title
+        </Typography>
+        <VersionChip version="1.0" />
+      </Stack>
+    )
   },
 
   render: Template

--- a/src/Wizard/Wizard.test.tsx
+++ b/src/Wizard/Wizard.test.tsx
@@ -1,7 +1,9 @@
+import { Box, Typography } from "@mui/material";
 import { render, screen } from "@testing-library/react";
 
 import React from "react";
 import ThemeProvider from "../ThemeProvider/ThemeProvider";
+import VersionChip from "../VersionChip/VersionChip";
 import Wizard from "./Wizard";
 
 describe("Wizard", () => {
@@ -34,5 +36,28 @@ describe("Wizard", () => {
       </ThemeProvider>
     );
     expect(screen.getByText("Wizard Title")).toHaveStyle("max-width: 100px");
+  });
+
+  it("can accept renders custom element in title prop", () => {
+    render(
+      <Wizard
+        title={
+          <Box>
+            <Typography
+              variant="h5"
+              color="textPrimary"
+              sx={{
+                fontWeight: 700
+              }}
+            >
+              Wizard Title
+            </Typography>
+            <VersionChip version="1.0" />
+          </Box>
+        }
+      />
+    );
+    expect(screen.getByText("Wizard Title")).toBeInTheDocument();
+    expect(screen.getByText("1.0")).toBeInTheDocument();
   });
 });

--- a/src/Wizard/Wizard.tsx
+++ b/src/Wizard/Wizard.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Box, ThemeProvider, Typography } from "@mui/material";
+import { Stack, ThemeProvider, Typography } from "@mui/material";
 import { WizardProps, WizardThemeOverrideProps } from "./Wizard.types";
 
 /**
@@ -10,7 +10,7 @@ import { WizardProps, WizardThemeOverrideProps } from "./Wizard.types";
 export default function Wizard({ title, children, maxWidth }: WizardProps) {
   return (
     <ThemeOverride maxWidth={maxWidth}>
-      <Box
+      <Stack
         sx={{
           display: "flex",
           flexDirection: "column",
@@ -18,7 +18,7 @@ export default function Wizard({ title, children, maxWidth }: WizardProps) {
           px: 3
         }}
       >
-        {title ? (
+        {typeof title === "string" ? (
           <Typography
             variant="h5"
             color="textPrimary"
@@ -33,9 +33,11 @@ export default function Wizard({ title, children, maxWidth }: WizardProps) {
           >
             {title}
           </Typography>
-        ) : null}
+        ) : (
+          title
+        )}
         {children}
-      </Box>
+      </Stack>
     </ThemeOverride>
   );
 }

--- a/src/Wizard/Wizard.types.ts
+++ b/src/Wizard/Wizard.types.ts
@@ -12,7 +12,7 @@ export type WizardProps = {
   /**
    * Wizard title
    */
-  title?: string;
+  title?: string | JSX.Element;
 };
 
 export type WizardThemeOverrideProps = {

--- a/src/Wizard/WizardSteps/WizardSteps.stories.tsx
+++ b/src/Wizard/WizardSteps/WizardSteps.stories.tsx
@@ -1,11 +1,9 @@
-import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import { Meta, StoryFn } from "@storybook/react";
 
 import React from "react";
 import WizardStep from "./WizardStep";
 import WizardSteps from "./WizardSteps";
 import { WizardStepsProps } from "./WizardSteps.types";
-
-type Story = StoryObj<typeof WizardSteps>;
 
 const meta: Meta<typeof WizardSteps> = {
   component: WizardSteps,
@@ -23,7 +21,7 @@ const BasicTemplate: StoryFn<WizardStepsProps> = args => {
   );
 };
 
-export const Default: Story = {
+export const Default = {
   args: {
     activeStep: 0
   },
@@ -41,7 +39,7 @@ const HelperTemplate: StoryFn<WizardStepsProps> = args => {
   );
 };
 
-export const WithHelperText: Story = {
+export const WithHelperText = {
   args: {
     ...Default.args
   },
@@ -60,7 +58,7 @@ const ErrorTemplate: StoryFn<WizardStepsProps> = args => {
   );
 };
 
-export const WithErrorText: Story = {
+export const WithErrorText = {
   args: {
     activeStep: 1
   },


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-2915](https://sce.myjetbrains.com/youtrack/issue/TD-2915/Update-title-prop-of-Wizard-in-RUI-to-accept-JSX-and-string)

## Changes

- Added support to accept element in `Wizard` component `tilte` prop
- Test added
- Fixed a type issue in `WizardSteps.stories` which causing the following error
![Screenshot (555)](https://github.com/user-attachments/assets/14dd43b8-069b-497b-950a-ef243f024bec)


## UI/UX
With string
![Screenshot (556)](https://github.com/user-attachments/assets/94ec6ce9-734c-4837-9110-e5f4ea375e3d)

With element
![Screenshot (557)](https://github.com/user-attachments/assets/76ce5cb2-84ae-45a7-9fbf-1b94c4cc32cf)

## Testing notes
How to open the preview to test? See screenshot
![Screenshot (558)](https://github.com/user-attachments/assets/09e8ebc8-461a-4068-a192-6df22c76ceaa)


Check the new `WithTitleTypeElement` story in Wizard  renders with an JSX element for prop `title`. Also make sure string case still works as before.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
