### PR TITLE
TD-3050 - Fix the close button alignment

### DIFF
--- a/src/DialogTitle/DialogTitle.tsx
+++ b/src/DialogTitle/DialogTitle.tsx
@@ -14,7 +14,7 @@ const DialogTitle = ({ children, onClose, ...other }: DialogTitleProps) => {
         display: "flex",
         m: 0,
         p: 2,
-        width: "100%"
+        pr: 1
       }}
       {...other}
     >
@@ -29,7 +29,7 @@ const DialogTitle = ({ children, onClose, ...other }: DialogTitleProps) => {
       {onClose ? (
         <Box
           sx={{
-            minWidth: 60
+            textAlign: "right"
           }}
         >
           <IconButton
@@ -38,9 +38,9 @@ const DialogTitle = ({ children, onClose, ...other }: DialogTitleProps) => {
             sx={{
               color: theme => theme.palette.grey[500],
               flexGrow: 0,
-              height: 40,
-              marginTop: -2,
-              width: 40
+              height: 35,
+              marginTop: -1,
+              width: 35
             }}
           >
             <CloseIcon />

--- a/src/DialogTitle/DialogTitle.tsx
+++ b/src/DialogTitle/DialogTitle.tsx
@@ -27,25 +27,19 @@ const DialogTitle = ({ children, onClose, ...other }: DialogTitleProps) => {
         {children}
       </Box>
       {onClose ? (
-        <Box
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
           sx={{
-            textAlign: "right"
+            color: theme => theme.palette.grey[500],
+            flexGrow: 0,
+            height: 35,
+            marginTop: -1,
+            width: 35
           }}
         >
-          <IconButton
-            aria-label="close"
-            onClick={onClose}
-            sx={{
-              color: theme => theme.palette.grey[500],
-              flexGrow: 0,
-              height: 35,
-              marginTop: -1,
-              width: 35
-            }}
-          >
-            <CloseIcon />
-          </IconButton>
-        </Box>
+          <CloseIcon />
+        </IconButton>
       ) : null}
     </MuiDialogTitle>
   );


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-3050](https://sce.myjetbrains.com/youtrack/issue/TD-3050/DialogTitle-close-button-misaligned)

This PR fixes the issue found with close button misalignment of `DialogTitle` component used in many places. This issue first noticed in `DeleteLabelDialog` in SCENE. This PR also fixes some unwanted scroll appearing with default story in storybook of this component.

## Changes

- Removed the `width` property of `h2`(MUI DialogTitle) to fix the content scrolling
- Close button style updated fix alignment.


## UI/UX

Before
in RUI
![Screenshot 2024-09-03 161333](https://github.com/user-attachments/assets/5585abae-e2a4-40d2-b90f-10d2fa676bc0)

in SCENE
![Screenshot 2024-09-03 155124](https://github.com/user-attachments/assets/c3aed416-2366-4bfa-8f8f-95b63855672b)

After
in RUI
![Screenshot 2024-09-04 094055](https://github.com/user-attachments/assets/40c267c7-673c-4c99-ac87-f5af2e6e2486)

## Testing notes

- Use the deploy-preview to test this
- Make sure no scrollbar appears on dialog title stories and close button properly aligned to right
- Also no text overlapping with close button

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Lint and test workflows pass.
