### PR TITLE
TD-3034 Remove redundant properties from RoadPreview types

### DIFF
--- a/src/RoadPreview/RoadPreview.stories.tsx
+++ b/src/RoadPreview/RoadPreview.stories.tsx
@@ -54,10 +54,16 @@ export const Default = {
         name: "Test label 4"
       },
       {
-        _id: "66cde4855d45d85421f8620e",
-        color: "rgb(121, 0, 168)",
-        description: "desc for hi",
+        _id: "66cd24823d45d85421f8620c",
+        color: "#005FA8",
+        description: "desc for 1 hi",
         name: "Test label 3"
+      },
+      {
+        _id: "66cd24823f15d85421f8620s",
+        color: "#005FA8",
+        description: "last",
+        name: "last"
       }
     ],
     name: "SanFrancisco_AEB",
@@ -86,7 +92,7 @@ export const WithOverflowText = {
       name: "A very looooooooooong Road File Name"
     },
     format: "ASAM OpenDRIVE",
-    label: [Default.args.label.pop()],
+    label: [Default.args?.label[Default?.args?.label?.length - 1]],
     name: "SanFrancisco_AEB_A looooong Road Name",
     user: "James a very long middle name Harper"
   },

--- a/src/RoadPreview/RoadPreview.stories.tsx
+++ b/src/RoadPreview/RoadPreview.stories.tsx
@@ -38,34 +38,26 @@ export const Default = {
       {
         _id: "66cd9b326217e44d2810e9d3",
         color: "#005FA8",
-        createdAt: "2024-08-27T09:24:02.096Z",
         description: "Label 1 desc",
-        name: "Label 1--------------rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
-        updatedAt: "2024-08-28T09:39:02.748Z"
+        name: "&test 09999"
       },
       {
         _id: "66cd9b8d6217e44d2810e9f7",
         color: "#005FA8",
-        createdAt: "2024-08-27T09:25:33.849Z",
         description: "one2three4",
-        name: "&1234",
-        updatedAt: "2024-09-03T08:42:18.213Z"
+        name: "&1234"
       },
       {
         _id: "66cde4855d45d85421f8620e",
         color: "rgb(121, 0, 168)",
-        createdAt: "2024-08-27T14:36:53.275Z",
         description: "desc for hi",
-        name: "Test label 3",
-        updatedAt: "2024-08-27T14:36:53.275Z"
+        name: "Test label 3"
       },
       {
         _id: "66cde4855d45d85421f8620e",
         color: "rgb(121, 0, 168)",
-        createdAt: "2024-08-27T14:36:53.275Z",
         description: "desc for hi",
-        name: "Test label 3",
-        updatedAt: "2024-08-27T14:36:53.275Z"
+        name: "Test label 3"
       }
     ],
     name: "SanFrancisco_AEB",

--- a/src/RoadPreview/RoadPreview.stories.tsx
+++ b/src/RoadPreview/RoadPreview.stories.tsx
@@ -92,7 +92,7 @@ export const WithOverflowText = {
       name: "A very looooooooooong Road File Name"
     },
     format: "ASAM OpenDRIVE",
-    label: [Default.args?.label[Default?.args?.label?.length - 1]],
+    label: [Default.args.label[0]],
     name: "SanFrancisco_AEB_A looooong Road Name",
     user: "James a very long middle name Harper"
   },

