### PR TITLE
TD-2862 FileUploader extension validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.2.0",
+  "version": "8.2.1-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/FileUploader/FileUploader.test.tsx
+++ b/src/FileUploader/FileUploader.test.tsx
@@ -1,5 +1,5 @@
 import { MultipleFiles, SingleFile } from "./__data__/uploaderTestFiles";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import FileUploader from "./FileUploader";
@@ -196,5 +196,34 @@ describe("FileUploader", () => {
     await waitFor(() =>
       expect(dropzoneElement).toHaveTextContent("File type must be .rd5.")
     );
+  });
+
+  test("accepts case insensitive extensions", async () => {
+    const onAdd = vi.fn();
+    const { getByTestId } = render(
+      <FileUploader acceptedFiles={{ "text/plain": [".rd5"] }} onAdd={onAdd} />
+    );
+
+    // create a valid file with an uppercase extension
+    const files = [new File(["ipg1"], "ipg1.RD5", { type: "text/plain" })];
+
+    // create a data transfer object with the files
+    const data = createDtWithFiles(files);
+
+    // get the dropzone element
+    const dropzoneElement = getByTestId("dropzone-root");
+
+    // trigger the drop event
+    fireEvent.drop(dropzoneElement, data);
+
+    // expect the onAdd callback to be called
+    await waitFor(() => {
+      expect(onAdd).toHaveBeenCalledOnce();
+      expect(onAdd).toHaveBeenCalledWith([
+        expect.objectContaining({
+          file: files[0]
+        })
+      ]);
+    });
   });
 });

--- a/src/FileUploader/FileUploader.test.tsx
+++ b/src/FileUploader/FileUploader.test.tsx
@@ -174,4 +174,27 @@ describe("FileUploader", () => {
       )
     );
   });
+
+  test("display error when file extension is not accepted", async () => {
+    const { getByTestId } = render(
+      <FileUploader filesLimit={1} acceptedFiles={{ "text/plain": [".rd5"] }} />
+    );
+
+    // create a file with a txt extension
+    const files = [new File(["ipg1"], "ipg1.txt", { type: "text/plain" })];
+
+    // create a data transfer object with the files
+    const data = createDtWithFiles(files);
+
+    // get the dropzone element
+    const dropzoneElement = getByTestId("dropzone-root");
+
+    // trigger the drop event
+    fireEvent.drop(dropzoneElement, data);
+
+    // wait for the error message to be displayed
+    await waitFor(() =>
+      expect(dropzoneElement).toHaveTextContent("File type must be .rd5.")
+    );
+  });
 });

--- a/src/FileUploader/FileUploader.tsx
+++ b/src/FileUploader/FileUploader.tsx
@@ -31,24 +31,19 @@ export default function FileUploader({
   subText
 }: FileUploaderProps) {
   // useUploader is a custom hook that handles the logic for uploading files
-  const {
-    getRootProps,
-    getInputProps,
-    handleDelete,
-    isDragReject,
-    rejectionMessage
-  } = useUploader({
-    acceptedFiles,
-    filesLimit,
-    maxFileSize,
-    multiple,
-    onAdd,
-    onDelete,
-    selectedFiles
-  });
+  const { getRootProps, getInputProps, handleDelete, rejectionMessage } =
+    useUploader({
+      acceptedFiles,
+      filesLimit,
+      maxFileSize,
+      multiple,
+      onAdd,
+      onDelete,
+      selectedFiles
+    });
 
   // are we rendering an error state?
-  const isError = isDragReject || rejectionMessage || error;
+  const isError = rejectionMessage || error;
 
   // render
   return (
@@ -95,10 +90,7 @@ export default function FileUploader({
               : theme.palette.text.secondary
           },
           background: theme.palette.background.default,
-          borderColor:
-            isDragReject || error
-              ? theme.palette.error.main
-              : theme.palette.divider,
+          borderColor: error ? theme.palette.error.main : theme.palette.divider,
           borderStyle: "dashed",
           borderWidth: 1,
           boxSizing: "border-box",

--- a/src/ImageUploader/ImageUploader.test.tsx
+++ b/src/ImageUploader/ImageUploader.test.tsx
@@ -134,4 +134,31 @@ describe("ImageUploader", () => {
       )
     );
   });
+
+  test("accepts case insensitive extensions", async () => {
+    const onAdd = vi.fn();
+    const { getByTestId } = render(<ImageUploader onAdd={onAdd} />);
+
+    // create a file with a png extension (uppercase)
+    const files = [new File(["ipg1"], "ipg1.PNG", { type: "image/png" })];
+
+    // create a data transfer object with the files
+    const data = createDtWithFiles(files);
+
+    // get the dropzone element
+    const dropzoneElement = getByTestId("dropzone-root");
+
+    // trigger the drop event
+    fireEvent.drop(dropzoneElement, data);
+
+    // expect the onAdd callback to be called
+    await waitFor(() => {
+      expect(onAdd).toHaveBeenCalledOnce();
+      expect(onAdd).toHaveBeenCalledWith([
+        expect.objectContaining({
+          file: files[0]
+        })
+      ]);
+    });
+  });
 });

