### PR TITLE
bug/Release v8.9.0 - "string can not be used to index object" build error 

### DIFF
--- a/src/Status/StatusCountTable/StatusCountTable.tsx
+++ b/src/Status/StatusCountTable/StatusCountTable.tsx
@@ -21,6 +21,9 @@ export function StatusCountTable({ title, count }: StatusCountTableProps) {
   /** Calculate the total cound of the statuses */
   const totalCount = Object.values(count).reduce((a, b) => a + b, 0);
 
+  /** Keys of the count object */
+  const countKeys = Object.keys(count) as (keyof typeof count)[];
+
   return (
     <TableContainer
       sx={{ borderRadius: "4px", boxShadow: 8, maxWidth: "280px" }}
@@ -49,29 +52,27 @@ export function StatusCountTable({ title, count }: StatusCountTableProps) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {Object.keys(count)
-            .reverse()
-            .map(row => (
-              <TableRow
-                key={row}
-                sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
-              >
-                <TableCell sx={{ pl: 2 }} component="th" scope="row">
-                  <Typography
-                    variant="body2"
-                    display="flex"
-                    alignItems="center"
-                    gap="8px"
-                  >
-                    <StatusIcon status={row as Status} width={24} height={24} />
-                    {statuses[row].label.text}
-                  </Typography>
-                </TableCell>
-                <TableCell align="right" sx={{ pr: 2 }}>
-                  <Typography variant="body2">{count[row]}</Typography>
-                </TableCell>
-              </TableRow>
-            ))}
+          {countKeys.reverse().map(row => (
+            <TableRow
+              key={row}
+              sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+            >
+              <TableCell sx={{ pl: 2 }} component="th" scope="row">
+                <Typography
+                  variant="body2"
+                  display="flex"
+                  alignItems="center"
+                  gap="8px"
+                >
+                  <StatusIcon status={row as Status} width={24} height={24} />
+                  {statuses[row].label.text}
+                </Typography>
+              </TableCell>
+              <TableCell align="right" sx={{ pr: 2 }}>
+                <Typography variant="body2">{count[row]}</Typography>
+              </TableCell>
+            </TableRow>
+          ))}
         </TableBody>
       </Table>
     </TableContainer>


### PR DESCRIPTION
Fixes an uncaught error from  [TD-955](https://github.com/IPG-Automotive-UK/react-ui/pull/955)

## Changes

Cast the string keys to a type that is a keyof the object. This was done to fix an uncaught error that was merged to main. 

Detailed below is how it was missed and caught:

Currently on RUI the linting does not catch this type of error among some others. Running the type-checks also does not expose the error. The only way to see the error is by running a build.

Updates not in this PR but being made for the upcoming major release:

- Bring linting in line with VIRTO so these issues can be caught earlier
- Adding a build step to the github CI/CD to ensure this builds correctly before we attempt a release
- Add running a build to the release checks in the Readme.

The above changes will be made in a following PR

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- ~~[ ] I have tested the changes in Docker / a deploy-preview.~~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~~[ ] I have included appropriate tests.~~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~~[ ] I have populated the deploy-preview with relevant test data.~~
