### PR TITLE
Add content ids

### DIFF
--- a/src/VirtoAppLayout/VirtoAppLayout.tsx
+++ b/src/VirtoAppLayout/VirtoAppLayout.tsx
@@ -101,6 +101,7 @@ function Layout({
         >
           <Box sx={theme => theme.mixins.toolbar} />
           <Box
+            id="page-content"
             sx={theme => ({
               height: `calc(100vh - ${theme.mixins.toolbar.minHeight}px)`,
               overflow: "auto",

--- a/src/Wizard/WizardContent/WizardContent.tsx
+++ b/src/Wizard/WizardContent/WizardContent.tsx
@@ -7,6 +7,7 @@ export default function WizardContent({ children }: WizardContentProps) {
   return (
     <Box
       role="region"
+      id="wizard-content"
       sx={{
         boxSizing: "border-box",
         height: "100%",


### PR DESCRIPTION
Contributes to [VE-130](https://sce.myjetbrains.com/youtrack/issue/VE-130/Scroll-restoration)

## Changes

Adds a unique id that can be queried using `document.querySelector` to the following components:
- VirtoAppLayout
- WizardContent

This will allow us to target these scrollable content areas and reset/restore the scroll on these elements in applications.

## Testing notes

In storybook you can check that you can target the elements. e.g. for VirtoAppLayout:

`const el = document.querySelector("#page-content");`

Then you can control the scroll e.g.

`el.scrollTop = 100`

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Lint and test workflows pass.