--- a/src/RoadPreview/RoadPreview.stories.tsx
+++ b/src/RoadPreview/RoadPreview.stories.tsx
@@ -51,7 +51,7 @@ export const Default = {
         _id: "66cde4855d45d85421f8620e",
         color: "rgb(121, 0, 168)",
         description: "desc for hi",
-        name: "Test label 3"
+        name: "Test label 4"
       },
       {
         _id: "66cde4855d45d85421f8620e",

--- a/src/RoadPreview/RoadPreview.test.tsx
+++ b/src/RoadPreview/RoadPreview.test.tsx
@@ -60,8 +60,8 @@ describe("RoadPreview", () => {
   // test if correct properties are rendered
   test("render the correct properties", () => {
     const currentTestFormat = "ASAM OpenDRIVE";
-    const currentLabel = Default.args.label[0];
-    render(
+    const firstLabel = Default.args.label[0];
+    const { container } = render(
       <RoadPreview
         name={Default.args.name}
         href={Default.args.href}
@@ -71,8 +71,9 @@ describe("RoadPreview", () => {
         format={currentTestFormat}
         formatVersion={Default.args.formatVersion}
         file={Default.args.file}
-        label={[currentLabel]}
+        label={Default.args.label}
         user={Default.args.user}
+        createdAt={Default.args.createdAt}
       />
     );
     // Get the current icon by alt text, so we can test the src attribute value
@@ -98,11 +99,15 @@ describe("RoadPreview", () => {
       "road-preview-format-version"
     );
 
-    // Get label rendered
-    const label = screen.getByText(currentLabel.name);
+    // Get first label and all labels
+    const label = screen.getByText(firstLabel.name);
+    const allLabels = container.querySelectorAll(".MuiChip-root");
 
     // Get user name rendered
     const user = screen.getByTestId("road-preview-user");
+
+    // Get created at date
+    const createdAt = screen.getByTestId("road-preview-created");
 
     // Check if AsamIcon component rendered
     expect(iconElement).toBeInTheDocument();
@@ -134,11 +139,16 @@ describe("RoadPreview", () => {
     // Check if href attribute of the road name element matches with the correct link
     expect(roadNameElement.getAttribute("href")).toContain(Default.args.href);
 
-    // Check if label is rendered
+    // Check if labels are rendered
     expect(label).toBeInTheDocument();
+    expect(allLabels.length).toBeGreaterThan(1);
 
     // Check if user name is rendered with correct value
     expect(user).toBeInTheDocument();
     expect(user).toHaveTextContent(Default.args.user);
+
+    // Check if created date is rendered with correct value
+    expect(createdAt).toBeInTheDocument();
+    expect(createdAt).toHaveTextContent(Default.args.createdAt);
   });
 });

--- a/src/RoadPreview/RoadPreview.test.tsx
+++ b/src/RoadPreview/RoadPreview.test.tsx
@@ -60,6 +60,7 @@ describe("RoadPreview", () => {
   // test if correct properties are rendered
   test("render the correct properties", () => {
     const currentTestFormat = "ASAM OpenDRIVE";
+    const currentLabel = Default.args.label[0];
     render(
       <RoadPreview
         name={Default.args.name}
@@ -70,6 +71,8 @@ describe("RoadPreview", () => {
         format={currentTestFormat}
         formatVersion={Default.args.formatVersion}
         file={Default.args.file}
+        label={[currentLabel]}
+        user={Default.args.user}
       />
     );
     // Get the current icon by alt text, so we can test the src attribute value
@@ -94,6 +97,12 @@ describe("RoadPreview", () => {
     const formatVersionElement = screen.getByTestId(
       "road-preview-format-version"
     );
+
+    // Get label rendered
+    const label = screen.getByText(currentLabel.name);
+
+    // Get user name rendered
+    const user = screen.getByTestId("road-preview-user");
 
     // Check if AsamIcon component rendered
     expect(iconElement).toBeInTheDocument();
@@ -124,5 +133,12 @@ describe("RoadPreview", () => {
 
     // Check if href attribute of the road name element matches with the correct link
     expect(roadNameElement.getAttribute("href")).toContain(Default.args.href);
+
+    // Check if label is rendered
+    expect(label).toBeInTheDocument();
+
+    // Check if user name is rendered with correct value
+    expect(user).toBeInTheDocument();
+    expect(user).toHaveTextContent(Default.args.user);
   });
 });

--- a/src/RoadPreview/RoadPreview.tsx
+++ b/src/RoadPreview/RoadPreview.tsx
@@ -192,7 +192,11 @@ export function RoadPreview({
                         />
                       </Tooltip>
 
-                      <Typography color="textSecondary" variant="caption">
+                      <Typography
+                        color="textSecondary"
+                        variant="caption"
+                        data-testid="road-preview-created"
+                      >
                         {createdAt}
                       </Typography>
                     </Stack>

--- a/src/RoadPreview/RoadPreview.tsx
+++ b/src/RoadPreview/RoadPreview.tsx
@@ -217,7 +217,11 @@ export function RoadPreview({
                         </div>
                       </Tooltip>
                       <NoWrapTypography>
-                        <Typography color="textSecondary" variant="caption">
+                        <Typography
+                          color="textSecondary"
+                          variant="caption"
+                          data-testid="road-preview-user"
+                        >
                           {user}
                         </Typography>
                       </NoWrapTypography>

--- a/src/RoadPreview/RoadPreview.types.ts
+++ b/src/RoadPreview/RoadPreview.types.ts
@@ -1,5 +1,7 @@
 import { SxProps, Theme } from "@mui/material";
 
+import { Label } from "../LabelSelector/Label.types";
+
 export type File = {
   /**
    * Unique identifier of the file
@@ -17,15 +19,6 @@ export type File = {
    * Path to the file on file-service. This is an internal only field and should not be exposed to the client.
    */
   path?: string;
-};
-
-export type Label = {
-  _id: string;
-  name: string;
-  description: string;
-  color: string;
-  createdAt: string;
-  updatedAt: string;
 };
 
 /**


### PR DESCRIPTION
Closes/Contributes [TD-3034](https://sce.myjetbrains.com/youtrack/issue/TD-3034/Add-new-RoadPreview-component-to-RUI)

## Changes

Removed Label type from RoadPreview types and added the correct one, which is Label, but from LabelSelector component. Two of the properties in the removed type createdAt and updatedAt were redundant and causing problems in Virto, because this was not the appropriate type.

A brief description of what this pull request solves / introduces.

- Added the correct label type
- Removed createdAt and updatedAt from the stories as well

## Dependencies
N/A

## UI/UX
N/A

## Testing notes


## Author checklist

Before I request a review:


- [x] I have reviewed my own code-diff.
- ~I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~I have populated the deploy-preview with relevant test data.~
