### PR TITLE
TD-3048 Update RUI TruncatedTooltip component to enable showing tooltip when element not truncated

### DIFF
--- a/src/TruncatedTooltip/TruncatedTooltip.spec.tsx
+++ b/src/TruncatedTooltip/TruncatedTooltip.spec.tsx
@@ -78,4 +78,28 @@ test.describe("TruncatedTooltip", () => {
     await expect(tooltip).toBeVisible();
     expect(tooltip).toHaveText(textContent);
   });
+
+  test("shows tooltip when text is not overflowing but we are setting the optional prop to show the tooltip anyway", async ({
+    page
+  }) => {
+    // open the storybook with a large (h1) font size to ensure the text overflows
+    const url = `http://localhost:6006/?path=/story/general-truncatedtooltip--link-using-component-without-truncation`;
+    await page.goto(url);
+    const frame = page.frameLocator('iframe[title="storybook-preview-iframe"]');
+
+    // hover over the text
+    const textContent = "No truncation";
+    await frame.getByText(textContent).hover();
+
+    // expect the tooltip to be visible and have the correct text
+    const tooltip = frame.locator("div[role=tooltip]").first();
+    await expect(tooltip).toBeVisible();
+    expect(tooltip).toHaveText(textContent);
+
+    // hover over another element to hide the tooltip
+    page.getByText("Controls").hover();
+
+    // expect the tooltip to be hidden
+    await expect(tooltip).not.toBeVisible();
+  });
 });

--- a/src/TruncatedTooltip/TruncatedTooltip.stories.tsx
+++ b/src/TruncatedTooltip/TruncatedTooltip.stories.tsx
@@ -67,3 +67,41 @@ export const Multiline = {
 
   render: Template
 };
+
+export const LinkUsingComponentWithoutTruncation: StoryObj<
+  typeof TruncatedTooltip
+> = {
+  args: {
+    alwaysShowTooltip: true,
+    children: "No truncation",
+    component: Link,
+    href: "This/can/take/an/href/prop"
+  },
+
+  render: Template
+};
+
+export const LinkUsingComponentAlwaysShowingTooltipTextTruncated: StoryObj<
+  typeof TruncatedTooltip
+> = {
+  args: {
+    alwaysShowTooltip: true,
+    children: "This is a long text that will be truncated",
+    component: Link,
+    href: "This/can/take/an/href/prop"
+  },
+
+  render: Template
+};
+
+export const ComponentUsesTooltipProps: StoryObj<typeof TruncatedTooltip> = {
+  args: {
+    TooltipProps: { placement: "bottom-start" },
+    alwaysShowTooltip: true,
+    children: "No truncation",
+    component: Link,
+    href: "This/can/take/an/href/prop"
+  },
+
+  render: Template
+};

--- a/src/TruncatedTooltip/TruncatedTooltip.tsx
+++ b/src/TruncatedTooltip/TruncatedTooltip.tsx
@@ -20,6 +20,8 @@ const TruncatedTooltip = <T extends React.ElementType = "span">({
   multiline,
   sx,
   tooltip,
+  alwaysShowTooltip = false,
+  TooltipProps = undefined,
   ...rest
 }: TruncatedTooltipProps<T>) => {
   // Ref to the text element.
@@ -35,7 +37,8 @@ const TruncatedTooltip = <T extends React.ElementType = "span">({
   }: React.MouseEvent<HTMLDivElement | null>) => {
     setOpen(
       currentTarget.scrollWidth > currentTarget.clientWidth ||
-        currentTarget.scrollHeight > currentTarget.clientHeight
+        currentTarget.scrollHeight > currentTarget.clientHeight ||
+        alwaysShowTooltip
     );
   };
 
@@ -84,6 +87,7 @@ const TruncatedTooltip = <T extends React.ElementType = "span">({
 
   return (
     <Tooltip
+      {...TooltipProps}
       open={open}
       title={tooltip || text}
       disableHoverListener={!open}

--- a/src/TruncatedTooltip/TruncatedTooltip.types.ts
+++ b/src/TruncatedTooltip/TruncatedTooltip.types.ts
@@ -1,4 +1,4 @@
-import { SxProps, Theme } from "@mui/material";
+import { SxProps, Theme, TooltipProps } from "@mui/material";
 
 /**
  * Props for the TruncatedTooltip component
@@ -24,6 +24,14 @@ export type TruncatedTooltipProps<T extends React.ElementType = "span"> = {
    * Component to render
    */
   component?: T;
+  /**
+   * Optional prop to enable showing the tooltip also when the element is not truncated. Default value is false.
+   */
+  alwaysShowTooltip?: boolean;
+  /**
+   * Props for the MUI Tooltip component.
+   */
+  TooltipProps?: TooltipProps;
   /**
    * The additional types ensure the TruncatedTooltipProps is inferring props based on the passed component
    */


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-3048](https://sce.myjetbrains.com/youtrack/issue/TD-3048/Update-RUI-TruncatedTooltip-component-to-enable-showing-tooltip-when-element-not-truncated)

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->
 
- adds an optional `alwaysShowTooltip` prop to the `TruncatedTooltip` component. Default value is false.
- If `alwaysShowTooltip` is true, we should show the tooltip even if the component is not truncated
- adds an optional `TooltipProps` prop to the `TruncatedTooltip` component. Default value is undefined.
- `TooltipProps` allows to pass through the props of MUI `Tooltip` to the component, enabling us to use these in the component.

## Dependencies

<!-- Does this branch need to be tested alongside branches from other apps? -->
<!-- Does this branch need to be merged after another Pull Request? -->

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->

Showcasing the tooltip being shown while not being truncated from the storybook:
![image](https://github.com/user-attachments/assets/cf49e62f-1c9a-4ad0-a0a8-cf6e4f9563ae)

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
