### PR TITLE
TD-2998 Close label popper on click

### DIFF
--- a/src/LabelSelector/LabelChip/LabelChip.test.tsx
+++ b/src/LabelSelector/LabelChip/LabelChip.test.tsx
@@ -50,10 +50,17 @@ describe("LabelChip", () => {
   });
   // test that on click, the callback is not called when not clickable
   it("does not call callback onClick when not clickable", () => {
-    render(<LabelChip label="Label" onClick={() => {}} />);
+    // render the label chip in a non-clickable state and spy on the onClick callback
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<LabelChip label="Label" onClick={onClick} clickable={false} />);
 
-    // there shouldn't be a button role
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    // find the label chip with the text "Label" and click it
+    const labelChip = screen.getByText(/label/i);
+    user.click(labelChip);
+
+    // check that the onClick callback was not called
+    expect(onClick).not.toHaveBeenCalled();
   });
   // test that on delete, the callback is called
   it("calls callback onDelete", async () => {

--- a/src/LabelSelector/LabelChip/LabelChip.tsx
+++ b/src/LabelSelector/LabelChip/LabelChip.tsx
@@ -8,13 +8,14 @@ import React from "react";
 // component to display a chip with custom colors
 export default function LabelChip({
   clickable = false,
-  label,
   color = "#005FA8",
+  description = "",
+  label,
+  onClick,
+  selected = false,
   size = "medium",
   variant = "filled",
   visible = true,
-  selected = false,
-  description = "",
   ...props
 }: LabelChipProps) {
   // return the styled chip component
@@ -25,6 +26,8 @@ export default function LabelChip({
         className="label-chip"
         clickable={clickable}
         icon={selected ? <DoneIcon color="inherit" /> : undefined}
+        label={<NoWrapTypography variant="inherit">{label}</NoWrapTypography>}
+        onClick={clickable ? onClick : undefined}
         sx={{
           "&:hover": {
             backgroundColor: clickable ? darken(color, 0.2) : color
@@ -39,7 +42,6 @@ export default function LabelChip({
           },
           visibility: visible ? "visible" : "hidden"
         }}
-        label={<NoWrapTypography variant="inherit">{label}</NoWrapTypography>}
         size={size}
         variant={variant}
       />

--- a/src/LabelSelector/LabelChipGroup/LabelChipGroup.spec.tsx
+++ b/src/LabelSelector/LabelChipGroup/LabelChipGroup.spec.tsx
@@ -38,7 +38,7 @@ test.describe("LabelChipGroup", () => {
       "http://localhost:6006/?path=/story/general-labelchipgroup--overflowing-parent"
     );
 
-    // check the first chip is visible
+    // check the first chips are visible
     await expect(
       page
         .frameLocator('iframe[title="storybook-preview-iframe"]')
@@ -61,8 +61,15 @@ test.describe("LabelChipGroup", () => {
     await expect(
       page
         .frameLocator('iframe[title="storybook-preview-iframe"]')
-        .getByRole("button")
-    ).toContainText("+1");
+        .getByRole("button", { name: "+" })
+    ).toContainText("+2");
+
+    // check the popper is not visible
+    await expect(
+      page
+        .frameLocator('iframe[title="storybook-preview-iframe"]')
+        .locator(".label-chip-group-popover")
+    ).not.toBeVisible();
 
     // click the more items button
     await page
@@ -78,5 +85,21 @@ test.describe("LabelChipGroup", () => {
         .filter({ hasText: /^Label 3$/ })
         .nth(1)
     ).toBeVisible();
+    await expect(
+      page
+        .frameLocator('iframe[title="storybook-preview-iframe"]')
+        .locator(".label-chip-group-popover")
+    ).toBeVisible();
+
+    // check we can click on one of the chips in the popper and the poper then closes
+    await page
+      .frameLocator('iframe[title="storybook-preview-iframe"]')
+      .getByRole("button", { name: "Label 3" })
+      .click();
+    await expect(
+      page
+        .frameLocator('iframe[title="storybook-preview-iframe"]')
+        .locator(".label-chip-group-popover")
+    ).not.toBeVisible();
   });
 });

--- a/src/LabelSelector/LabelChipGroup/LabelChipGroup.stories.tsx
+++ b/src/LabelSelector/LabelChipGroup/LabelChipGroup.stories.tsx
@@ -69,18 +69,22 @@ export const Default = {
   args: {
     chips: [
       {
+        clickable: true,
         color: "#005FA8",
         label: "Label 1"
       },
       {
+        clickable: true,
         color: "#1D9586",
         label: "Label 2"
       },
       {
+        clickable: true,
         color: "#fcba03",
         label: "Label 3"
       },
       {
+        clickable: true,
         color: "#47357a",
         label:
           "This is a really long label that is so long it will even overflow the popover container so we should see some ellipsis here and a tooltip"

--- a/src/LabelSelector/LabelChipGroup/LabelChipGroup.tsx
+++ b/src/LabelSelector/LabelChipGroup/LabelChipGroup.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Popover, Stack, Typography } from "@mui/material";
 
 import LabelChip from "../LabelChip/LabelChip";
 import { LabelChipGroupProps } from "./LabelChipGroup.types";
+import type { LabelChipProps } from "../LabelChip/LabelChip.types";
 import React from "react";
 import { ResizeObserver } from "@juggle/resize-observer";
 import { sortLabelChips } from "./sortLabelChips";
@@ -88,6 +89,20 @@ export default function LabelChipGroup({ chips }: LabelChipGroupProps) {
     }
   }, [chips, moreItemsRef, parentRef]);
 
+  // custom onClick event handler for label chips shown in the popper to close the popper on click
+  const handleOverflowingChipClick = (
+    event: React.MouseEvent<HTMLDivElement>,
+    onClick: LabelChipProps["onClick"]
+  ) => {
+    // close the popover
+    setPopoverOpen(false);
+
+    // call the original onClick event handler if it exists
+    if (onClick) {
+      onClick(event);
+    }
+  };
+
   // render all the chips in a row with a stack component, initially all chips invisible
   // if any chips are overflowing, we show how many are hidden and provide a popover to show the list of hidden chips
   // the resize oberserver effect will update the visibility of chips and position the more items button next to the last visible chip by changing the order of the hidden chips
@@ -145,7 +160,12 @@ export default function LabelChipGroup({ chips }: LabelChipGroupProps) {
             >
               {overflowingChips.map((chip, index) => (
                 <Box key={index}>
-                  <LabelChip {...chip} />
+                  <LabelChip
+                    {...chip}
+                    onClick={event =>
+                      handleOverflowingChipClick(event, chip.onClick)
+                    }
+                  />
                 </Box>
               ))}
             </Stack>


### PR DESCRIPTION
Closes [TD-2998](https://sce.myjetbrains.com/youtrack/issue/TD-2998/LabelChipGroup-popover-stays-open-after-clicking-a-LabelChip)

## Changes

* Intercept the onClick callback for labels which are shown in the overflow popper inside LabelChipGroup so we can also close the popper when one of them is clicked.
* Updated the existing story for label chip group overflowing parent so labels are clickable to allow this to be tested.
* Updated the Playwright test to check popper is closed when we click on a label chip.

## Dependencies

N/A

## UI/UX

N/A

## Testing notes

Use Storybook to check the popper closes when you click a label. The overflowing parent story for label chip group can be used.

Run the Playwright tests. Note these need to be run locally as they are not currently part of the GitHub actions.

```
npx playwright install
npx playwright test LabelChipGroup
```

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