--- a/src/ImageUploader/ImageUploader.tsx
+++ b/src/ImageUploader/ImageUploader.tsx
@@ -19,29 +19,24 @@ export default function ImageUploader({
   required = false
 }: ImageUploaderProps) {
   // useUploader is a custom hook that handles the logic for uploading files
-  const {
-    getRootProps,
-    getInputProps,
-    handleDelete,
-    isDragReject,
-    rejectionMessage
-  } = useUploader({
-    acceptedFiles: {
-      "image/gif": [".gif"],
-      "image/jpeg": [".jpg", ".jpeg"],
-      "image/png": [".png"],
-      "image/webp": [".webp"]
-    },
-    filesLimit: 1,
-    maxFileSize,
-    multiple: false,
-    onAdd,
-    onDelete,
-    selectedFiles
-  });
+  const { getRootProps, getInputProps, handleDelete, rejectionMessage } =
+    useUploader({
+      acceptedFiles: {
+        "image/gif": [".gif"],
+        "image/jpeg": [".jpg", ".jpeg"],
+        "image/png": [".png"],
+        "image/webp": [".webp"]
+      },
+      filesLimit: 1,
+      maxFileSize,
+      multiple: false,
+      onAdd,
+      onDelete,
+      selectedFiles
+    });
 
   // are we rendering an error state?
-  const isError = isDragReject || rejectionMessage;
+  const isError = rejectionMessage;
 
   // render
   return (
@@ -83,9 +78,7 @@ export default function ImageUploader({
             justifyContent: "center"
           },
           backgroundColor: theme.palette.background.default,
-          borderColor: isDragReject
-            ? theme.palette.error.main
-            : theme.palette.divider,
+          borderColor: theme.palette.divider,
           borderStyle: "dashed",
           borderWidth: 1,
           boxSizing: "border-box",

--- a/src/Uploader/useUploader.ts
+++ b/src/Uploader/useUploader.ts
@@ -105,10 +105,12 @@ export default function useUploader({
 
   // validator for file extension
   const validator = (file: File | DataTransferItem) => {
-    // react-dropozne validator types are incorrect https://github.com/react-dropzone/react-dropzone/issues/1333
+    // react-dropzone validator types are incorrect https://github.com/react-dropzone/react-dropzone/issues/1333
     if (
-      file instanceof File &&
-      !acceptedFileExtensions.includes(getFileExtension(file.name))
+      file instanceof File && // if we got a file
+      acceptedFileExtensions && // and we have accepted file extensions
+      acceptedFileExtensions.length > 0 && // and we have accepted file extensions
+      !acceptedFileExtensions.includes(getFileExtension(file.name)) // and file extension is not accepted
     )
       return {
         code: "file-invalid-type",

--- a/src/Uploader/useUploader.ts
+++ b/src/Uploader/useUploader.ts
@@ -68,6 +68,9 @@ export default function useUploader({
     onAdd && onAdd(newSelection);
   };
 
+  // get the accepted file type extensions
+  const acceptedFileExtensions = Object.values(acceptedFiles ?? {}).flat();
+
   // handle file drops that are rejected by showing the first error message as a rejection message
   const onDropRejected = (fileRejection: FileRejection[]) => {
     // deafult error message
@@ -76,16 +79,11 @@ export default function useUploader({
     // get the error code
     const errorCode = fileRejection[0].errors[0].code;
 
-    // get the accepted file type extensions
-    const acceptedFileExtensions = Object.values(acceptedFiles ?? {})
-      .flat()
-      .join(", ");
-
     // set error message based on error code
     let errorMessage = "";
     switch (errorCode) {
       case "file-invalid-type":
-        errorMessage = `File type must be ${acceptedFileExtensions}.`;
+        errorMessage = `File type must be ${acceptedFileExtensions.join(", ")}.`;
         break;
       case "file-too-large": {
         // get file size limit in MB
@@ -105,6 +103,20 @@ export default function useUploader({
     setRejectionMessage(errorMessage);
   };
 
+  // validator for file extension
+  const validator = (file: File | DataTransferItem) => {
+    // react-dropozne validator types are incorrect https://github.com/react-dropzone/react-dropzone/issues/1333
+    if (
+      file instanceof File &&
+      !acceptedFileExtensions.includes(getFileExtension(file.name))
+    )
+      return {
+        code: "file-invalid-type",
+        message: `File type must be one of ${acceptedFileExtensions.join(", ")}`
+      };
+    return null;
+  };
+
   // use react-dropzone hook
   const dropzone = useDropzone({
     accept: acceptedFiles,
@@ -113,7 +125,8 @@ export default function useUploader({
     multiple,
     onDropAccepted,
     onDropRejected,
-    useFsAccessApi: false
+    useFsAccessApi: false,
+    validator
   });
 
   // handle file deletion
@@ -131,4 +144,23 @@ export default function useUploader({
     handleDelete,
     rejectionMessage
   };
+}
+
+/**
+ * Extracts the file extension from a given file name.
+ *
+ * @param fileName - The name of the file.
+ * @return The file extension.
+ *
+ * @example
+ * const fileName = "example.txt";
+ * const extension = getFileExtension(fileName);
+ * console.log(extension); // Output: ".txt"
+ */
+function getFileExtension(fileName: string) {
+  const parts = fileName.split(".");
+  if (parts.length > 1) {
+    return "." + parts.pop();
+  }
+  return "";
 }

--- a/src/Uploader/useUploader.ts
+++ b/src/Uploader/useUploader.ts
@@ -69,7 +69,9 @@ export default function useUploader({
   };
 
   // get the accepted file type extensions
-  const acceptedFileExtensions = Object.values(acceptedFiles ?? {}).flat();
+  const acceptedFileExtensions = Object.values(acceptedFiles ?? {})
+    .flat()
+    .map(s => s.toLowerCase());
 
   // handle file drops that are rejected by showing the first error message as a rejection message
   const onDropRejected = (fileRejection: FileRejection[]) => {
@@ -110,7 +112,9 @@ export default function useUploader({
       file instanceof File && // if we got a file
       acceptedFileExtensions && // and we have accepted file extensions
       acceptedFileExtensions.length > 0 && // and we have accepted file extensions
-      !acceptedFileExtensions.includes(getFileExtension(file.name)) // and file extension is not accepted
+      !acceptedFileExtensions.includes(
+        getFileExtension(file.name).toLowerCase()
+      ) // and file extension is not accepted
     )
       return {
         code: "file-invalid-type",


### PR DESCRIPTION
Contributes to [TD-2862](https://sce.myjetbrains.com/youtrack/issue/TD-2862/Validate-file-extensions-in-the-RUI-Uploader-component)

## Changes

- We no longer render any file rejection messages on hover. This is because the DataTransferItem object we have access to during this event does not contain enough information to correctly validate the file. Instead we wait for the drop event.
- We now validate files based on their extension. react-dropzone internally will allow files that pass the mime-type check through so even if we say `{ acceptedFiles: { "text/plain": [".rd5"] } }`, `.txt` were still being accepted.

## Testing notes

- Check that you do not get any errors on hovering with files. Validation should now only occur on drop.
- Check that for instance the `{ acceptedFiles: { "text/plain": [".rd5"] } }` case no longer allows `.txt` files to be accepted. There is a new automated test to cover this case as well.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
