### PR TITLE
TD-3034 Added Optional SX Props

### DIFF
--- a/src/RoadPreview/RoadPreview.stories.tsx
+++ b/src/RoadPreview/RoadPreview.stories.tsx
@@ -69,6 +69,12 @@ export const Default = {
       }
     ],
     name: "SanFrancisco_AEB",
+    sx: {
+      borderRadius: "8px",
+      boxShadow: 3,
+      maxWidth: "480px",
+      padding: "16px"
+    },
     user: "James Harper",
     version: "1.1"
   },
@@ -111,6 +117,7 @@ export const WithoutOptionalProps = {
     href: "test",
     image: "https://picsum.photos/id/191/400/200",
     name: "SanFrancisco_AEB",
+    sx: { ...Default.args.sx },
     version: "1.1"
   },
   render: Template

--- a/src/RoadPreview/RoadPreview.tsx
+++ b/src/RoadPreview/RoadPreview.tsx
@@ -35,7 +35,8 @@ export function RoadPreview({
   file,
   createdAt,
   user,
-  label = []
+  label = [],
+  sx
 }: RoadPreviewProps) {
   // theme hook for returning specific colors from the theme to MUI icon
   const theme = useTheme();
@@ -63,13 +64,7 @@ export function RoadPreview({
       minWidth={0}
       fontFamily="Montserrat"
       data-testid="road-preview-wrapper"
-      sx={{
-        borderRadius: "8px",
-        boxShadow: 3,
-        boxSizing: "border-box",
-        maxWidth: "480px",
-        padding: "16px"
-      }}
+      sx={{ ...sx }}
     >
       <Box gap={1}>
         <Stack direction="row" spacing={1} minWidth={0}>

--- a/src/RoadPreview/RoadPreview.types.ts
+++ b/src/RoadPreview/RoadPreview.types.ts
@@ -1,4 +1,4 @@
-import { SxProps } from "@mui/material";
+import { SxProps, Theme } from "@mui/material";
 
 export type File = {
   /**
@@ -77,7 +77,7 @@ export type RoadPreviewProps = {
    */
   label?: Label[];
   /**
-   * Style props for wrapper of the component road preview
+   * Additional styles to apply for the road preview wrapper
    */
-  sx?: SxProps & {};
+  sx?: SxProps<Theme>;
 };

--- a/src/RoadPreview/RoadPreview.types.ts
+++ b/src/RoadPreview/RoadPreview.types.ts
@@ -1,3 +1,5 @@
+import { SxProps } from "@mui/material";
+
 export type File = {
   /**
    * Unique identifier of the file
@@ -74,4 +76,8 @@ export type RoadPreviewProps = {
    * Label/s which are set to this road
    */
   label?: Label[];
+  /**
+   * Style props for wrapper of the component road preview
+   */
+  sx?: SxProps & {};
 };


### PR DESCRIPTION
Closes [TD-3034](https://sce.myjetbrains.com/youtrack/issue/TD-3034/Add-new-RoadPreview-component-to-RUI)
Contributes to [TD-3034](https://sce.myjetbrains.com/youtrack/issue/TD-3034/Add-new-RoadPreview-component-to-RUI)

## Changes

Added optional SX style props to RoadPreview component.

A brief description of what this pull request solves / introduces.

- Possibility to adjust the styles of the wrapper element of RoadPreview component.

## Dependencies

N/A

## UI/UX
![image](https://github.com/user-attachments/assets/9cc4660a-8311-4a82-9e9a-3147d109fe84)
![image](https://github.com/user-attachments/assets/2ad5e2c0-ab51-44fb-9252-ec2760fc4407)

## Testing notes

We can change the SX properties so the styles are updated on RoadPreview wrapper element

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [ ] ~Branch has been run in docker.~
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] ~Appropriate tests have been added.~
- [x] Lint and test workflows pass.
