### PR TITLE
TD-3039 Add titleVariant prop

### DIFF
--- a/src/Status/StatusCard/StatusCard.stories.tsx
+++ b/src/Status/StatusCard/StatusCard.stories.tsx
@@ -52,7 +52,7 @@ const statusList = [
 /**
  * Story template for the StatusCard with a fixed width wrapper
  */
-const WithFixedWidth: StoryFn<StatusCardProps> = args => {
+const WithGrid: StoryFn<StatusCardProps> = args => {
   return (
     <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
       {statusList.map(s => {
@@ -110,9 +110,19 @@ export const WithIconTooltip = {
  * This story will display a different title variant and truncated title with tooltip if it is too long
  */
 export const WithGridLayout = {
+  argTypes: {
+    iconTooltipText: {
+      control: false
+    },
+    name: {
+      control: false
+    },
+    status: {
+      control: false
+    }
+  },
   args: {
     ...Default.args
   },
-
-  render: WithFixedWidth
+  render: WithGrid
 };

--- a/src/Status/StatusCard/StatusCard.stories.tsx
+++ b/src/Status/StatusCard/StatusCard.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryFn } from "@storybook/react";
 
+import { Box } from "@mui/material";
 import React from "react";
 import StatusCard from "./StatusCard";
 import { StatusCardProps } from "./StatusCard.types";
@@ -18,6 +19,66 @@ export default meta;
  */
 const Template: StoryFn<StatusCardProps> = args => {
   return <StatusCard {...args} />;
+};
+
+// List of statuses to display
+const statusList = [
+  {
+    name: "Test title 1",
+    status: "failed"
+  },
+  {
+    name: "This is a long title that will be truncated as this is a long title that will be truncated",
+    status: "passed"
+  },
+  {
+    name: "Test title 2",
+    status: "pending"
+  },
+  {
+    name: "Test title 3",
+    status: "completed"
+  },
+  {
+    name: "Test title 4",
+    status: "queued"
+  },
+  {
+    name: "Another title that will be truncated as this is a long title that will be truncated",
+    status: "cancelled"
+  }
+] as const;
+
+/**
+ * Story template for the StatusCard with a fixed width wrapper
+ */
+const WithFixedWidth: StoryFn<StatusCardProps> = args => {
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+      {statusList.map(s => {
+        return (
+          <Box
+            key={s.name}
+            sx={theme => ({
+              flex: "1 1 100%",
+              [theme.breakpoints.up("lg")]: {
+                flex: "1 1 30%"
+              },
+              [theme.breakpoints.up("md")]: {
+                flex: "1 1 40%"
+              }
+            })}
+          >
+            <StatusCard
+              name={s.name}
+              status={s.status}
+              titleVariant={args.titleVariant}
+            />
+          </Box>
+        );
+      })}
+    </Box>
+  );
 };
 
 /**
@@ -43,4 +104,15 @@ export const WithIconTooltip = {
   },
 
   render: Template
+};
+
+/**
+ * This story will display a different title variant and truncated title with tooltip if it is too long
+ */
+export const WithGridLayout = {
+  args: {
+    ...Default.args
+  },
+
+  render: WithFixedWidth
 };

--- a/src/Status/StatusCard/StatusCard.stories.tsx
+++ b/src/Status/StatusCard/StatusCard.stories.tsx
@@ -50,7 +50,7 @@ const statusList = [
 ] as const;
 
 /**
- * Story template for the StatusCard with a fixed width wrapper
+ * Story template for the StatusCard with grid layout
  */
 const WithGrid: StoryFn<StatusCardProps> = args => {
   return (

--- a/src/Status/StatusCard/StatusCard.stories.tsx
+++ b/src/Status/StatusCard/StatusCard.stories.tsx
@@ -54,29 +54,24 @@ const statusList = [
  */
 const WithGrid: StoryFn<StatusCardProps> = args => {
   return (
-    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-      {statusList.map(s => {
-        return (
-          <Box
-            key={s.name}
-            sx={theme => ({
-              flex: "1 1 100%",
-              [theme.breakpoints.up("lg")]: {
-                flex: "1 1 30%"
-              },
-              [theme.breakpoints.up("md")]: {
-                flex: "1 1 40%"
-              }
-            })}
-          >
-            <StatusCard
-              name={s.name}
-              status={s.status}
-              titleVariant={args.titleVariant}
-            />
-          </Box>
-        );
+    <Box
+      sx={theme => ({
+        display: "grid",
+        gap: 1,
+        [theme.breakpoints.up("lg")]: {
+          gridTemplateColumns: "repeat(3, 1fr)"
+        },
+        [theme.breakpoints.up("sm")]: { gridTemplateColumns: "repeat(2, 1fr)" }
       })}
+    >
+      {statusList.map(s => (
+        <StatusCard
+          key={s.name}
+          name={s.name}
+          status={s.status}
+          titleVariant={args.titleVariant}
+        />
+      ))}
     </Box>
   );
 };

--- a/src/Status/StatusCard/StatusCard.test.tsx
+++ b/src/Status/StatusCard/StatusCard.test.tsx
@@ -45,4 +45,22 @@ describe("StatusCard", () => {
       );
     }
   );
+
+  test("renders titleVariant prop", () => {
+    // data to render
+    const status = "passed";
+    const name = "Test title";
+    const titleVariant = "h6";
+
+    // render the component
+    render(
+      <StatusCard status={status} name={name} titleVariant={titleVariant} />
+    );
+
+    // find the title element
+    const titleElement = screen.getByText(name);
+
+    // expect the titleElement has font size of h6
+    expect(titleElement).toHaveStyle("font-size: 1.25rem");
+  });
 });

--- a/src/Status/StatusCard/StatusCard.tsx
+++ b/src/Status/StatusCard/StatusCard.tsx
@@ -4,10 +4,16 @@ import { Box, Card, CardContent, Typography } from "@mui/material";
 
 import { StatusCardProps } from "./StatusCard.types";
 import StatusIcon from "../StatusIcon/StatusIcon";
+import TruncatedTooltip from "../../TruncatedTooltip";
 import statuses from "../statuses";
 
 // custom card component that will be used to display status information
-const card = ({ status, name, iconTooltipText }: StatusCardProps) => {
+const card = ({
+  status,
+  name,
+  iconTooltipText,
+  titleVariant
+}: StatusCardProps) => {
   const {
     label: { text }
   } = statuses[status];
@@ -15,7 +21,6 @@ const card = ({ status, name, iconTooltipText }: StatusCardProps) => {
     <CardContent
       sx={{
         ":last-child": { pb: "14px" },
-        px: 3,
         py: "14px"
       }}
     >
@@ -32,11 +37,21 @@ const card = ({ status, name, iconTooltipText }: StatusCardProps) => {
           iconTooltipText={iconTooltipText}
         />
         <Box
-          sx={{ display: "flex", flexDirection: "column", marginLeft: "8px" }}
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            marginLeft: "8px"
+          }}
         >
-          <Typography variant="h6" color="text.primary" fontWeight={600}>
-            {name}
-          </Typography>
+          <TruncatedTooltip multiline={1}>
+            <Typography
+              variant={titleVariant}
+              color="text.primary"
+              fontWeight={600}
+            >
+              {name}
+            </Typography>
+          </TruncatedTooltip>
           <Typography variant="caption" color="text.primary">
             {text}
           </Typography>
@@ -50,7 +65,8 @@ const card = ({ status, name, iconTooltipText }: StatusCardProps) => {
 export default function StatusCard({
   status = "passed",
   name = "Test",
-  iconTooltipText = ""
+  iconTooltipText = "",
+  titleVariant = "subtitle2"
 }: StatusCardProps) {
   // return components
   return (
@@ -60,7 +76,7 @@ export default function StatusCard({
         borderRadius: "6px"
       }}
     >
-      {card({ iconTooltipText, name, status })}
+      {card({ iconTooltipText, name, status, titleVariant })}
     </Card>
   );
 }

--- a/src/Status/StatusCard/StatusCard.types.ts
+++ b/src/Status/StatusCard/StatusCard.types.ts
@@ -1,4 +1,5 @@
 import { Status } from "../statuses.types";
+import { TypographyVariant } from "@mui/material";
 
 export type StatusCardProps = {
   /**
@@ -13,4 +14,8 @@ export type StatusCardProps = {
    * Tooltip text to display on hover of the icon
    */
   iconTooltipText?: string;
+  /**
+   * The variant of the title
+   */
+  titleVariant?: TypographyVariant;
 };


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Closes/Contributes [TD-3037](https://sce.myjetbrains.com/youtrack/issue/TD-3037/Update-StatusCard)

While working on this [TD-3039](https://sce.myjetbrains.com/youtrack/issue/TD-3039/Update-RUI-in-all-apps) i came to notice in FLEET under quality tab the `StatusCard` title size was not quite as the previous design, this was actually fixed in `StatusCard`. To fix this we are adding a `titleVariant` prop to `StatusCard`. We also noticed the `StatusCard` title is not taking care of long texts, to fix this i have wrapped `StatusCard` title within `TruncatedTooltip`.

Issue in FLEET
![Screenshot 2024-09-12 163354](https://github.com/user-attachments/assets/8cc4852b-d861-4cc9-b2cd-3cb5cedc279c)

## Changes

- Added optional `titleVariant` which defaults to `subtitle2`
- Added `WithGridLayout` story which shows  `StatusCard` in grid layout with a dynamically added with to the wrapper.
- Wrapped `StatusCard` title with `TruncatedTooltip`, now overflowing text will shown in a tooltip.

## UI/UX
@Sowbhagya-ipg 
![Screenshot 2024-09-12 164845](https://github.com/user-attachments/assets/b4c26806-4677-4400-bfe5-2d8eb54c5e74)

## Testing notes

- Check the `titleVariant` works fine on doc.
- Check new story properly demonstares the grid use-case. 
- Check title is truncated and shown in a tooltip on hover

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- [ ] ~I have populated the deploy-preview with relevant test data.~
