### PR TITLE
v8.7.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.6.1",
+  "version": "8.7.0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/TruncatedTooltip/TruncatedTooltip.spec.tsx
+++ b/src/TruncatedTooltip/TruncatedTooltip.spec.tsx
@@ -78,4 +78,28 @@ test.describe("TruncatedTooltip", () => {
     await expect(tooltip).toBeVisible();
     expect(tooltip).toHaveText(textContent);
   });
+
+  test("shows tooltip when text is not overflowing but we are setting the optional prop to show the tooltip anyway", async ({
+    page
+  }) => {
+    // open the storybook with a large (h1) font size to ensure the text overflows
+    const url = `http://localhost:6006/?path=/story/general-truncatedtooltip--link-using-component-without-truncation`;
+    await page.goto(url);
+    const frame = page.frameLocator('iframe[title="storybook-preview-iframe"]');
+
+    // hover over the text
+    const textContent = "No truncation";
+    await frame.getByText(textContent).hover();
+
+    // expect the tooltip to be visible and have the correct text
+    const tooltip = frame.locator("div[role=tooltip]").first();
+    await expect(tooltip).toBeVisible();
+    expect(tooltip).toHaveText(textContent);
+
+    // hover over another element to hide the tooltip
+    page.getByText("Controls").hover();
+
+    // expect the tooltip to be hidden
+    await expect(tooltip).not.toBeVisible();
+  });
 });

--- a/src/TruncatedTooltip/TruncatedTooltip.stories.tsx
+++ b/src/TruncatedTooltip/TruncatedTooltip.stories.tsx
@@ -67,3 +67,41 @@ export const Multiline = {
 
   render: Template
 };
+
+export const LinkUsingComponentWithoutTruncation: StoryObj<
+  typeof TruncatedTooltip
+> = {
+  args: {
+    alwaysShowTooltip: true,
+    children: "No truncation",
+    component: Link,
+    href: "This/can/take/an/href/prop"
+  },
+
+  render: Template
+};
+
+export const LinkUsingComponentAlwaysShowingTooltipTextTruncated: StoryObj<
+  typeof TruncatedTooltip
+> = {
+  args: {
+    alwaysShowTooltip: true,
+    children: "This is a long text that will be truncated",
+    component: Link,
+    href: "This/can/take/an/href/prop"
+  },
+
+  render: Template
+};
+
+export const ComponentUsesTooltipProps: StoryObj<typeof TruncatedTooltip> = {
+  args: {
+    TooltipProps: { placement: "bottom-start" },
+    alwaysShowTooltip: true,
+    children: "No truncation",
+    component: Link,
+    href: "This/can/take/an/href/prop"
+  },
+
+  render: Template
+};

--- a/src/TruncatedTooltip/TruncatedTooltip.tsx
+++ b/src/TruncatedTooltip/TruncatedTooltip.tsx
@@ -20,6 +20,8 @@ const TruncatedTooltip = <T extends React.ElementType = "span">({
   multiline,
   sx,
   tooltip,
+  alwaysShowTooltip = false,
+  TooltipProps = undefined,
   ...rest
 }: TruncatedTooltipProps<T>) => {
   // Ref to the text element.
@@ -35,7 +37,8 @@ const TruncatedTooltip = <T extends React.ElementType = "span">({
   }: React.MouseEvent<HTMLDivElement | null>) => {
     setOpen(
       currentTarget.scrollWidth > currentTarget.clientWidth ||
-        currentTarget.scrollHeight > currentTarget.clientHeight
+        currentTarget.scrollHeight > currentTarget.clientHeight ||
+        alwaysShowTooltip
     );
   };
 
@@ -84,6 +87,7 @@ const TruncatedTooltip = <T extends React.ElementType = "span">({
 
   return (
     <Tooltip
+      {...TooltipProps}
       open={open}
       title={tooltip || text}
       disableHoverListener={!open}

--- a/src/TruncatedTooltip/TruncatedTooltip.types.ts
+++ b/src/TruncatedTooltip/TruncatedTooltip.types.ts
@@ -1,4 +1,4 @@
-import { SxProps, Theme } from "@mui/material";
+import { SxProps, Theme, TooltipProps } from "@mui/material";
 
 /**
  * Props for the TruncatedTooltip component
@@ -24,6 +24,14 @@ export type TruncatedTooltipProps<T extends React.ElementType = "span"> = {
    * Component to render
    */
   component?: T;
+  /**
+   * Optional prop to enable showing the tooltip also when the element is not truncated. Default value is false.
+   */
+  alwaysShowTooltip?: boolean;
+  /**
+   * Props for the MUI Tooltip component.
+   */
+  TooltipProps?: TooltipProps;
   /**
    * The additional types ensure the TruncatedTooltipProps is inferring props based on the passed component
    */


### PR DESCRIPTION
- [x] `TruncatedTooltip` - Allow tooltip to always display whether truncated or not and add TooltipProps prop as a MUI TooltipProps pass through #933 