### PR TITLE
TD-3144 Equal width TableCard columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.10.0",
+  "version": "8.10.1-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/Card/TableCard/TableCard.jsx
+++ b/src/Card/TableCard/TableCard.jsx
@@ -45,7 +45,7 @@ function TableCard({ action = null, tableContent = [], title = "Table" }) {
                 >
                   <TableCell
                     sx={{
-                      width: 100
+                      width: "50%"
                     }}
                   >
                     {row[0]}
@@ -53,7 +53,7 @@ function TableCard({ action = null, tableContent = [], title = "Table" }) {
                   <TableCell
                     sx={{
                       overflowWrap: "anywhere",
-                      width: 100
+                      width: "50%"
                     }}
                   >
                     {row[1]}


### PR DESCRIPTION
Closes [TD-3144](https://sce.myjetbrains.com/youtrack/issue/TD-3144/Adjust-the-width-of-each-Table-Data-in-Table-Row-in-Table-Card-component)
Contributes[TD-3128](https://sce.myjetbrains.com/youtrack/issue/TD-3128/Update-scenario-details-page)
## Changes

Changed Table Card td element in Table row width to 50% instead of 100px, so the table data will be visualized in equal spacing.

A brief description of what this pull request solves / introduces.

- td width changed to equal in table row in TableCard component

## Dependencies

N/A

## UI/UX
Tested with pre-release branch in VIRTO Scene

Before
![image](https://github.com/user-attachments/assets/7ef9ea2d-cde3-4f3b-be9b-02e00752a0e7)

After
![image](https://github.com/user-attachments/assets/b9a67a72-8df6-413c-9394-6b9b08ee700f)

## Testing notes

N/A

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- ~[ ] I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~[ ] I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[ ] I have populated the deploy-preview with relevant test data.~
