### PR TITLE
TD-2973 Add disabled prop to FileUploader

### DIFF
--- a/src/FileUploader/FileUploader.stories.tsx
+++ b/src/FileUploader/FileUploader.stories.tsx
@@ -52,6 +52,7 @@ export default meta;
 type Story = StoryObj<typeof FileUploader>;
 export const Default: Story = {
   args: {
+    disabled: false,
     dropzoneText: "Drag & Drop a file here or browse",
     filesLimit: 1,
     isValidating: false,

--- a/src/FileUploader/FileUploader.test.tsx
+++ b/src/FileUploader/FileUploader.test.tsx
@@ -1,5 +1,5 @@
 import { MultipleFiles, SingleFile } from "./__data__/uploaderTestFiles";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import FileUploader from "./FileUploader";
@@ -173,5 +173,34 @@ describe("FileUploader", () => {
         "File size exceeds the limit of 1 MB."
       )
     );
+  });
+
+  test("accepts no files when disabled", () => {
+    const onAdd = vi.fn();
+    const { getByTestId } = render(
+      <FileUploader disabled={true} onAdd={onAdd} />
+    );
+
+    // get the dropzone element
+    const dropzoneElement = getByTestId("dropzone-root");
+
+    // create a file
+    const files = [new File(["ipg1"], "ipg1.png", { type: "image/png" })];
+
+    // trigger the drop event
+    fireEvent.drop(dropzoneElement, createDtWithFiles(files));
+
+    // expect the onAdd function to not be called
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  test("cannot delete files when disabled", () => {
+    const screen = render(<FileUploader disabled={true} />);
+
+    // get the delete button
+    const deleteButton = screen.queryByTestId("delete-button");
+
+    // expect the delete button to not be present
+    expect(deleteButton).toBeNull();
   });
 });

