### PR TITLE
TD-2979 moreOptionsRef prop to Summarycard 

### DIFF
--- a/src/Card/SummaryCard/SummaryCard.stories.tsx
+++ b/src/Card/SummaryCard/SummaryCard.stories.tsx
@@ -23,12 +23,16 @@ import SummaryCard from "./SummaryCard";
 import { SummaryCardProps } from "./SummaryCard.types";
 import { Theme } from "@mui/material/styles";
 import { action } from "@storybook/addon-actions";
-import { useArgs } from "@storybook/preview-api";
 
 /**
  * Story metadata
  */
 const meta: Meta<typeof SummaryCard> = {
+  argTypes: {
+    moreOptionsRef: {
+      control: false
+    }
+  },
   component: SummaryCard,
   title: "Card/SummaryCard"
 };
@@ -46,42 +50,30 @@ const Template: StoryFn<SummaryCardProps> = args => {
 };
 
 const WithMoreOptionsButton: StoryFn<SummaryCardProps> = args => {
-  // Set the anchor element to know where to render the menu
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-
-  const [{ moreOptionsRef }, updateArgs] = useArgs<SummaryCardProps>();
-
-  // Check if the menu is open
-  const open = Boolean(anchorEl);
+  const ref = React.useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = React.useState(false);
 
   // more options dropdown
   const MoreOptions = (
     <MenuList>
-      <MenuItem onClick={e => handleLabelMenuClick(e)}>
+      <MenuItem onClick={e => handlePopoverMenuClick(e)}>
         <ListItemIcon>
           <LabelIcon />
         </ListItemIcon>
-        <ListItemText primary="Labels" />
-      </MenuItem>
-      <MenuItem onClick={action("onDeleteClick")}>
-        <ListItemIcon>
-          <Delete />
-        </ListItemIcon>
-        <ListItemText primary="Delete" />
+        <ListItemText primary="Open Popover" />
       </MenuItem>
     </MenuList>
   );
 
   // handle the click of the more options button by setting the more options anchor element
-  const handleLabelMenuClick = event => {
-    updateArgs({ moreOptionsRef: event.currentTarget });
-    setAnchorEl(event.currentTarget);
+  const handlePopoverMenuClick = event => {
+    setOpen(true);
     action("onLabelMenuClick")(event);
   };
 
   // handle the close of the more options popover by setting the more options anchor element to null
   const handleMoreOptionsClose = () => {
-    setAnchorEl(null);
+    setOpen(false);
   };
 
   return (
@@ -92,11 +84,21 @@ const WithMoreOptionsButton: StoryFn<SummaryCardProps> = args => {
           action("onLabelClick")(label);
         }}
         moreOptionsPopover={MoreOptions}
-        moreOptionsRef={moreOptionsRef}
+        moreOptionsRef={ref}
       />
-      <Popover open={open} anchorEl={anchorEl} onClose={handleMoreOptionsClose}>
+      <Popover
+        open={open}
+        anchorEl={ref.current}
+        onClose={handleMoreOptionsClose}
+        anchorOrigin={{
+          horizontal: "left",
+          vertical: "bottom"
+        }}
+      >
         <Box p={2}>
-          <Typography>Popover Content</Typography>
+          <Typography>
+            This popover is anchored to the more options button
+          </Typography>
         </Box>
       </Popover>
     </>

--- a/src/Card/SummaryCard/SummaryCard.stories.tsx
+++ b/src/Card/SummaryCard/SummaryCard.stories.tsx
@@ -50,7 +50,10 @@ const Template: StoryFn<SummaryCardProps> = args => {
 };
 
 const WithMoreOptionsButton: StoryFn<SummaryCardProps> = args => {
+  // create a ref for the more options button
   const ref = React.useRef<HTMLButtonElement>(null);
+
+  // more options popover anchor state
   const [open, setOpen] = React.useState(false);
 
   // more options dropdown

--- a/src/Card/SummaryCard/SummaryCard.stories.tsx
+++ b/src/Card/SummaryCard/SummaryCard.stories.tsx
@@ -1,24 +1,29 @@
 import {
+  Box,
   Button,
   Divider,
   ListItemIcon,
   ListItemText,
   MenuItem,
   MenuList,
+  Popover,
   Table,
   TableBody,
   TableCell,
   TableContainer,
-  TableRow
+  TableRow,
+  Typography
 } from "@mui/material";
 import { Delete, Edit } from "@mui/icons-material";
 import { Meta, StoryFn } from "@storybook/react";
 
+import LabelIcon from "@mui/icons-material/Label";
 import React from "react";
 import SummaryCard from "./SummaryCard";
 import { SummaryCardProps } from "./SummaryCard.types";
 import { Theme } from "@mui/material/styles";
 import { action } from "@storybook/addon-actions";
+import { useArgs } from "@storybook/preview-api";
 
 /**
  * Story metadata
@@ -37,6 +42,64 @@ const Template: StoryFn<SummaryCardProps> = args => {
         action("onLabelClick")(label);
       }}
     />
+  );
+};
+
+const WithMoreOptionsButton: StoryFn<SummaryCardProps> = args => {
+  // Set the anchor element to know where to render the menu
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+  const [{ moreOptionsRef }, updateArgs] = useArgs<SummaryCardProps>();
+
+  // Check if the menu is open
+  const open = Boolean(anchorEl);
+
+  // more options dropdown
+  const MoreOptions = (
+    <MenuList>
+      <MenuItem onClick={e => handleLabelMenuClick(e)}>
+        <ListItemIcon>
+          <LabelIcon />
+        </ListItemIcon>
+        <ListItemText primary="Labels" />
+      </MenuItem>
+      <MenuItem onClick={action("onDeleteClick")}>
+        <ListItemIcon>
+          <Delete />
+        </ListItemIcon>
+        <ListItemText primary="Delete" />
+      </MenuItem>
+    </MenuList>
+  );
+
+  // handle the click of the more options button by setting the more options anchor element
+  const handleLabelMenuClick = event => {
+    updateArgs({ moreOptionsRef: event.currentTarget });
+    setAnchorEl(event.currentTarget);
+    action("onLabelMenuClick")(event);
+  };
+
+  // handle the close of the more options popover by setting the more options anchor element to null
+  const handleMoreOptionsClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <SummaryCard
+        {...args}
+        onClickLabel={label => {
+          action("onLabelClick")(label);
+        }}
+        moreOptionsPopover={MoreOptions}
+        moreOptionsRef={moreOptionsRef}
+      />
+      <Popover open={open} anchorEl={anchorEl} onClose={handleMoreOptionsClose}>
+        <Box p={2}>
+          <Typography>Popover Content</Typography>
+        </Box>
+      </Popover>
+    </>
   );
 };
 
@@ -214,6 +277,14 @@ export const withMoreOptionsPopover = {
   },
 
   render: Template
+};
+
+export const withMoreOptionsButtonRef = {
+  args: {
+    ...withMoreCardActions.args
+  },
+
+  render: WithMoreOptionsButton
 };
 
 export const ScenarioExample = {

--- a/src/Card/SummaryCard/SummaryCard.stories.tsx
+++ b/src/Card/SummaryCard/SummaryCard.stories.tsx
@@ -49,7 +49,7 @@ const Template: StoryFn<SummaryCardProps> = args => {
   );
 };
 
-const WithMoreOptionsButton: StoryFn<SummaryCardProps> = args => {
+const WithMoreOptionsButtonRef: StoryFn<SummaryCardProps> = args => {
   // create a ref for the more options button
   const ref = React.useRef<HTMLButtonElement>(null);
 
@@ -68,13 +68,13 @@ const WithMoreOptionsButton: StoryFn<SummaryCardProps> = args => {
     </MenuList>
   );
 
-  // handle the click of the more options button by setting the more options anchor element
+  // open the popover and call the onLabelMenuClick action
   const handlePopoverMenuClick = event => {
     setOpen(true);
     action("onLabelMenuClick")(event);
   };
 
-  // handle the close of the more options popover by setting the more options anchor element to null
+  // close the popover
   const handleMoreOptionsClose = () => {
     setOpen(false);
   };
@@ -289,7 +289,7 @@ export const withMoreOptionsButtonRef = {
     ...withMoreCardActions.args
   },
 
-  render: WithMoreOptionsButton
+  render: WithMoreOptionsButtonRef
 };
 
 export const ScenarioExample = {

--- a/src/Card/SummaryCard/SummaryCard.stories.tsx
+++ b/src/Card/SummaryCard/SummaryCard.stories.tsx
@@ -43,7 +43,7 @@ const Template: StoryFn<SummaryCardProps> = args => {
     <SummaryCard
       {...args}
       onClickLabel={label => {
-        action("onLabelClick")(label);
+        action("onClickLabel")(label);
       }}
     />
   );
@@ -71,7 +71,7 @@ const WithMoreOptionsButtonRef: StoryFn<SummaryCardProps> = args => {
   // open the popover and call the onLabelMenuClick action
   const handlePopoverMenuClick = event => {
     setOpen(true);
-    action("onLabelMenuClick")(event);
+    action("onLabelsClick")(event);
   };
 
   // close the popover
@@ -84,7 +84,7 @@ const WithMoreOptionsButtonRef: StoryFn<SummaryCardProps> = args => {
       <SummaryCard
         {...args}
         onClickLabel={label => {
-          action("onLabelClick")(label);
+          action("onClickLabel")(label);
         }}
         moreOptionsPopover={MoreOptions}
         moreOptionsRef={ref}

--- a/src/Card/SummaryCard/SummaryCard.test.tsx
+++ b/src/Card/SummaryCard/SummaryCard.test.tsx
@@ -263,4 +263,33 @@ describe("SummaryCard", () => {
     // expect the onClickViewFiles function to be called
     expect(onClickViewFiles).toHaveBeenCalledTimes(1);
   });
+
+  // test ref is passed to more options button
+  it("passes ref to more options button", () => {
+    // create a ref
+    const ref = React.createRef<HTMLButtonElement>();
+
+    render(
+      <SummaryCard
+        title="summary card title"
+        subtitle="summary card subtitle"
+        moreOptionsRef={ref}
+        moreOptionsPopover={
+          <List>
+            <ListItem disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  <Edit />
+                </ListItemIcon>
+                <ListItemText primary="Edit" />
+              </ListItemButton>
+            </ListItem>
+          </List>
+        }
+      />
+    );
+
+    // expect the ref to be passed to the more options button
+    expect(ref.current).toBeInTheDocument();
+  });
 });

--- a/src/Card/SummaryCard/SummaryCard.tsx
+++ b/src/Card/SummaryCard/SummaryCard.tsx
@@ -29,7 +29,8 @@ function SummaryCard({
   moreCardActions = null,
   subtitle = "subtitle",
   title = "title",
-  width = 368
+  width = 368,
+  moreOptionsRef
 }: SummaryCardProps) {
   // more options popover anchor state
   const [moreOptionsAnchorEl, setMoreOptionsAnchorEl] =
@@ -86,6 +87,7 @@ function SummaryCard({
           action={
             moreOptionsPopover ? (
               <IconButton
+                ref={moreOptionsRef}
                 aria-label="settings"
                 onClick={handleMoreOptionsClick}
               >

--- a/src/Card/SummaryCard/SummaryCard.types.ts
+++ b/src/Card/SummaryCard/SummaryCard.types.ts
@@ -1,3 +1,5 @@
+import { MenuProps } from "@mui/material";
+
 export type SummaryCardProps = {
   /**
    * The content of the card to be displayed under the media.
@@ -32,6 +34,10 @@ export type SummaryCardProps = {
    * The content of the more options popover.
    */
   moreOptionsPopover?: React.ReactNode;
+  /**
+   * a ref to the more options button.
+   */
+  moreOptionsRef?: React.RefObject<HTMLButtonElement>;
   /**
    * Callback fired when the label is clicked.
    */

--- a/src/Card/SummaryCard/SummaryCard.types.ts
+++ b/src/Card/SummaryCard/SummaryCard.types.ts
@@ -1,5 +1,3 @@
-import { MenuProps } from "@mui/material";
-
 export type SummaryCardProps = {
   /**
    * The content of the card to be displayed under the media.


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-2979](https://sce.myjetbrains.com/youtrack/issue/TD-2979/Add-moreOptionsRef-prop-to-SummaryCard)

We are making this change here because of a required use case in this tikcet [TD-2960](https://sce.myjetbrains.com/youtrack/issue/TD-2960/Implement-LabelSelectorPopover). On click of card view more menu item(Labels) we need to open another popover which should be anchored to the three dots button to keep the anchorReference, this is possible only by creating a `ref` and pass it to the three dots button then use it as `anchorEl` to the Popover. 

## Changes

- `moreOptionsRef` optional prop added
- A new story added for above use-case
- Test added for new prop



## UI/UX
New story
![Screenshot 2024-08-15 143624](https://github.com/user-attachments/assets/2c4407c9-4f31-406e-85aa-184bc65a7e54)


## Testing notes

Check new story is working as expected with new prop.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
