### PR TITLE
TD-3038 Update app launcher

### DIFF
--- a/src/AppLauncher/AppLauncher.tsx
+++ b/src/AppLauncher/AppLauncher.tsx
@@ -164,7 +164,7 @@ function AppLauncher({
           );
         })}
       </Box>
-      <Divider sx={{ margin: theme => theme.spacing(0, 0, 3, 0) }} />
+      <Divider sx={{ margin: theme => theme.spacing(0, 0, 2.5, 0) }} />
       <Box sx={{ textAlign: "center" }}>
         <Link
           data-testid="virto-status-link"

--- a/src/AppLauncher/AppLauncher.tsx
+++ b/src/AppLauncher/AppLauncher.tsx
@@ -164,13 +164,13 @@ function AppLauncher({
           );
         })}
       </Box>
-      <Divider sx={{ margin: theme => theme.spacing(0, 0, 2.5, 0) }} />
+      <Divider sx={{ mb: 2.5 }} />
       <Box sx={{ textAlign: "center" }}>
         <Link
-          data-testid="virto-status-link"
+          data-testid="app-launcher-status-link"
           href={`${baseUrl}/status`}
           variant="body1"
-          underline="none"
+          underline="hover"
           target="_blank"
         >
           VIRTO Status

--- a/src/AppLauncher/AppLauncher.tsx
+++ b/src/AppLauncher/AppLauncher.tsx
@@ -164,6 +164,18 @@ function AppLauncher({
           );
         })}
       </Box>
+      <Divider sx={{ margin: theme => theme.spacing(0, 0, 3, 0) }} />
+      <Box sx={{ textAlign: "center" }}>
+        <Link
+          data-testid="virto-status-link"
+          href={`${baseUrl}/status`}
+          variant="body1"
+          underline="none"
+          target="_blank"
+        >
+          VIRTO Status
+        </Link>
+      </Box>
       <Box flexGrow={1} />
     </Box>
   );

--- a/src/VirtoAppHeader/VirtoAppHeader.tsx
+++ b/src/VirtoAppHeader/VirtoAppHeader.tsx
@@ -155,7 +155,7 @@ function VirtoAppHeader({
         onClose={() => setAppOpen(false)}
         sx={{
           "& .MuiDrawer-paper": {
-            height: theme => `calc(100% - ${theme.mixins.toolbar.minHeight})`,
+            height: theme => `calc(100% - ${theme.mixins.toolbar.minHeight}px)`,
             top: theme => theme.mixins.toolbar.minHeight,
             width: applancherWidth
           }


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->

Closes [TD-3038](https://sce.myjetbrains.com/youtrack/issue/TD-3038/Update-AppLauncher)

## Changes

- Added "VIRTO Status" link text at the bottom of  `AppLauncher`
- Added missing `px` in height calucation for `Drawer` in `VirtoAppHeader` which was causing missing padding bottom in the launcher when there is a scroller.

## UI/UX

Figma: https://www.figma.com/design/5qkWskMGpXY38REVIDcJnW/Landing-Page?node-id=2480-13370&node-type=CANVAS&t=usvKg62evL72zXSb-0

VIRTO Status link in `AppLauncher`
![Screenshot 2024-09-06 165302](https://github.com/user-attachments/assets/983b00c4-847a-491e-8eb0-d5ec0949b0f8)


## Testing notes

- Check 'AppLauncher`  has new "VIRTO Sataus" link text at the bottom which opens in a new tab
- Check  'AppLauncher` renders with  "VIRTO Sataus" link in `VirtoAppLayout` and there is padding at the bottom if there is a scroller

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [x] Lint and test workflows pass.