--- a/src/FileUploader/FileUploader.tsx
+++ b/src/FileUploader/FileUploader.tsx
@@ -17,6 +17,7 @@ import useUploader from "../Uploader/useUploader";
 export default function FileUploader({
   acceptedFiles,
   error,
+  disabled = false,
   dropzoneText = "Drag & Drop a file here or browse",
   filesLimit = 1,
   isValidating = false,
@@ -39,6 +40,7 @@ export default function FileUploader({
     rejectionMessage
   } = useUploader({
     acceptedFiles,
+    disabled,
     filesLimit,
     maxFileSize,
     multiple,
@@ -60,6 +62,7 @@ export default function FileUploader({
         required={required}
         showDelete={!isValidating && !multiple && selectedFiles.length === 1}
         onDelete={() => handleDelete(selectedFiles[0])}
+        disabled={disabled}
       />
       <Box
         {...getRootProps()}
@@ -79,8 +82,10 @@ export default function FileUploader({
               : theme.palette.primary.main,
             color: theme.palette.primary.main
           },
-          ".dropzoneSingleFile": {
-            color: theme.palette.primary.main
+          ".dropzoneSingleFile, .dropzoneSingleFile > *": {
+            color: disabled
+              ? theme.palette.text.disabled
+              : theme.palette.primary.main
           },
           ".dropzoneSingleFile, .dropzoneText": {
             alignItems: "center",
@@ -89,10 +94,14 @@ export default function FileUploader({
             height: "100%",
             justifyContent: "center"
           },
-          ".dropzoneText": {
+          ".dropzoneText, .dropzoneText > *": {
             color: isError
               ? theme.palette.error.main
-              : theme.palette.text.secondary
+              : disabled
+                ? theme.palette.text.disabled
+                : theme.palette.mode === "dark"
+                  ? theme.palette.text.primary
+                  : theme.palette.text.secondary
           },
           background: theme.palette.background.default,
           borderColor:
@@ -109,7 +118,9 @@ export default function FileUploader({
           justifyContent: "center",
           p: 2,
           pointerEvents:
-            isValidating || (!multiple && selectedFiles.length === 1)
+            disabled ||
+            isValidating ||
+            (!multiple && selectedFiles.length === 1)
               ? "none"
               : "auto"
         })}
@@ -149,10 +160,10 @@ export default function FileUploader({
             return (
               <Grid item={true} key={`${thisFile.file?.name ?? "file"}-${i}`}>
                 <Chip
-                  disabled={isValidating}
+                  disabled={disabled || isValidating}
                   variant="outlined"
                   label={thisFile.file.name}
-                  onDelete={() => handleDelete(thisFile)}
+                  onDelete={disabled ? undefined : () => handleDelete(thisFile)}
                 />
               </Grid>
             );

--- a/src/FileUploader/FileUploader.types.ts
+++ b/src/FileUploader/FileUploader.types.ts
@@ -12,6 +12,10 @@ export type FileUploaderProps = {
    */
   error?: boolean;
   /**
+   * If true, the dropzone will be disabled.
+   */
+  disabled?: boolean;
+  /**
    * Text to display in dropzone
    */
   dropzoneText?: string;

--- a/src/ImageUploader/ImageUploader.tsx
+++ b/src/ImageUploader/ImageUploader.tsx
@@ -74,13 +74,17 @@ export default function ImageUploader({
           },
           ".dropzoneText": {
             alignItems: "center",
-            color: isError
-              ? theme.palette.error.main
-              : theme.palette.text.secondary,
             flexDirection: "row",
             gap: 1,
             height: "100%",
             justifyContent: "center"
+          },
+          ".dropzoneText > *": {
+            color: isError
+              ? theme.palette.error.main
+              : theme.palette.mode === "dark"
+                ? theme.palette.text.primary
+                : theme.palette.text.secondary
           },
           backgroundColor: theme.palette.background.default,
           borderColor: isDragReject

--- a/src/Uploader/UploaderHeader.tsx
+++ b/src/Uploader/UploaderHeader.tsx
@@ -16,6 +16,7 @@ import { UploaderHeaderProps } from "./UploaderHeader.types";
  * @returns
  */
 export default function UploaderHeader({
+  disabled = false,
   title,
   titleVariant = "body",
   subText,
@@ -27,13 +28,11 @@ export default function UploaderHeader({
   let titleTypographyProps: TypographyProps = {};
   if (titleVariant === "title") {
     titleTypographyProps = {
-      color: "textPrimary",
       fontSize: "20px",
       fontWeight: 600
     };
   } else if (titleVariant === "subtitle") {
     titleTypographyProps = {
-      color: "textPrimary",
       fontSize: "14px",
       fontWeight: 500
     };
@@ -42,6 +41,10 @@ export default function UploaderHeader({
       variant: "body1"
     };
   }
+  titleTypographyProps.sx = {
+    color: theme =>
+      disabled ? theme.palette.text.disabled : theme.palette.text.primary
+  };
 
   return (
     <Stack
@@ -69,11 +72,9 @@ export default function UploaderHeader({
             </Typography>
           ) : null}
         </Typography>
-        <Typography variant="caption" color="textPrimary">
-          {subText}
-        </Typography>
+        <Typography variant="caption">{subText}</Typography>
       </Box>
-      {showDelete ? (
+      {showDelete && !disabled ? (
         <IconButton aria-label="DeleteIcon" onClick={onDelete} size="small">
           <DeleteIcon color="error" fontSize="small" />
         </IconButton>

--- a/src/Uploader/UploaderHeader.types.ts
+++ b/src/Uploader/UploaderHeader.types.ts
@@ -1,8 +1,12 @@
 export type UploaderHeaderProps = {
   /**
    * Callback fired when the delete button is clicked
-   *   */
+   */
   onDelete?: React.MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Disables interaction if true
+   */
+  disabled?: boolean;
   /**
    * Is field required?
    */

--- a/src/Uploader/useUploader.ts
+++ b/src/Uploader/useUploader.ts
@@ -8,6 +8,7 @@ import { readAsDataURL } from "../utils/readAsDataURL";
 /**
  * Hook to handle file selection logic for uploaders. It is a wrapper around react-dropzone.
  * @param acceptedFiles - Definition of acceptable file mime types and extensions
+ * @param disabled - Whether the dropzone is disabled
  * @param maxFileSize - Maximum allowed file size in bytes
  * @param multiple - Whether multiple files can be selected
  * @param filesLimit - Maximum number of files that can be selected
@@ -18,6 +19,7 @@ import { readAsDataURL } from "../utils/readAsDataURL";
  */
 export default function useUploader({
   acceptedFiles,
+  disabled = false,
   maxFileSize = Infinity,
   multiple = false,
   filesLimit = 1,
@@ -108,6 +110,7 @@ export default function useUploader({
   // use react-dropzone hook
   const dropzone = useDropzone({
     accept: acceptedFiles,
+    disabled,
     maxFiles: filesLimit,
     maxSize: maxFileSize,
     multiple,

--- a/src/Uploader/useUploader.types.ts
+++ b/src/Uploader/useUploader.types.ts
@@ -7,6 +7,10 @@ export interface UseUploaderProps {
    */
   acceptedFiles?: Accept;
   /**
+   * If true, the dropzone will be disabled.
+   */
+  disabled?: boolean;
+  /**
    * Maximum number of files that the dropzone will accept.
    */
   filesLimit?: number;


### PR DESCRIPTION
Closes [TD-2973](https://sce.myjetbrains.com/youtrack/issue/TD-2973/Update-RUI-FileUploader-to-add-disabled-prop)

## Changes

- Adds a `disabled` property to the FileUploader component. When true, this removes and deletion button, disables any hover effects on the dropzone, and disables any ability to drag/drop files.
- Also fixed an issue with the FileUploader in darkmode where text was always white, even when in an error state.

## UI/UX

Empty
<img width="814" alt="image" src="https://github.com/user-attachments/assets/e8e4d823-c67c-4775-aff1-3a26788cfe22">
<img width="822" alt="image" src="https://github.com/user-attachments/assets/f3ba29ef-da07-4133-a2a9-9d352a13c6d7">

Single file
![image](https://github.com/user-attachments/assets/21b92221-11fd-4394-a81c-207542f91c93)
![image](https://github.com/user-attachments/assets/7c7e600b-0b16-4aa4-b80c-62d22c11035c)

Multi file
![image](https://github.com/user-attachments/assets/41356d66-d763-43a4-9a4b-43d78bebdff8)
<img width="823" alt="image" src="https://github.com/user-attachments/assets/ccf6330d-f70d-49db-bd39-34bb97a8972f">


## Testing notes

- Test that disabled renders and behaves correctly for empty / single file / multiple file. The Figma can be found [here](https://www.figma.com/proto/0CVK945S1cs1ku0sUXcgv7/VIRTO.SCENE?node-id=2875-43915&t=MrVx5Q7gmwWRp35R-1). You can set the disabled flag using the story controls.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
