### PR TITLE
TD 3111 Add Status Count Bar Component Bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.10.0-3",
+  "version": "8.10.0-4",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/Status/StatusCountBar/StatusCountBar.types.ts
+++ b/src/Status/StatusCountBar/StatusCountBar.types.ts
@@ -8,5 +8,5 @@ export type StatusCountBarProps = {
   /**
    * The status count object of different statuses.
    */
-  count: Record<Status, number>;
+  count: Record<Partial<Status>, number>;
 };

--- a/src/Status/StatusCountBar/StatusCountBar.types.ts
+++ b/src/Status/StatusCountBar/StatusCountBar.types.ts
@@ -1,4 +1,4 @@
-import { Status } from "../statuses.types";
+import { StatusCount } from "../StatusCountTable";
 
 export type StatusCountBarProps = {
   /**
@@ -8,5 +8,5 @@ export type StatusCountBarProps = {
   /**
    * The status count object of different statuses.
    */
-  count: Record<Partial<Status>, number>;
+  count: StatusCount;
 };

--- a/src/Status/StatusCountBar/StatusCountBar.types.ts
+++ b/src/Status/StatusCountBar/StatusCountBar.types.ts
@@ -1,12 +1,4 @@
-import { StatusCount } from "../StatusCountTable";
+import type { StatusCountTableProps } from "../StatusCountTable";
 
-export type StatusCountBarProps = {
-  /**
-   * The status bar title.
-   */
-  title: string;
-  /**
-   * The status count object of different statuses.
-   */
-  count: StatusCount;
-};
+// StatusCountBar shares the same props as StatusCountTable
+export type StatusCountBarProps = StatusCountTableProps;

--- a/src/Status/StatusCountTable/StatusCountTable.types.ts
+++ b/src/Status/StatusCountTable/StatusCountTable.types.ts
@@ -1,7 +1,5 @@
 import { Status } from "../statuses.types";
 
-export type StatusCount = Partial<Record<Status, number>>;
-
 export type StatusCountTableProps = {
   /**
    * Title of the table
@@ -10,5 +8,5 @@ export type StatusCountTableProps = {
   /**
    * Count is an object which contains objects with partial key status name and status count
    */
-  count: StatusCount;
+  count: Partial<Record<Status, number>>;
 };

--- a/src/Status/StatusCountTable/StatusCountTable.types.ts
+++ b/src/Status/StatusCountTable/StatusCountTable.types.ts
@@ -1,12 +1,14 @@
 import { Status } from "../statuses.types";
 
+export type StatusCount = Partial<Record<Status, number>>;
+
 export type StatusCountTableProps = {
   /**
    * Title of the table
    */
   title: string;
   /**
-   * Count is an object which contains objects with key status name and status count
+   * Count is an object which contains objects with partial key status name and status count
    */
-  count: Record<Partial<Status>, number>;
+  count: StatusCount;
 };

--- a/src/Status/StatusCountTable/StatusCountTable.types.ts
+++ b/src/Status/StatusCountTable/StatusCountTable.types.ts
@@ -8,5 +8,5 @@ export type StatusCountTableProps = {
   /**
    * Count is an object which contains objects with key status name and status count
    */
-  count: Record<Status, number>;
+  count: Record<Partial<Status>, number>;
 };

--- a/src/Status/StatusCountTable/index.ts
+++ b/src/Status/StatusCountTable/index.ts
@@ -1,3 +1,2 @@
 export { StatusCountTable } from "./StatusCountTable";
 export type { StatusCountTableProps } from "./StatusCountTable.types";
-export type { StatusCount } from "./StatusCountTable.types";

--- a/src/Status/StatusCountTable/index.ts
+++ b/src/Status/StatusCountTable/index.ts
@@ -1,2 +1,3 @@
 export { StatusCountTable } from "./StatusCountTable";
 export type { StatusCountTableProps } from "./StatusCountTable.types";
+export type { StatusCount } from "./StatusCountTable.types";


### PR DESCRIPTION
Contributes [TD-3111](https://sce.myjetbrains.com/youtrack/issue/TD-3111/Display-StatusCountBar-in-TestTable)

## Changes

Changed Props of the StatusCountBar component, for the count object which currently is Record<Status, number>. This change is necessary, because there is an error currently in Virto Test. This error is caused by differences in types for status in ipguk/types and Status types in RUI. In RUI there are many types supported and listed below:
type Status = "aborted" | "completed" | "disrupted" | "errored" | "failed" | "no-metrics" | "not-ready" | "not-run" | "operational" | "passed" | "pending" | "queued" | "ready" | "running"
In ipguk/types there are the following status types: 
type Status = "aborted" | "completed" | "errored" | "not-ready" | "queued" | "ready" | "running";
This is a mismatch and that's why I have updated the StatusCountBar component props instead of Status type in the record, to Partial<Status>.

A brief description of what this pull request solves / introduces.

- Fixed type mismatch between the Test app types and RUI types.

Maybe a short description of what is not included and will come in future work where appropriate.

## Dependencies

N/A

## UI/UX

N/A

## Testing notes

N/A

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- ~[ ] I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~[ ] I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[ ] I have populated the deploy-preview with relevant test data.~
