### PR TITLE
TD-3081 Renamed Cancel status to Aborted

### DIFF
--- a/src/Status/StatusCard/StatusCard.stories.tsx
+++ b/src/Status/StatusCard/StatusCard.stories.tsx
@@ -45,7 +45,7 @@ const statusList = [
   },
   {
     name: "Another title that will be truncated as this is a long title that will be truncated",
-    status: "cancelled"
+    status: "aborted"
   }
 ] as const;
 

--- a/src/Status/statuses.ts
+++ b/src/Status/statuses.ts
@@ -16,13 +16,13 @@ import { amber, green, grey, indigo, red, teal } from "@mui/material/colors";
  * Handles icon, colours and label for each status type
  */
 const statuses = {
-  cancelled: {
+  aborted: {
     icon: {
       color: grey[500],
       type: Block
     },
     label: {
-      text: "Cancelled"
+      text: "Aborted"
     }
   },
   completed: {


### PR DESCRIPTION
Closes/Contributes [TD-3081](https://sce.myjetbrains.com/youtrack/issue/TD-3081/Rename-cancelled-status-to-aborted-in-RUI)

## Changes

Changed status name from cancelled to aborted in RUI Status card component and in statuses config file.
Icon stays the same. 

A brief description of what this pull request solves / introduces.

- Renamed "Cancelled" to "Aborted" in Status Card


## Dependencies

N/A

## UI/UX

Before
![image](https://github.com/user-attachments/assets/c5c38b71-c6fe-4de9-996c-15941d2f1941)

After
![image](https://github.com/user-attachments/assets/0398fd1d-c598-4579-9c95-6ae98d35c0ed)


## Testing notes

N/A

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- ~[ ] I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~[ ] I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[ ] I have populated the deploy-preview with relevant test data.~
