### PR TITLE
TD - 3037 Update status card

### DIFF
--- a/src/Status/StatusCard/StatusCard.stories.tsx
+++ b/src/Status/StatusCard/StatusCard.stories.tsx
@@ -20,10 +20,26 @@ const Template: StoryFn<StatusCardProps> = args => {
   return <StatusCard {...args} />;
 };
 
+/**
+ * Default story
+ */
 export const Default = {
   args: {
     name: "Title",
     status: "passed"
+  },
+
+  render: Template
+};
+
+/**
+ * This story will display a tooltip on hover of the Icon
+ */
+export const WithIconTooltip = {
+  args: {
+    ...Default.args,
+    status: "failed",
+    title: "Last update: 2 days ago"
   },
 
   render: Template

--- a/src/Status/StatusCard/StatusCard.stories.tsx
+++ b/src/Status/StatusCard/StatusCard.stories.tsx
@@ -38,8 +38,8 @@ export const Default = {
 export const WithIconTooltip = {
   args: {
     ...Default.args,
-    status: "failed",
-    title: "Last update: 2 days ago"
+    iconTooltipText: "Last update: 2 days ago",
+    status: "failed"
   },
 
   render: Template

--- a/src/Status/StatusCard/StatusCard.tsx
+++ b/src/Status/StatusCard/StatusCard.tsx
@@ -4,35 +4,35 @@ import { Box, Card, CardContent, Typography } from "@mui/material";
 
 import { StatusCardProps } from "./StatusCard.types";
 import StatusIcon from "../StatusIcon/StatusIcon";
-import { grey } from "@mui/material/colors";
 import statuses from "../statuses";
 
 // custom card component that will be used to display status information
-const card = ({ status, name }: StatusCardProps) => {
+const card = ({ status, name, title }: StatusCardProps) => {
   const {
     label: { text }
   } = statuses[status];
   return (
     <CardContent
       sx={{
-        ":last-child": { pb: 2 }
+        ":last-child": { pb: 2 },
+        px: 2.5,
+        py: "14px"
       }}
     >
       <Box
         sx={{
           alignItems: "center",
-          display: "flex",
-          gap: "8px"
+          display: "flex"
         }}
       >
-        <StatusIcon status={status} width={39} height={39} />
+        <StatusIcon status={status} width={39} height={39} title={title} />
         <Box
           sx={{ display: "flex", flexDirection: "column", marginLeft: "8px" }}
         >
-          <Typography variant="subtitle2" color="text.primary">
+          <Typography variant="h6" color="text.primary" fontWeight={600}>
             {name}
           </Typography>
-          <Typography variant="body1" sx={{ color: grey[500] }}>
+          <Typography variant="caption" color="text.primary">
             {text}
           </Typography>
         </Box>
@@ -44,7 +44,8 @@ const card = ({ status, name }: StatusCardProps) => {
 // create a custom card component that will be used to display status information
 export default function StatusCard({
   status = "passed",
-  name = "Test"
+  name = "Test",
+  title = ""
 }: StatusCardProps) {
   // return components
   return (
@@ -52,7 +53,7 @@ export default function StatusCard({
       variant="outlined"
       sx={{ borderRadius: "6px", minWidth: "337px", width: "337px" }}
     >
-      {card({ name, status })}
+      {card({ name, status, title })}
     </Card>
   );
 }

--- a/src/Status/StatusCard/StatusCard.tsx
+++ b/src/Status/StatusCard/StatusCard.tsx
@@ -7,15 +7,15 @@ import StatusIcon from "../StatusIcon/StatusIcon";
 import statuses from "../statuses";
 
 // custom card component that will be used to display status information
-const card = ({ status, name, title }: StatusCardProps) => {
+const card = ({ status, name, iconTooltipText }: StatusCardProps) => {
   const {
     label: { text }
   } = statuses[status];
   return (
     <CardContent
       sx={{
-        ":last-child": { pb: 2 },
-        px: 2.5,
+        ":last-child": { pb: "14px" },
+        px: 3,
         py: "14px"
       }}
     >
@@ -25,7 +25,12 @@ const card = ({ status, name, title }: StatusCardProps) => {
           display: "flex"
         }}
       >
-        <StatusIcon status={status} width={39} height={39} title={title} />
+        <StatusIcon
+          status={status}
+          width={39}
+          height={39}
+          iconTooltipText={iconTooltipText}
+        />
         <Box
           sx={{ display: "flex", flexDirection: "column", marginLeft: "8px" }}
         >
@@ -45,15 +50,21 @@ const card = ({ status, name, title }: StatusCardProps) => {
 export default function StatusCard({
   status = "passed",
   name = "Test",
-  title = ""
+  iconTooltipText = ""
 }: StatusCardProps) {
   // return components
   return (
     <Card
       variant="outlined"
-      sx={{ borderRadius: "6px", minWidth: "337px", width: "337px" }}
+      sx={{
+        // border: theme =>
+        //   `1px solid ${alpha(theme.palette.background.default, 0.23)}`,
+        borderRadius: "6px",
+        minWidth: "337px",
+        width: "337px"
+      }}
     >
-      {card({ name, status, title })}
+      {card({ iconTooltipText, name, status })}
     </Card>
   );
 }

--- a/src/Status/StatusCard/StatusCard.types.ts
+++ b/src/Status/StatusCard/StatusCard.types.ts
@@ -9,4 +9,8 @@ export type StatusCardProps = {
    * The status message.
    */
   name: string;
+  /**
+   * Tooltip text to display on hover of the icon
+   */
+  title?: string;
 };

--- a/src/Status/StatusCard/StatusCard.types.ts
+++ b/src/Status/StatusCard/StatusCard.types.ts
@@ -12,5 +12,5 @@ export type StatusCardProps = {
   /**
    * Tooltip text to display on hover of the icon
    */
-  title?: string;
+  iconTooltipText?: string;
 };

--- a/src/Status/StatusIcon/StatusIcon.stories.tsx
+++ b/src/Status/StatusIcon/StatusIcon.stories.tsx
@@ -21,11 +21,26 @@ const Template: StoryFn<StatusIconProps> = args => {
   return <StatusIcon {...args} />;
 };
 
+/**
+ * Default story
+ */
 export const Default = {
   args: {
     height: 40,
     status: statusTypes[0],
     width: 40
+  },
+  render: Template
+};
+
+/**
+ * This story will display a tooltip on hover of the Icon
+ */
+export const WithTooltip = {
+  args: {
+    ...Default.args,
+    status: statusTypes[2],
+    title: "Last update: 2 days ago"
   },
   render: Template
 };

--- a/src/Status/StatusIcon/StatusIcon.stories.tsx
+++ b/src/Status/StatusIcon/StatusIcon.stories.tsx
@@ -39,8 +39,8 @@ export const Default = {
 export const WithTooltip = {
   args: {
     ...Default.args,
-    status: statusTypes[2],
-    title: "Last update: 2 days ago"
+    iconTooltipText: "Last update: 2 days ago",
+    status: statusTypes[2]
   },
   render: Template
 };

--- a/src/Status/StatusIcon/StatusIcon.test.tsx
+++ b/src/Status/StatusIcon/StatusIcon.test.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
-
+import React, { act } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
 import statuses, { statusTypes } from "../statuses";
 
 import StatusIcon from "./StatusIcon";
-import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 describe("StatusIcon", () => {
   test.each(statusTypes)("renders correct icon for %s", statusType => {
@@ -23,5 +23,33 @@ describe("StatusIcon", () => {
     expect(container.querySelector("svg")?.getAttribute("data-testid")).toEqual(
       iconContainer.querySelector("svg")?.getAttribute("data-testid")
     );
+  });
+
+  // renders tooltip on hover of an Icon
+  test("renders tooltip on hover", async () => {
+    render(<StatusIcon status={"disrupted"} title={"This a tooltip title"} />);
+
+    // trigger hover on the Icon
+    await act(async () => {
+      await userEvent.hover(screen.getByTestId("ErrorIcon"));
+    });
+
+    // wait for the tooltip to be visible
+    await waitFor(() => {
+      expect(
+        screen.getByRole("tooltip", {
+          hidden: true,
+          name: "This a tooltip title"
+        })
+      ).toBeVisible();
+    });
+  });
+
+  // test that the tooltip is not rendered when title is not passed
+  test("does not render tooltip when description is not passed", () => {
+    render(<StatusIcon status={"disrupted"} />);
+
+    // there shouldn't be a tooltip
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 });

--- a/src/Status/StatusIcon/StatusIcon.test.tsx
+++ b/src/Status/StatusIcon/StatusIcon.test.tsx
@@ -27,7 +27,12 @@ describe("StatusIcon", () => {
 
   // renders tooltip on hover of an Icon
   test("renders tooltip on hover", async () => {
-    render(<StatusIcon status={"disrupted"} title={"This a tooltip title"} />);
+    render(
+      <StatusIcon
+        status={"disrupted"}
+        iconTooltipText={"This a tooltip title"}
+      />
+    );
 
     // trigger hover on the Icon
     await act(async () => {

--- a/src/Status/StatusIcon/StatusIcon.tsx
+++ b/src/Status/StatusIcon/StatusIcon.tsx
@@ -11,13 +11,13 @@ export default function StatusIcon({
   status,
   width = 40,
   height = 40,
-  title
+  iconTooltipText
 }: StatusIconProps) {
   const {
     icon: { type: Icon, color }
   } = statuses[status];
   return (
-    <Tooltip title={title} placement="bottom">
+    <Tooltip title={iconTooltipText} placement="bottom">
       <Icon
         sx={{
           color,

--- a/src/Status/StatusIcon/StatusIcon.tsx
+++ b/src/Status/StatusIcon/StatusIcon.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { StatusIconProps } from "./StatusIcon.types";
+import { Tooltip } from "@mui/material";
 import statuses from "../statuses";
 
 /**
@@ -9,19 +10,22 @@ import statuses from "../statuses";
 export default function StatusIcon({
   status,
   width = 40,
-  height = 40
+  height = 40,
+  title
 }: StatusIconProps) {
   const {
     icon: { type: Icon, color }
   } = statuses[status];
   return (
-    <Icon
-      sx={{
-        color,
-        height,
-        padding: "2px",
-        width
-      }}
-    />
+    <Tooltip title={title} placement="bottom">
+      <Icon
+        sx={{
+          color,
+          height,
+          padding: "2px",
+          width
+        }}
+      />
+    </Tooltip>
   );
 }

--- a/src/Status/StatusIcon/StatusIcon.types.ts
+++ b/src/Status/StatusIcon/StatusIcon.types.ts
@@ -15,4 +15,8 @@ export type StatusIconProps = {
    * The status type.
    */
   status: Status;
+  /**
+   * Tooltip text to display on hover of the icon
+   */
+  title?: string;
 };

--- a/src/Status/StatusIcon/StatusIcon.types.ts
+++ b/src/Status/StatusIcon/StatusIcon.types.ts
@@ -18,5 +18,5 @@ export type StatusIconProps = {
   /**
    * Tooltip text to display on hover of the icon
    */
-  title?: string;
+  iconTooltipText?: string;
 };

--- a/src/Status/statuses.ts
+++ b/src/Status/statuses.ts
@@ -34,6 +34,15 @@ const statuses = {
       text: "Completed"
     }
   },
+  disrupted: {
+    icon: {
+      color: red[700],
+      type: Error
+    },
+    label: {
+      text: "Disrupted"
+    }
+  },
   errored: {
     icon: {
       color: red[700],
@@ -77,6 +86,15 @@ const statuses = {
     },
     label: {
       text: "Not Run"
+    }
+  },
+  operational: {
+    icon: {
+      color: green[800],
+      type: CheckCircle
+    },
+    label: {
+      text: "Operational"
     }
   },
   passed: {


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-3037](https://sce.myjetbrains.com/youtrack/issue/TD-3037/Update-StatusCard)

## Changes

- `Operational` and `Disrupted` statuses added to `statuses.ts`
- `StatusCard`  title and status `typography` updated as per Figma
- `Tooltip` added to `StatusIcon` with optional `title` prop
- New stories added for `tooltip`
- `StatusIcon` tests updated for `tooltip`

## UI/UX
Figma: https://www.figma.com/design/5qkWskMGpXY38REVIDcJnW/Landing-Page?node-id=3559-32542&node-type=FRAME&t=usvKg62evL72zXSb-0

New statuses
![Screenshot 2024-09-06 161002](https://github.com/user-attachments/assets/c49fe0a9-6a2e-4bca-94b9-1e78b6f03e8c)
![Screenshot 2024-09-06 160949](https://github.com/user-attachments/assets/7be7c88b-eefd-4b81-b12a-5ee4fa509122)

Status Icon updated style with tooltip
![Screenshot 2024-09-06 160234](https://github.com/user-attachments/assets/e54c6d27-338a-4cd6-bbdc-45b09706e021)

## Testing notes

- Check `StatusCard` typography and spacing is same as Figma now
- Check new Statuses are shown and working fine on `StatusCard` doc
- Check `Tooltip` is displayed on hover of icon if `title` prop exists

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Appropriate tests have been added.
- [x] Lint and test workflows pass.
