### PR TITLE
TD-3097 Fix of the heigth and padding of the ststus count bar

### DIFF
--- a/src/Status/StatusCountBar/StatusCountBar.tsx
+++ b/src/Status/StatusCountBar/StatusCountBar.tsx
@@ -28,7 +28,6 @@ export function StatusCountBar({ title, count }: StatusCountBarProps) {
     <>
       <Box
         display="flex"
-        height="14px"
         width="100%"
         padding="2px"
         gap="2px"
@@ -43,6 +42,7 @@ export function StatusCountBar({ title, count }: StatusCountBarProps) {
               key={status}
               sx={{
                 backgroundColor: color,
+                height: "14px",
                 width: `${percentage}%`
               }}
               data-testid={`status-bar-${status}`}


### PR DESCRIPTION
Closes: [TD-3097](https://sce.myjetbrains.com/youtrack/issue/TD-3097)

Contributes to: [TD-3065](https://sce.myjetbrains.com/youtrack/issue/TD-3065)

## Changes

- Applied a change to the height of the count bar to be with right design.
- The height is now applied to each individual box that form the whole bar, and the padding is on the wrapper.

## Dependencies
N/A

## UI/UX
before:
![image (4)](https://github.com/user-attachments/assets/1bac7d74-d526-491a-a973-e8895da3d2bf)

after:
![image](https://github.com/user-attachments/assets/6b6614bd-c55d-46ea-b327-dd8d8b954dd7)


## Testing notes

Check the padding and the height in the browser.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [ ] ~I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [ ] ~I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- [ ] ~I have populated the deploy-preview with relevant test data.~
