### PR TITLE
VE-160 Update TransferList

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.13.0-0",
+  "version": "8.12.0-4",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.12.0-6",
+  "version": "8.12.0-8",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.12.0-4",
+  "version": "8.12.0-5",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.12.0-8",
+  "version": "8.12.0-9",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.11.1",
+  "version": "8.13.0-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.12.0-9",
+  "version": "8.12.0-12",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.12.0-5",
+  "version": "8.12.0-6",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/SearchBar/SearchBar.tsx
+++ b/src/SearchBar/SearchBar.tsx
@@ -25,6 +25,7 @@ export default function SearchBar({
       }}
     >
       <InputBase
+        aria-label={"Search"}
         placeholder={placeholder}
         value={value}
         onChange={onChange}

--- a/src/SearchBar/SearchBar.tsx
+++ b/src/SearchBar/SearchBar.tsx
@@ -34,6 +34,7 @@ export default function SearchBar({
       />
       {hasValue ? (
         <IconButton
+          aria-label="clear search"
           onClick={() => {
             onChange({ target: { value: "" } });
           }}

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -40,7 +40,7 @@ const TransferListWithState: StoryFn<TransferListProps> = args => {
   return (
     <TransferList
       {...args}
-      selectedItems={selectedItems}
+      selectedItems={selectedItems || []}
       onChange={handleChange}
     />
   );

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -23,24 +23,17 @@ const TransferListWithState: StoryFn<TransferListProps> = () => {
   const [targetKeys, setTargetKeys] = React.useState<string[]>([]);
 
   // Create function to transfer items
-  const handleTransfer: TransferListProps["handleTransfer"] = (
-    newKeys,
-    intent
-  ) => {
+  const handleChange: TransferListProps["handleChange"] = value => {
     // Move list items in state based on intent
-    if (intent === "toTarget") {
-      setTargetKeys([...newKeys, ...targetKeys]);
-    } else {
-      setTargetKeys(targetKeys.filter(key => !newKeys.includes(key)));
-    }
-    action("handleTransfer")(newKeys, intent);
+    setTargetKeys(value);
+    action("handleChange")(value);
   };
 
   return (
     <TransferList
       sourceListLabel={"Source List Label"}
       targetListLabel={"Target List Label"}
-      targetListKeys={targetKeys}
+      selectedItems={targetKeys}
       items={[
         { key: "Apples", primaryLabel: "Apples" },
         { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
@@ -57,7 +50,7 @@ const TransferListWithState: StoryFn<TransferListProps> = () => {
         { key: "Grapes", primaryLabel: "Grapes" },
         { key: "Cherry", primaryLabel: "Cherry" }
       ]}
-      handleTransfer={handleTransfer}
+      handleChange={handleChange}
     />
   );
 };
@@ -105,7 +98,7 @@ export const WithStringArray: StoryObj<typeof TransferList> = {
       "Grapes",
       "Cherry"
     ],
-    targetListKeys: ["Apples", "Grapes"]
+    selectedItems: ["Apples", "Grapes"]
   },
   render: TransferList
 };
@@ -131,7 +124,7 @@ export const WithSecondaryLabel: StoryObj<typeof TransferList> = {
   render: TransferList
 };
 
-// controlled component that calls the handleTransfer callback with data
+// controlled component that calls the handleChange callback with data
 export const Controlled: StoryObj<typeof TransferList> = {
   render: TransferListWithState
 };

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -45,7 +45,6 @@ export const WithDefaultObjectArray: StoryObj<
       { id: "Grapes", label: "Grapes" },
       { id: "Cherry", label: "Cherry" }
     ],
-    selectedItems: ["Apples"],
     sourceListLabel: "Source List Label",
     targetListLabel: "Target List Label"
   },
@@ -59,7 +58,6 @@ export const WithCustomObjectArray: StoryObj<
   args: {
     ...defaultArgs,
     filterKey: item => item.key,
-    initialTargetItemKeys: ["Cherry", "Kiwi"],
     itemLabel: item => item.name,
     items: [
       { key: "Apples", name: "Apples" },
@@ -73,8 +71,8 @@ export const WithCustomObjectArray: StoryObj<
       { key: "Grapes", name: "Grapes" },
       { key: "Cherry", name: "Cherry" }
     ],
-    selectedItems: ["Apples"],
     sourceListLabel: "Source List Label",
+    targetListKeys: ["Cherry", "Kiwi"],
     targetListLabel: "Target List Label"
   },
 
@@ -85,7 +83,6 @@ export const WithStringArray: StoryObj<typeof TransferList<TransferListItem>> =
   {
     args: {
       ...defaultArgs,
-      initialTargetItemKeys: ["Apples", "Grapes"],
       items: [
         "Apples",
         "Pears",
@@ -97,7 +94,8 @@ export const WithStringArray: StoryObj<typeof TransferList<TransferListItem>> =
         "Plum",
         "Grapes",
         "Cherry"
-      ]
+      ],
+      targetListKeys: ["Apples", "Grapes"]
     },
     render: TransferList
   };

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -1,50 +1,101 @@
-import { Meta, StoryFn } from "@storybook/react";
-
-import { Box } from "@mui/material";
+import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
+
 import TransferList from "./TransferList";
-import { TransferListProps } from "./TransferList.types";
-import { action } from "@storybook/addon-actions";
+import { TransferListItem } from "./TransferList.types";
 
 /**
  * Story metadata
  */
 const meta: Meta<typeof TransferList> = {
   component: TransferList,
+  decorators: Story => (
+    <div style={{ height: "400px" }}>
+      <Story />
+    </div>
+  ),
   title: "Lists/TransferList"
 };
 export default meta;
 
-const Template: StoryFn<TransferListProps> = args => {
-  // local state for selected items
-  const [selectedItems, setSelectedItems] = React.useState(["Apples"]);
-  React.useEffect(() => {
-    if (args.selectedItems) {
-      setSelectedItems(args.selectedItems);
-    }
-  }, [args.selectedItems]);
-  const onChange: TransferListProps["onChange"] = newItems => {
-    setSelectedItems(newItems);
-    action("onChange")(newItems);
-  };
-
-  return (
-    <Box sx={{ height: 200 }}>
-      <TransferList
-        {...args}
-        selectedItems={selectedItems}
-        onChange={onChange}
-      />
-    </Box>
-  );
+type CustomTransferListItemType = {
+  key: string;
+  name: string;
 };
 
-export const Default = {
+const defaultArgs: StoryObj<typeof TransferList<TransferListItem>>["args"] = {
+  sourceListLabel: "Source List Label",
+  targetListLabel: "Target List Label"
+};
+
+export const WithDefaultObjectArray: StoryObj<
+  typeof TransferList<TransferListItem>
+> = {
   args: {
-    items: ["Apples", "Pears", "Oranges", "Banana", "Mangoes"],
-    onChange: () => {},
-    selectedItems: ["Apples"]
+    ...defaultArgs,
+    items: [
+      { id: "Apples", label: "Apples" },
+      { id: "Pears", label: "Pears" },
+      { id: "Oranges", label: "Oranges" },
+      { id: "Bananas", label: "Bananas" },
+      { id: "Mangoes", label: "Mangoes" },
+      { id: "Kiwi", label: "Kiwi" },
+      { id: "Dragonfruit", label: "Dragonfruit" },
+      { id: "Plum", label: "Plum" },
+      { id: "Grapes", label: "Grapes" },
+      { id: "Cherry", label: "Cherry" }
+    ],
+    selectedItems: ["Apples"],
+    sourceListLabel: "Source List Label",
+    targetListLabel: "Target List Label"
   },
 
-  render: Template
+  render: TransferList
 };
+
+export const WithCustomObjectArray: StoryObj<
+  typeof TransferList<CustomTransferListItemType>
+> = {
+  args: {
+    ...defaultArgs,
+    filterKey: item => item.key,
+    itemLabel: item => item.name,
+    items: [
+      { key: "Apples", name: "Apples" },
+      { key: "Pears", name: "Pears" },
+      { key: "Oranges", name: "Oranges" },
+      { key: "Bananas", name: "Bananas" },
+      { key: "Mangoes", name: "Mangoes" },
+      { key: "Kiwi", name: "Kiwi" },
+      { key: "Dragonfruit", name: "Dragonfruit" },
+      { key: "Plum", name: "Plum" },
+      { key: "Grapes", name: "Grapes" },
+      { key: "Cherry", name: "Cherry" }
+    ],
+    selectedItems: ["Apples"],
+    sourceListLabel: "Source List Label",
+    targetListLabel: "Target List Label"
+  },
+
+  render: TransferList
+};
+
+export const WithStringArray: StoryObj<typeof TransferList<TransferListItem>> =
+  {
+    args: {
+      ...defaultArgs,
+      items: [
+        "Apples",
+        "Pears",
+        "Oranges",
+        "Bananas",
+        "Mangoes",
+        "Kiwi",
+        "Dragonfruit",
+        "Plum",
+        "Grapes",
+        "Cherry"
+      ]
+    },
+    render: TransferList
+  };

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -60,19 +60,19 @@ export const WithCustomObjectArray: StoryObj<
     filterKey: item => item.key,
     itemLabel: item => item.name,
     items: [
-      { key: "Apples", name: "Apples" },
-      { key: "Pears", name: "Pears" },
-      { key: "Oranges", name: "Oranges" },
-      { key: "Bananas", name: "Bananas" },
-      { key: "Mangoes", name: "Mangoes" },
-      { key: "Kiwi", name: "Kiwi" },
-      { key: "Dragonfruit", name: "Dragonfruit" },
-      { key: "Plum", name: "Plum" },
-      { key: "Grapes", name: "Grapes" },
-      { key: "Cherry", name: "Cherry" }
+      { key: "A", name: "Apples" },
+      { key: "P", name: "Pears" },
+      { key: "O", name: "Oranges" },
+      { key: "B", name: "Bananas" },
+      { key: "M", name: "Mangoes" },
+      { key: "K", name: "Kiwi" },
+      { key: "D", name: "Dragonfruit" },
+      { key: "Pl", name: "Plum" },
+      { key: "G", name: "Grapes" },
+      { key: "C", name: "Cherry" }
     ],
     sourceListLabel: "Source List Label",
-    targetListKeys: ["Cherry", "Kiwi"],
+    targetListKeys: ["C", "K"],
     targetListLabel: "Target List Label"
   },
 

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -26,21 +26,21 @@ const defaultArgs: StoryObj<typeof TransferList>["args"] = {
   targetListLabel: "Target List Label"
 };
 
+// set up state for controlled stories
 const TransferListWithState: StoryFn<TransferListProps> = args => {
-  const [{ selectedKeys }, updateArgs] = useArgs();
+  const [{ selectedItems }, updateArgs] = useArgs<TransferListProps>();
 
   // Create function to transfer items
   const handleChange: TransferListProps["onChange"] = value => {
     // Set the selected item keys
-    updateArgs({ selectedKeys: value });
+    updateArgs({ selectedItems: value.map(item => item.key || item) });
     action("handleChange")(value);
   };
 
   return (
     <TransferList
-      {...defaultArgs}
       {...args}
-      selectedItems={selectedKeys}
+      selectedItems={selectedItems}
       onChange={handleChange}
     />
   );

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
-import React from "react";
 
+import React from "react";
 import TransferList from "./TransferList";
-import { TransferListItem } from "./TransferList.types";
 import { action } from "@storybook/addon-actions";
 
 /**
@@ -19,22 +18,14 @@ const meta: Meta<typeof TransferList> = {
 };
 export default meta;
 
-// type for custom object
-type CustomTransferListItemType = {
-  key: string;
-  name: string;
-};
-
 // default args for every test
-const defaultArgs: StoryObj<typeof TransferList<TransferListItem>>["args"] = {
+const defaultArgs: StoryObj<typeof TransferList>["args"] = {
   sourceListLabel: "Source List Label",
   targetListLabel: "Target List Label"
 };
 
-// use a pre-defined object shape sarry with no additional confiuration
-export const WithDefaultObjectArray: StoryObj<
-  typeof TransferList<TransferListItem>
-> = {
+// use a pre-defined object shape array with no additional configuration
+export const WithDefaultObjectArray: StoryObj<typeof TransferList> = {
   args: {
     ...defaultArgs,
     items: [
@@ -55,61 +46,28 @@ export const WithDefaultObjectArray: StoryObj<
 };
 
 // use an array of strings with pre-transferred items
-export const WithStringArray: StoryObj<typeof TransferList<TransferListItem>> =
-  {
-    args: {
-      ...defaultArgs,
-      items: [
-        "Apples",
-        "Pears",
-        "Oranges",
-        "Bananas",
-        "Mangoes",
-        "Kiwi",
-        "Dragonfruit",
-        "Plum",
-        "Grapes",
-        "Cherry"
-      ],
-      targetListKeys: ["Apples", "Grapes"]
-    },
-    render: TransferList
-  };
-
-// use a custom object shape array with filterKey and itemLabel configurations
-export const WithCustomObjectArray: StoryObj<
-  typeof TransferList<CustomTransferListItemType>
-> = {
+export const WithStringArray: StoryObj<typeof TransferList> = {
   args: {
     ...defaultArgs,
-    filterKey: item => item.key,
-    itemProps: {
-      primaryLabel: item => item.name
-    },
     items: [
-      { key: "A", name: "Apples" },
-      { key: "P", name: "Pears" },
-      { key: "O", name: "Oranges" },
-      { key: "B", name: "Bananas" },
-      { key: "M", name: "Mangoes" },
-      { key: "K", name: "Kiwi" },
-      { key: "D", name: "Dragonfruit" },
-      { key: "Pl", name: "Plum" },
-      { key: "G", name: "Grapes" },
-      { key: "C", name: "Cherry" }
+      "Apples",
+      "Pears",
+      "Oranges",
+      "Bananas",
+      "Mangoes",
+      "Kiwi",
+      "Dragonfruit",
+      "Plum",
+      "Grapes",
+      "Cherry"
     ],
-    sourceListLabel: "Source List Label",
-    targetListKeys: ["C", "K"],
-    targetListLabel: "Target List Label"
+    targetListKeys: ["Apples", "Grapes"]
   },
-
   render: TransferList
 };
 
 // use a pre-defined object shape sarry with no additional confiuration
-export const WithSecondaryLabel: StoryObj<
-  typeof TransferList<TransferListItem>
-> = {
+export const WithSecondaryLabel: StoryObj<typeof TransferList> = {
   args: {
     ...defaultArgs,
     items: [
@@ -130,7 +88,7 @@ export const WithSecondaryLabel: StoryObj<
 };
 
 // controlled component that calls the handleTransfer callback with data
-export const Controlled: StoryObj<typeof TransferList<TransferListItem>> = {
+export const Controlled: StoryObj<typeof TransferList> = {
   args: {
     ...defaultArgs,
     handleTransfer: (data, intent) => action("handleTransfer")(data, intent),

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -38,16 +38,16 @@ export const WithDefaultObjectArray: StoryObj<
   args: {
     ...defaultArgs,
     items: [
-      { id: "Apples", label: "Apples" },
-      { id: "Pears", label: "Pears" },
-      { id: "Oranges", label: "Oranges" },
-      { id: "Bananas", label: "Bananas" },
-      { id: "Mangoes", label: "Mangoes" },
-      { id: "Kiwi", label: "Kiwi" },
-      { id: "Dragonfruit", label: "Dragonfruit" },
-      { id: "Plum", label: "Plum" },
-      { id: "Grapes", label: "Grapes" },
-      { id: "Cherry", label: "Cherry" }
+      { id: "Apples", primaryLabel: "Apples" },
+      { id: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+      { id: "Oranges", primaryLabel: "Oranges" },
+      { id: "Bananas", primaryLabel: "Bananas", secondaryLabel: "Blue Java" },
+      { id: "Mangoes", primaryLabel: "Mangoes" },
+      { id: "Kiwi", primaryLabel: "Kiwi" },
+      { id: "Dragonfruit", primaryLabel: "Dragonfruit" },
+      { id: "Plum", primaryLabel: "Plum" },
+      { id: "Grapes", primaryLabel: "Grapes" },
+      { id: "Cherry", primaryLabel: "Cherry" }
     ]
   },
 
@@ -83,7 +83,9 @@ export const WithCustomObjectArray: StoryObj<
   args: {
     ...defaultArgs,
     filterKey: item => item.key,
-    itemLabel: item => item.name,
+    itemProps: {
+      primaryLabel: item => item.name
+    },
     items: [
       { key: "A", name: "Apples" },
       { key: "P", name: "Pears" },
@@ -99,6 +101,29 @@ export const WithCustomObjectArray: StoryObj<
     sourceListLabel: "Source List Label",
     targetListKeys: ["C", "K"],
     targetListLabel: "Target List Label"
+  },
+
+  render: TransferList
+};
+
+// use a pre-defined object shape sarry with no additional confiuration
+export const WithSecondaryLabel: StoryObj<
+  typeof TransferList<TransferListItem>
+> = {
+  args: {
+    ...defaultArgs,
+    items: [
+      { id: "Apples", primaryLabel: "Apples", secondaryLabel: "Granny Smith" },
+      { id: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+      { id: "Oranges", primaryLabel: "Oranges", secondaryLabel: "Jaffa" },
+      { id: "Bananas", primaryLabel: "Bananas", secondaryLabel: "Blue Java" },
+      { id: "Mangoes", primaryLabel: "Mangoes", secondaryLabel: "Alphonso" },
+      { id: "Kiwi", primaryLabel: "Kiwi", secondaryLabel: "Golden" },
+      { id: "Dragonfruit", primaryLabel: "Dragonfruit" },
+      { id: "Plum", primaryLabel: "Plum" },
+      { id: "Grapes", primaryLabel: "Grapes", secondaryLabel: "Mixed" },
+      { id: "Cherry", primaryLabel: "Cherry", secondaryLabel: "Black" }
+    ]
   },
 
   render: TransferList

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import TransferList from "./TransferList";
 import { TransferListProps } from "./TransferList.types";
 import { action } from "@storybook/addon-actions";
+import { useArgs } from "@storybook/preview-api";
 
 /**
  * Story metadata
@@ -19,46 +20,30 @@ const meta: Meta<typeof TransferList> = {
 };
 export default meta;
 
-const TransferListWithState: StoryFn<TransferListProps> = () => {
-  const [selectedKeys, setSelectedKeys] = React.useState<string[]>([]);
+// default args for every story
+const defaultArgs: StoryObj<typeof TransferList>["args"] = {
+  sourceListLabel: "Source List Label",
+  targetListLabel: "Target List Label"
+};
+
+const TransferListWithState: StoryFn<TransferListProps> = args => {
+  const [{ selectedKeys }, updateArgs] = useArgs();
 
   // Create function to transfer items
-  const handleChange: TransferListProps["handleChange"] = value => {
+  const handleChange: TransferListProps["onChange"] = value => {
     // Set the selected item keys
-    setSelectedKeys(value);
+    updateArgs({ selectedKeys: value });
     action("handleChange")(value);
   };
 
   return (
     <TransferList
-      sourceListLabel={"Source List Label"}
-      targetListLabel={"Target List Label"}
+      {...defaultArgs}
+      {...args}
       selectedItems={selectedKeys}
-      items={[
-        { key: "Apples", primaryLabel: "Apples" },
-        { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
-        { key: "Oranges", primaryLabel: "Oranges" },
-        {
-          key: "Bananas",
-          primaryLabel: "Bananas",
-          secondaryLabel: "Blue Java"
-        },
-        { key: "Mangoes", primaryLabel: "Mangoes" },
-        { key: "Kiwi", primaryLabel: "Kiwi" },
-        { key: "Dragonfruit", primaryLabel: "Dragonfruit" },
-        { key: "Plum", primaryLabel: "Plum" },
-        { key: "Grapes", primaryLabel: "Grapes" },
-        { key: "Cherry", primaryLabel: "Cherry" }
-      ]}
-      handleChange={handleChange}
+      onChange={handleChange}
     />
   );
-};
-
-// default args for every story
-const defaultArgs: StoryObj<typeof TransferList>["args"] = {
-  sourceListLabel: "Source List Label",
-  targetListLabel: "Target List Label"
 };
 
 // use an object array to render the transfer list
@@ -85,7 +70,7 @@ export const WithDefaultObjectArray: StoryObj<typeof TransferList> = {
 // use an array of strings with pre-transferred items
 export const WithStringArray: StoryObj<typeof TransferList> = {
   args: {
-    ...defaultArgs,
+    defaultSelectedItems: ["Apples", "Grapes"],
     items: [
       "Apples",
       "Pears",
@@ -98,7 +83,8 @@ export const WithStringArray: StoryObj<typeof TransferList> = {
       "Grapes",
       "Cherry"
     ],
-    selectedItems: ["Apples", "Grapes"]
+    sourceListLabel: "Source List Label",
+    targetListLabel: "Target List Label"
   },
   render: TransferList
 };
@@ -126,5 +112,24 @@ export const WithSecondaryLabel: StoryObj<typeof TransferList> = {
 
 // controlled component that calls the handleChange callback with data
 export const Controlled: StoryObj<typeof TransferList> = {
+  args: {
+    ...defaultArgs,
+    items: [
+      { key: "Apples", primaryLabel: "Apples" },
+      { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+      { key: "Oranges", primaryLabel: "Oranges" },
+      {
+        key: "Bananas",
+        primaryLabel: "Bananas",
+        secondaryLabel: "Blue Java"
+      },
+      { key: "Mangoes", primaryLabel: "Mangoes" },
+      { key: "Kiwi", primaryLabel: "Kiwi" },
+      { key: "Dragonfruit", primaryLabel: "Dragonfruit" },
+      { key: "Plum", primaryLabel: "Plum" },
+      { key: "Grapes", primaryLabel: "Grapes" },
+      { key: "Cherry", primaryLabel: "Cherry" }
+    ]
+  },
   render: TransferListWithState
 };

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -59,6 +59,7 @@ export const WithCustomObjectArray: StoryObj<
   args: {
     ...defaultArgs,
     filterKey: item => item.key,
+    initialTargetItemKeys: ["Cherry", "Kiwi"],
     itemLabel: item => item.name,
     items: [
       { key: "Apples", name: "Apples" },
@@ -84,6 +85,7 @@ export const WithStringArray: StoryObj<typeof TransferList<TransferListItem>> =
   {
     args: {
       ...defaultArgs,
+      initialTargetItemKeys: ["Apples", "Grapes"],
       items: [
         "Apples",
         "Pears",

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -20,12 +20,12 @@ const meta: Meta<typeof TransferList> = {
 export default meta;
 
 const TransferListWithState: StoryFn<TransferListProps> = () => {
-  const [targetKeys, setTargetKeys] = React.useState<string[]>([]);
+  const [selectedKeys, setSelectedKeys] = React.useState<string[]>([]);
 
   // Create function to transfer items
   const handleChange: TransferListProps["handleChange"] = value => {
-    // Move list items in state based on intent
-    setTargetKeys(value);
+    // Set the selected item keys
+    setSelectedKeys(value);
     action("handleChange")(value);
   };
 
@@ -33,7 +33,7 @@ const TransferListWithState: StoryFn<TransferListProps> = () => {
     <TransferList
       sourceListLabel={"Source List Label"}
       targetListLabel={"Target List Label"}
-      selectedItems={targetKeys}
+      selectedItems={selectedKeys}
       items={[
         { key: "Apples", primaryLabel: "Apples" },
         { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
@@ -55,13 +55,13 @@ const TransferListWithState: StoryFn<TransferListProps> = () => {
   );
 };
 
-// default args for every test
+// default args for every story
 const defaultArgs: StoryObj<typeof TransferList>["args"] = {
   sourceListLabel: "Source List Label",
   targetListLabel: "Target List Label"
 };
 
-// use a pre-defined object shape array with no additional configuration
+// use an object array to render the transfer list
 export const WithDefaultObjectArray: StoryObj<typeof TransferList> = {
   args: {
     ...defaultArgs,
@@ -103,7 +103,7 @@ export const WithStringArray: StoryObj<typeof TransferList> = {
   render: TransferList
 };
 
-// use a pre-defined object shape sarry with no additional confiuration
+// use an object array with secondary labels
 export const WithSecondaryLabel: StoryObj<typeof TransferList> = {
   args: {
     ...defaultArgs,

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import TransferList from "./TransferList";
 import { TransferListItem } from "./TransferList.types";
+import { action } from "@storybook/addon-actions";
 
 /**
  * Story metadata
@@ -18,16 +19,19 @@ const meta: Meta<typeof TransferList> = {
 };
 export default meta;
 
+// type for custom object
 type CustomTransferListItemType = {
   key: string;
   name: string;
 };
 
+// default args for every test
 const defaultArgs: StoryObj<typeof TransferList<TransferListItem>>["args"] = {
   sourceListLabel: "Source List Label",
   targetListLabel: "Target List Label"
 };
 
+// use a pre-defined object shape sarry with no additional confiuration
 export const WithDefaultObjectArray: StoryObj<
   typeof TransferList<TransferListItem>
 > = {
@@ -44,14 +48,35 @@ export const WithDefaultObjectArray: StoryObj<
       { id: "Plum", label: "Plum" },
       { id: "Grapes", label: "Grapes" },
       { id: "Cherry", label: "Cherry" }
-    ],
-    sourceListLabel: "Source List Label",
-    targetListLabel: "Target List Label"
+    ]
   },
 
   render: TransferList
 };
 
+// use an array of strings with pre-transferred items
+export const WithStringArray: StoryObj<typeof TransferList<TransferListItem>> =
+  {
+    args: {
+      ...defaultArgs,
+      items: [
+        "Apples",
+        "Pears",
+        "Oranges",
+        "Bananas",
+        "Mangoes",
+        "Kiwi",
+        "Dragonfruit",
+        "Plum",
+        "Grapes",
+        "Cherry"
+      ],
+      targetListKeys: ["Apples", "Grapes"]
+    },
+    render: TransferList
+  };
+
+// use a custom object shape array with filterKey and itemLabel configurations
 export const WithCustomObjectArray: StoryObj<
   typeof TransferList<CustomTransferListItemType>
 > = {
@@ -79,23 +104,24 @@ export const WithCustomObjectArray: StoryObj<
   render: TransferList
 };
 
-export const WithStringArray: StoryObj<typeof TransferList<TransferListItem>> =
-  {
-    args: {
-      ...defaultArgs,
-      items: [
-        "Apples",
-        "Pears",
-        "Oranges",
-        "Bananas",
-        "Mangoes",
-        "Kiwi",
-        "Dragonfruit",
-        "Plum",
-        "Grapes",
-        "Cherry"
-      ],
-      targetListKeys: ["Apples", "Grapes"]
-    },
-    render: TransferList
-  };
+// controlled component that calls the handleTransfer callback with data
+export const Controlled: StoryObj<typeof TransferList<TransferListItem>> = {
+  args: {
+    ...defaultArgs,
+    handleTransfer: (data, intent) => action("handleTransfer")(data, intent),
+    items: [
+      "Apples",
+      "Pears",
+      "Oranges",
+      "Bananas",
+      "Mangoes",
+      "Kiwi",
+      "Dragonfruit",
+      "Plum",
+      "Grapes",
+      "Cherry"
+    ],
+    targetListKeys: ["Apples", "Grapes"]
+  },
+  render: TransferList
+};

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -42,16 +42,20 @@ const TransferListWithState: StoryFn<TransferListProps> = () => {
       targetListLabel={"Target List Label"}
       targetListKeys={targetKeys}
       items={[
-        { id: "Apples", primaryLabel: "Apples" },
-        { id: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
-        { id: "Oranges", primaryLabel: "Oranges" },
-        { id: "Bananas", primaryLabel: "Bananas", secondaryLabel: "Blue Java" },
-        { id: "Mangoes", primaryLabel: "Mangoes" },
-        { id: "Kiwi", primaryLabel: "Kiwi" },
-        { id: "Dragonfruit", primaryLabel: "Dragonfruit" },
-        { id: "Plum", primaryLabel: "Plum" },
-        { id: "Grapes", primaryLabel: "Grapes" },
-        { id: "Cherry", primaryLabel: "Cherry" }
+        { key: "Apples", primaryLabel: "Apples" },
+        { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+        { key: "Oranges", primaryLabel: "Oranges" },
+        {
+          key: "Bananas",
+          primaryLabel: "Bananas",
+          secondaryLabel: "Blue Java"
+        },
+        { key: "Mangoes", primaryLabel: "Mangoes" },
+        { key: "Kiwi", primaryLabel: "Kiwi" },
+        { key: "Dragonfruit", primaryLabel: "Dragonfruit" },
+        { key: "Plum", primaryLabel: "Plum" },
+        { key: "Grapes", primaryLabel: "Grapes" },
+        { key: "Cherry", primaryLabel: "Cherry" }
       ]}
       handleTransfer={handleTransfer}
     />
@@ -69,16 +73,16 @@ export const WithDefaultObjectArray: StoryObj<typeof TransferList> = {
   args: {
     ...defaultArgs,
     items: [
-      { id: "Apples", primaryLabel: "Apples" },
-      { id: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
-      { id: "Oranges", primaryLabel: "Oranges" },
-      { id: "Bananas", primaryLabel: "Bananas", secondaryLabel: "Blue Java" },
-      { id: "Mangoes", primaryLabel: "Mangoes" },
-      { id: "Kiwi", primaryLabel: "Kiwi" },
-      { id: "Dragonfruit", primaryLabel: "Dragonfruit" },
-      { id: "Plum", primaryLabel: "Plum" },
-      { id: "Grapes", primaryLabel: "Grapes" },
-      { id: "Cherry", primaryLabel: "Cherry" }
+      { key: "Apples", primaryLabel: "Apples" },
+      { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+      { key: "Oranges", primaryLabel: "Oranges" },
+      { key: "Bananas", primaryLabel: "Bananas", secondaryLabel: "Blue Java" },
+      { key: "Mangoes", primaryLabel: "Mangoes" },
+      { key: "Kiwi", primaryLabel: "Kiwi" },
+      { key: "Dragonfruit", primaryLabel: "Dragonfruit" },
+      { key: "Plum", primaryLabel: "Plum" },
+      { key: "Grapes", primaryLabel: "Grapes" },
+      { key: "Cherry", primaryLabel: "Cherry" }
     ]
   },
 
@@ -111,16 +115,16 @@ export const WithSecondaryLabel: StoryObj<typeof TransferList> = {
   args: {
     ...defaultArgs,
     items: [
-      { id: "Apples", primaryLabel: "Apples", secondaryLabel: "Granny Smith" },
-      { id: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
-      { id: "Oranges", primaryLabel: "Oranges", secondaryLabel: "Jaffa" },
-      { id: "Bananas", primaryLabel: "Bananas", secondaryLabel: "Blue Java" },
-      { id: "Mangoes", primaryLabel: "Mangoes", secondaryLabel: "Alphonso" },
-      { id: "Kiwi", primaryLabel: "Kiwi", secondaryLabel: "Golden" },
-      { id: "Dragonfruit", primaryLabel: "Dragonfruit" },
-      { id: "Plum", primaryLabel: "Plum" },
-      { id: "Grapes", primaryLabel: "Grapes", secondaryLabel: "Mixed" },
-      { id: "Cherry", primaryLabel: "Cherry", secondaryLabel: "Black" }
+      { key: "Apples", primaryLabel: "Apples", secondaryLabel: "Granny Smith" },
+      { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+      { key: "Oranges", primaryLabel: "Oranges", secondaryLabel: "Jaffa" },
+      { key: "Bananas", primaryLabel: "Bananas", secondaryLabel: "Blue Java" },
+      { key: "Mangoes", primaryLabel: "Mangoes", secondaryLabel: "Alphonso" },
+      { key: "Kiwi", primaryLabel: "Kiwi", secondaryLabel: "Golden" },
+      { key: "Dragonfruit", primaryLabel: "Dragonfruit" },
+      { key: "Plum", primaryLabel: "Plum" },
+      { key: "Grapes", primaryLabel: "Grapes", secondaryLabel: "Mixed" },
+      { key: "Cherry", primaryLabel: "Cherry", secondaryLabel: "Black" }
     ]
   },
 

--- a/src/TransferList/TransferList.stories.tsx
+++ b/src/TransferList/TransferList.stories.tsx
@@ -1,7 +1,8 @@
-import { Meta, StoryObj } from "@storybook/react";
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
 
 import React from "react";
 import TransferList from "./TransferList";
+import { TransferListProps } from "./TransferList.types";
 import { action } from "@storybook/addon-actions";
 
 /**
@@ -17,6 +18,45 @@ const meta: Meta<typeof TransferList> = {
   title: "Lists/TransferList"
 };
 export default meta;
+
+const TransferListWithState: StoryFn<TransferListProps> = () => {
+  const [targetKeys, setTargetKeys] = React.useState<string[]>([]);
+
+  // Create function to transfer items
+  const handleTransfer: TransferListProps["handleTransfer"] = (
+    newKeys,
+    intent
+  ) => {
+    // Move list items in state based on intent
+    if (intent === "toTarget") {
+      setTargetKeys([...newKeys, ...targetKeys]);
+    } else {
+      setTargetKeys(targetKeys.filter(key => !newKeys.includes(key)));
+    }
+    action("handleTransfer")(newKeys, intent);
+  };
+
+  return (
+    <TransferList
+      sourceListLabel={"Source List Label"}
+      targetListLabel={"Target List Label"}
+      targetListKeys={targetKeys}
+      items={[
+        { id: "Apples", primaryLabel: "Apples" },
+        { id: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+        { id: "Oranges", primaryLabel: "Oranges" },
+        { id: "Bananas", primaryLabel: "Bananas", secondaryLabel: "Blue Java" },
+        { id: "Mangoes", primaryLabel: "Mangoes" },
+        { id: "Kiwi", primaryLabel: "Kiwi" },
+        { id: "Dragonfruit", primaryLabel: "Dragonfruit" },
+        { id: "Plum", primaryLabel: "Plum" },
+        { id: "Grapes", primaryLabel: "Grapes" },
+        { id: "Cherry", primaryLabel: "Cherry" }
+      ]}
+      handleTransfer={handleTransfer}
+    />
+  );
+};
 
 // default args for every test
 const defaultArgs: StoryObj<typeof TransferList>["args"] = {
@@ -89,22 +129,5 @@ export const WithSecondaryLabel: StoryObj<typeof TransferList> = {
 
 // controlled component that calls the handleTransfer callback with data
 export const Controlled: StoryObj<typeof TransferList> = {
-  args: {
-    ...defaultArgs,
-    handleTransfer: (data, intent) => action("handleTransfer")(data, intent),
-    items: [
-      "Apples",
-      "Pears",
-      "Oranges",
-      "Bananas",
-      "Mangoes",
-      "Kiwi",
-      "Dragonfruit",
-      "Plum",
-      "Grapes",
-      "Cherry"
-    ],
-    targetListKeys: ["Apples", "Grapes"]
-  },
-  render: TransferList
+  render: TransferListWithState
 };

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -1,9 +1,8 @@
-import { describe, expect, test } from "vitest";
-import { getByLabelText, render, screen, within } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
 
 import React from "react";
 import TransferList from ".";
-import { TransferListProps } from "./TransferList.types";
 import userEvent from "@testing-library/user-event";
 
 const defaultItemArray = [
@@ -24,62 +23,13 @@ const customItemArray = [
     key: "b"
   },
   {
-    fruit: "oranges",
+    fruit: "Oranges",
     key: "c"
   }
 ];
 
-// /**
-//  * Test wrapper for TransferList
-//  * Provides state for the selectedItems
-//  */
-// const SelectedItemsWithState = ({
-//   items: itemsIn = [
-//     { key: "Apples", label: "Apples" },
-//     { key: "Pears", label: "Pears" },
-//     { key: "Oranges", label: "Oranges" }
-//   ],
-//   onChange,
-//   selectedItems: selectedItemsIn = ["Apples"],
-//   ...rest
-// }: TransferListProps) => {
-//   const [selectedItems, setSelectedItems] = React.useState(selectedItemsIn);
-//   const handleChange: TransferListProps["onChange"] = newSelections => {
-//     setSelectedItems(newSelections);
-//     onChange && onChange(newSelections);
-//   };
-//   return (
-//     <TransferList
-//       {...rest}
-//       filterKey={item => item.key}
-//       itemLabel={item => item.label}
-//       items={itemsIn}
-//       onChange={handleChange}
-//       selectedItems={selectedItems}
-//     />
-//   );
-// };
-
 describe("TransferList", () => {
-  // test("Clicking clear all button clears selections", async () => {
-  //   // render component
-  //   const user = userEvent.setup();
-  //   const onChange = vi.fn();
-  //   const { container } = render(
-  //     <SelectedItemsWithState onChange={onChange} />
-  //   );
-
-  //   // click clear button
-  //   const button = screen.getByTestId("clear-all-button");
-  //   await user.click(button);
-
-  //   // check selections have been cleared
-  //   expect(container.querySelector(".MuiTypography-body1")?.textContent).toBe(
-  //     "None Selected"
-  //   );
-  //   expect(onChange).toHaveBeenCalledWith([]);
-  // });
-  test("Renders a list of unfiltered items in the source list", async () => {
+  test("Renders a list of unfiltered items in the source list", () => {
     // render component
     render(
       <TransferList
@@ -241,7 +191,7 @@ describe("TransferList", () => {
     expect(screen.getByText("0/1 selected"));
   });
 
-  test("clicked items check correctly, enable transfer and update the heading", async () => {
+  test("Clicked items check correctly, enable transfer and update the heading", async () => {
     // render component
     const user = userEvent.setup();
     render(
@@ -285,7 +235,7 @@ describe("TransferList", () => {
     expect(screen.getByText("2/3 selected"));
   });
 
-  test("checked items transfer from source to target and uncheck", async () => {
+  test("Checked items transfer from source to target and uncheck", async () => {
     // render component
     const user = userEvent.setup();
     render(
@@ -368,7 +318,7 @@ describe("TransferList", () => {
     expect(selectAllTargetCheckbox).toHaveProperty("disabled", true);
   });
 
-  test("Check all checkboxes check all the list items", async () => {
+  test("Source list check all checks all the source list items", async () => {
     // render component
     const user = userEvent.setup();
 
@@ -392,88 +342,208 @@ describe("TransferList", () => {
     expect(selectAllSourceCheckbox).toHaveProperty("disabled", false);
     expect(selectAllTargetCheckbox).toHaveProperty("disabled", true);
 
-    //user.click(selectAllSourceCheckbox);
+    await user.click(selectAllSourceCheckbox);
+
+    // check updated source entries
+    const sourceList = screen.getByRole("source-list");
+    const sourceItems = within(sourceList).getAllByRole("source-list-item");
+
+    // all source list elements should be checked
+    expect(within(sourceItems[0]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      true
+    );
+    expect(within(sourceItems[1]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      true
+    );
+    expect(within(sourceItems[2]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      true
+    );
   });
 
-  // test("the check all checkboxes check all the list items", async () => {
-  //   const checkAllSource;
-  // });
+  test("Target list check all checks all the target list items", async () => {
+    // render component
+    const user = userEvent.setup();
 
-  // test("Search filters the list items", async () => {
-  //   // render component
-  //   const user = userEvent.setup();
-  //   const onChange = vi.fn();
-  //   const { container } = render(
-  //     <SelectedItemsWithState onChange={onChange} />
-  //   );
+    render(
+      <TransferList
+        items={defaultItemArray}
+        targetListKeys={["Apples", "Pears", "Oranges"]}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
 
-  //   // type in search input
-  //   const inputBase = container.querySelector(
-  //     ".MuiInputBase-input"
-  //   ) as HTMLInputElement;
-  //   await user.type(inputBase, "p");
+    // get checkboxes
+    const selectAllSourceCheckbox = within(
+      screen.getByLabelText("select all source list items")
+    ).getByRole("checkbox");
+    const selectAllTargetCheckbox = within(
+      screen.getByLabelText("select all target list items")
+    ).getByRole("checkbox");
 
-  //   // check if the left list has been filtered
-  //   const list = screen.getByRole("list");
-  //   const { getAllByRole } = within(list);
-  //   const items = getAllByRole("listitem1");
-  //   expect(items[0].textContent).toBe("Apples");
-  //   expect(items[1].textContent).toBe("Pears");
-  // });
+    // test transfer buttons exist and are disabled and enabled correctly
+    expect(selectAllSourceCheckbox).toHaveProperty("disabled", true);
+    expect(selectAllTargetCheckbox).toHaveProperty("disabled", false);
 
-  // test("Can select a list item", async () => {
-  //   // render component
-  //   const user = userEvent.setup();
-  //   const onChange = vi.fn();
-  //   render(
-  //     <SelectedItemsWithState
-  //       onChange={onChange}
-  //       items={["Apples", "Pears", "Oranges"]}
-  //       selectedItems={[]}
-  //     />
-  //   );
+    await user.click(selectAllTargetCheckbox);
 
-  //   // select item
-  //   const list = screen.getByRole("list");
-  //   const { getAllByRole } = within(list);
-  //   const items = getAllByRole("listitem1");
-  //   await user.click(items[1]);
+    // check updated source entries
+    const targetList = screen.getByRole("target-list");
+    const targetItems = within(targetList).getAllByRole("target-list-item");
 
-  //   // check if the item has been selected
-  //   expect(onChange).toHaveBeenCalledWith(["Pears"]);
-  // });
+    // all source list elements should be checked
+    expect(within(targetItems[0]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      true
+    );
+    expect(within(targetItems[1]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      true
+    );
+    expect(within(targetItems[2]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      true
+    );
+  });
 
-  // it("Can remove a list item selection", async () => {
-  //   // render component
-  //   const user = userEvent.setup();
-  //   const onChange = vi.fn();
-  //   render(
-  //     <SelectedItemsWithState
-  //       onChange={onChange}
-  //       items={["Apples", "Pears", "Oranges"]}
-  //       selectedItems={[]}
-  //     />
-  //   );
+  test("Calls onTransfer callback with data and intent", async () => {
+    // render component
+    const user = userEvent.setup();
+    // transfer function
+    const transferFn = vi.fn();
 
-  //   // select item
-  //   const list = screen.getByRole("list");
-  //   const { getAllByRole } = within(list);
-  //   const items = getAllByRole("listitem1");
-  //   await user.click(items[1]);
+    render(
+      <TransferList
+        items={defaultItemArray}
+        onTransfer={transferFn}
+        targetListKeys={["Apples", "Pears", "Oranges"]}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
 
-  //   // check if the item has been selected
-  //   expect(onChange).toHaveBeenCalledWith(["Pears"]);
+    // get checkboxes
+    const selectAllSourceCheckbox = within(
+      screen.getByLabelText("select all source list items")
+    ).getByRole("checkbox");
+    const selectAllTargetCheckbox = within(
+      screen.getByLabelText("select all target list items")
+    ).getByRole("checkbox");
 
-  //   // find the IconButton by its data-testid attribute
-  //   const deleteButtons = screen.getAllByTestId("close");
+    // test transfer buttons exist and are disabled and enabled correctly
+    expect(selectAllSourceCheckbox).toHaveProperty("disabled", true);
+    expect(selectAllTargetCheckbox).toHaveProperty("disabled", false);
 
-  //   // trigger a click event on the IconButton
-  //   fireEvent.click(deleteButtons[0]);
+    // select all the target list items
+    await user.click(selectAllTargetCheckbox);
 
-  //   // check if the onChange function was called with an empty array (selection removed)
-  //   expect(onChange).toHaveBeenCalledWith([]);
+    // get transfer to source button
+    const transferToSourceButton = screen.getByLabelText(
+      "transfer to source list"
+    );
 
-  //   // check if the "None Selected" text is displayed
-  //   expect(screen.getByTestId("none-selected")).toBeInTheDocument();
-  // });
+    // transfer all target list items to source
+    await user.click(transferToSourceButton);
+
+    // check the callback data
+    expect(transferFn).toHaveBeenCalledWith(
+      ["Apples", "Pears", "Oranges"],
+      "toSource"
+    );
+
+    // select all the source list items
+    await user.click(selectAllSourceCheckbox);
+
+    // get transfer to target button
+    const transferToTargetButton = screen.getByLabelText(
+      "transfer to target list"
+    );
+
+    // transfer all source list items to target
+    await user.click(transferToTargetButton);
+
+    // check the callback data
+    expect(transferFn).toHaveBeenCalledWith(
+      ["Apples", "Pears", "Oranges"],
+      "toTarget"
+    );
+  });
+
+  test("accepts array of strings as items", async () => {
+    // render component
+    const user = userEvent.setup();
+    // transfer function
+    const transferFn = vi.fn();
+
+    render(
+      <TransferList
+        items={stringItemArray}
+        onTransfer={transferFn}
+        targetListKeys={["Apples", "Pears", "Oranges"]}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    const selectAllTargetCheckbox = within(
+      screen.getByLabelText("select all target list items")
+    ).getByRole("checkbox");
+
+    // select all the target list items
+    await user.click(selectAllTargetCheckbox);
+
+    // get transfer to source button
+    const transferToSourceButton = screen.getByLabelText(
+      "transfer to source list"
+    );
+
+    // transfer all target list items to source
+    await user.click(transferToSourceButton);
+
+    // check the callback data
+    expect(transferFn).toHaveBeenCalledWith(
+      ["Apples", "Pears", "Oranges"],
+      "toSource"
+    );
+  });
+
+  test("accepts any object type with a filterKey and item label function", async () => {
+    // render component
+    const user = userEvent.setup();
+    // transfer function
+    const transferFn = vi.fn();
+
+    render(
+      <TransferList
+        filterKey={item => item.key}
+        itemLabel={item => item.fruit}
+        items={customItemArray}
+        onTransfer={transferFn}
+        targetListKeys={["a", "b", "c"]}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    const selectAllTargetCheckbox = within(
+      screen.getByLabelText("select all target list items")
+    ).getByRole("checkbox");
+
+    // select all the target list items
+    await user.click(selectAllTargetCheckbox);
+
+    // get transfer to source button
+    const transferToSourceButton = screen.getByLabelText(
+      "transfer to source list"
+    );
+
+    // transfer all target list items to source
+    await user.click(transferToSourceButton);
+
+    // check the callback data
+    expect(transferFn).toHaveBeenCalledWith(["a", "b", "c"], "toSource");
+  });
 });

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -160,7 +160,7 @@ describe("TransferList", () => {
     expect(items[2].textContent).toBe("Oranges");
   });
 
-  test("renders items in the target list and not the source list if target list keys are provided", () => {
+  test("renders items in the target list and not the source list if selected items are provided", () => {
     // render component
     render(
       <TransferList
@@ -365,7 +365,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("target list check all checks all the target list items", async () => {
+  test("target list check all checks all the selected list items", async () => {
     // render component
     const user = userEvent.setup();
 
@@ -410,7 +410,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("onChange callback fires with data and intent", async () => {
+  test("onChange callback fires with selected items", async () => {
     // render component
     const user = userEvent.setup();
     // transfer function
@@ -451,7 +451,7 @@ describe("TransferList", () => {
     await user.click(transferToSourceButton);
 
     // check the callback data
-    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
+    expect(transferFn).toHaveBeenCalledWith([]);
 
     // select all the source list items
     await user.click(selectAllSourceCheckbox);
@@ -468,7 +468,7 @@ describe("TransferList", () => {
     expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
   });
 
-  test("handleChange callback fires with data and intent", async () => {
+  test("handleChange callback fires with selected items array", async () => {
     // render component
     const user = userEvent.setup();
     // transfer function
@@ -501,7 +501,7 @@ describe("TransferList", () => {
     await user.click(transferToSourceButton);
 
     // check the callback data
-    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
+    expect(transferFn).toHaveBeenCalledWith([]);
   });
 
   test("accepts array of strings as items", async () => {
@@ -536,6 +536,6 @@ describe("TransferList", () => {
     await user.click(transferToSourceButton);
 
     // check the callback data
-    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
+    expect(transferFn).toHaveBeenCalledWith([]);
   });
 });

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -1,131 +1,479 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { getByLabelText, render, screen, within } from "@testing-library/react";
 
 import React from "react";
 import TransferList from ".";
 import { TransferListProps } from "./TransferList.types";
 import userEvent from "@testing-library/user-event";
-import { vi } from "vitest";
 
-/**
- * Test wrapper for TransferList
- * Provides state for the selectedItems
- */
-const SelectedItemsWithState = ({
-  items: itemsIn = ["Apples", "Pears", "Oranges"],
-  onChange,
-  selectedItems: selectedItemsIn = ["Apples"],
-  ...rest
-}: TransferListProps) => {
-  const [selectedItems, setSelectedItems] = React.useState(selectedItemsIn);
-  const handleChange: TransferListProps["onChange"] = newSelections => {
-    setSelectedItems(newSelections);
-    onChange && onChange(newSelections);
-  };
-  return (
-    <TransferList
-      {...rest}
-      items={itemsIn}
-      onChange={handleChange}
-      selectedItems={selectedItems}
-    />
-  );
-};
+const defaultItemArray = [
+  { id: "Apples", label: "Apples" },
+  { id: "Pears", label: "Pears" },
+  { id: "Oranges", label: "Oranges" }
+];
+
+const stringItemArray = ["Apples", "Pears", "Oranges"];
+
+const customItemArray = [
+  {
+    fruit: "Apples",
+    key: "a"
+  },
+  {
+    fruit: "Pears",
+    key: "b"
+  },
+  {
+    fruit: "oranges",
+    key: "c"
+  }
+];
+
+// /**
+//  * Test wrapper for TransferList
+//  * Provides state for the selectedItems
+//  */
+// const SelectedItemsWithState = ({
+//   items: itemsIn = [
+//     { key: "Apples", label: "Apples" },
+//     { key: "Pears", label: "Pears" },
+//     { key: "Oranges", label: "Oranges" }
+//   ],
+//   onChange,
+//   selectedItems: selectedItemsIn = ["Apples"],
+//   ...rest
+// }: TransferListProps) => {
+//   const [selectedItems, setSelectedItems] = React.useState(selectedItemsIn);
+//   const handleChange: TransferListProps["onChange"] = newSelections => {
+//     setSelectedItems(newSelections);
+//     onChange && onChange(newSelections);
+//   };
+//   return (
+//     <TransferList
+//       {...rest}
+//       filterKey={item => item.key}
+//       itemLabel={item => item.label}
+//       items={itemsIn}
+//       onChange={handleChange}
+//       selectedItems={selectedItems}
+//     />
+//   );
+// };
 
 describe("TransferList", () => {
-  test("Clicking clear all button clears selections", async () => {
+  // test("Clicking clear all button clears selections", async () => {
+  //   // render component
+  //   const user = userEvent.setup();
+  //   const onChange = vi.fn();
+  //   const { container } = render(
+  //     <SelectedItemsWithState onChange={onChange} />
+  //   );
+
+  //   // click clear button
+  //   const button = screen.getByTestId("clear-all-button");
+  //   await user.click(button);
+
+  //   // check selections have been cleared
+  //   expect(container.querySelector(".MuiTypography-body1")?.textContent).toBe(
+  //     "None Selected"
+  //   );
+  //   expect(onChange).toHaveBeenCalledWith([]);
+  // });
+  test("Renders a list of unfiltered items in the source list", async () => {
     // render component
-    const user = userEvent.setup();
-    const onChange = vi.fn();
-    const { container } = render(
-      <SelectedItemsWithState onChange={onChange} />
+    render(
+      <TransferList
+        items={defaultItemArray}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
     );
 
-    // click clear button
-    const button = screen.getByTestId("clear-all-button");
-    await user.click(button);
-
-    // check selections have been cleared
-    expect(container.querySelector(".MuiTypography-body1")?.textContent).toBe(
-      "None Selected"
-    );
-    expect(onChange).toHaveBeenCalledWith([]);
-  });
-
-  test("Search filters the list items", async () => {
-    // render component
-    const user = userEvent.setup();
-    const onChange = vi.fn();
-    const { container } = render(
-      <SelectedItemsWithState onChange={onChange} />
-    );
-
-    // type in search input
-    const inputBase = container.querySelector(
-      ".MuiInputBase-input"
-    ) as HTMLInputElement;
-    await user.type(inputBase, "p");
-
-    // check if the left list has been filtered
-    const list = screen.getByRole("list");
+    // get list
+    const list = screen.getByRole("source-list");
+    // get all list entries
     const { getAllByRole } = within(list);
-    const items = getAllByRole("listitem1");
+    const items = getAllByRole("source-list-item");
+
+    // test existence of list items
     expect(items[0].textContent).toBe("Apples");
     expect(items[1].textContent).toBe("Pears");
+    expect(items[2].textContent).toBe("Oranges");
   });
 
-  test("Can select a list item", async () => {
+  test("Renders correct heading text", () => {
     // render component
-    const user = userEvent.setup();
-    const onChange = vi.fn();
     render(
-      <SelectedItemsWithState
-        onChange={onChange}
-        items={["Apples", "Pears", "Oranges"]}
-        selectedItems={[]}
+      <TransferList
+        items={defaultItemArray}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
       />
     );
 
-    // select item
-    const list = screen.getByRole("list");
-    const { getAllByRole } = within(list);
-    const items = getAllByRole("listitem1");
-    await user.click(items[1]);
+    // test existence of list items
+    expect(screen.getByText("My Source List"));
+    expect(screen.getByText("0/3 selected"));
 
-    // check if the item has been selected
-    expect(onChange).toHaveBeenCalledWith(["Pears"]);
+    // test existence of list items
+    expect(screen.getByText("My Target List"));
+    expect(screen.getByText("0/0 selected"));
   });
 
-  it("Can remove a list item selection", async () => {
+  test("Renders disabled transfer buttons by default", () => {
     // render component
-    const user = userEvent.setup();
-    const onChange = vi.fn();
     render(
-      <SelectedItemsWithState
-        onChange={onChange}
-        items={["Apples", "Pears", "Oranges"]}
-        selectedItems={[]}
+      <TransferList
+        items={defaultItemArray}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
       />
     );
 
-    // select item
-    const list = screen.getByRole("list");
+    // test transfer buttons exist and are disabled by default
+    expect(screen.getByLabelText("transfer to target list")).toHaveProperty(
+      "disabled",
+      true
+    );
+    expect(screen.getByLabelText("transfer to source list")).toHaveProperty(
+      "disabled",
+      true
+    );
+  });
+
+  test("Source search filters the source list", async () => {
+    // render component
+    const user = userEvent.setup();
+    render(
+      <TransferList
+        items={defaultItemArray}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    // get search bar
+    const input = screen.getAllByPlaceholderText("Search");
+
+    // get list entries
+    const list = screen.getByRole("source-list");
     const { getAllByRole } = within(list);
-    const items = getAllByRole("listitem1");
+    const items = getAllByRole("source-list-item");
+
+    // get initially rendered list
+    expect(items[0].textContent).toBe("Apples");
+    expect(items[1].textContent).toBe("Pears");
+    expect(items[2].textContent).toBe("Oranges");
+
+    // Filter the list
+    await user.type(input[0], "p");
+
+    // check if the source list has been filtered
+    const filteredItems = getAllByRole("source-list-item");
+    expect(filteredItems[2]).toBeUndefined();
+
+    // check that the selected items title remains the same
+    expect(screen.getByText("0/3 selected"));
+  });
+
+  test("Clearing the source filter brings back the full source list", async () => {
+    // render component
+    const user = userEvent.setup();
+    render(
+      <TransferList
+        items={defaultItemArray}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    // get search bar
+    const input = screen.getAllByPlaceholderText("Search");
+
+    // get list entries
+    const list = screen.getByRole("source-list");
+    const { getAllByRole } = within(list);
+
+    // filter the list
+    await user.type(input[0], "p");
+
+    // clear the filter
+    const clearButton = screen.getByLabelText("clear search");
+    await user.click(clearButton);
+
+    // check if the source list has been unfiltered
+    const items = getAllByRole("source-list-item");
+    expect(items[0].textContent).toBe("Apples");
+    expect(items[1].textContent).toBe("Pears");
+    expect(items[2].textContent).toBe("Oranges");
+  });
+
+  test("Renders items in target list and not source list if keys provided in prop", () => {
+    // render component
+    render(
+      <TransferList
+        items={defaultItemArray}
+        targetListKeys={["Apples"]}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    // get source list
+    const sourceList = screen.getByRole("source-list");
+    // get all list entries
+    const sourceItems = within(sourceList).getAllByRole("source-list-item");
+
+    // test existence of source list items
+    expect(sourceItems[0].textContent).toBe("Pears");
+    expect(sourceItems[1].textContent).toBe("Oranges");
+
+    // test selected items heading remains the same
+    expect(screen.getByText("0/2 selected"));
+
+    // get target list
+    const targetList = screen.getByRole("target-list");
+    // get all list entries
+    const targetItems = within(targetList).getAllByRole("target-list-item");
+
+    // test existence of target list items
+    expect(targetItems[0].textContent).toBe("Apples");
+    expect(screen.getByText("0/1 selected"));
+  });
+
+  test("clicked items check correctly, enable transfer and update the heading", async () => {
+    // render component
+    const user = userEvent.setup();
+    render(
+      <TransferList
+        items={defaultItemArray}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    // get list entries
+    const list = screen.getByRole("source-list");
+    const { getAllByRole } = within(list);
+
+    // check if the source list has been unfiltered
+    const items = getAllByRole("source-list-item");
+
+    // click first two items in list
+    await user.click(items[0]);
     await user.click(items[1]);
 
-    // check if the item has been selected
-    expect(onChange).toHaveBeenCalledWith(["Pears"]);
+    // test button is enabled
+    expect(screen.getByLabelText("transfer to target list")).toHaveProperty(
+      "disabled",
+      false
+    );
 
-    // find the IconButton by its data-testid attribute
-    const deleteButtons = screen.getAllByTestId("close");
-
-    // trigger a click event on the IconButton
-    fireEvent.click(deleteButtons[0]);
-
-    // check if the onChange function was called with an empty array (selection removed)
-    expect(onChange).toHaveBeenCalledWith([]);
-
-    // check if the "None Selected" text is displayed
-    expect(screen.getByTestId("none-selected")).toBeInTheDocument();
+    // test checked status of checkboxes
+    expect(within(items[0]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      true
+    );
+    expect(within(items[1]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      true
+    );
+    expect(within(items[2]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      false
+    );
+    expect(screen.getByText("2/3 selected"));
   });
+
+  test("checked items transfer from source to target and uncheck", async () => {
+    // render component
+    const user = userEvent.setup();
+    render(
+      <TransferList
+        items={defaultItemArray}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    // get list entries
+    const sourceList = screen.getByRole("source-list");
+    const sourceItems = within(sourceList).getAllByRole("source-list-item");
+
+    // get transfer to target button
+    const transferToTargetButton = screen.getByLabelText(
+      "transfer to target list"
+    );
+
+    // click first two items in list
+    expect(sourceItems.length).toBe(3);
+    expect(sourceItems[0].textContent).toBe("Apples");
+    expect(sourceItems[1].textContent).toBe("Pears");
+    expect(sourceItems[2].textContent).toBe("Oranges");
+    await user.click(sourceItems[0]);
+    await user.click(sourceItems[1]);
+
+    // click transfer button
+    await user.click(transferToTargetButton);
+
+    // get target entries
+    const targetList = screen.getByRole("target-list");
+    const targetItems = within(targetList).getAllByRole("target-list-item");
+    expect(targetItems.length).toBe(2);
+    expect(targetItems[0].textContent).toBe("Apples");
+    expect(targetItems[1].textContent).toBe("Pears");
+
+    // check updated source entries
+    const updatedSourceList = screen.getByRole("source-list");
+    const updatedSourceItems =
+      within(updatedSourceList).getAllByRole("source-list-item");
+
+    expect(updatedSourceItems.length).toBe(1);
+    expect(updatedSourceItems[0].textContent).toBe("Oranges");
+
+    // ensure everything is unchecked
+    expect(within(updatedSourceItems[0]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      false
+    );
+    expect(within(targetItems[0]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      false
+    );
+    expect(within(targetItems[1]).getByRole("checkbox")).toHaveProperty(
+      "checked",
+      false
+    );
+  });
+
+  test("Check all checkboxes are disabled unless the list has entries", () => {
+    // render component
+    render(
+      <TransferList
+        items={[]}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    const selectAllSourceCheckbox = within(
+      screen.getByLabelText("select all source list items")
+    ).getByRole("checkbox");
+    const selectAllTargetCheckbox = within(
+      screen.getByLabelText("select all target list items")
+    ).getByRole("checkbox");
+
+    // test transfer buttons exist and are disabled by default
+    expect(selectAllSourceCheckbox).toHaveProperty("disabled", true);
+    expect(selectAllTargetCheckbox).toHaveProperty("disabled", true);
+  });
+
+  test("Check all checkboxes check all the list items", async () => {
+    // render component
+    const user = userEvent.setup();
+
+    render(
+      <TransferList
+        items={defaultItemArray}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    // get checkboxes
+    const selectAllSourceCheckbox = within(
+      screen.getByLabelText("select all source list items")
+    ).getByRole("checkbox");
+    const selectAllTargetCheckbox = within(
+      screen.getByLabelText("select all target list items")
+    ).getByRole("checkbox");
+
+    // test transfer buttons exist and are disabled and enabled correctly
+    expect(selectAllSourceCheckbox).toHaveProperty("disabled", false);
+    expect(selectAllTargetCheckbox).toHaveProperty("disabled", true);
+
+    //user.click(selectAllSourceCheckbox);
+  });
+
+  // test("the check all checkboxes check all the list items", async () => {
+  //   const checkAllSource;
+  // });
+
+  // test("Search filters the list items", async () => {
+  //   // render component
+  //   const user = userEvent.setup();
+  //   const onChange = vi.fn();
+  //   const { container } = render(
+  //     <SelectedItemsWithState onChange={onChange} />
+  //   );
+
+  //   // type in search input
+  //   const inputBase = container.querySelector(
+  //     ".MuiInputBase-input"
+  //   ) as HTMLInputElement;
+  //   await user.type(inputBase, "p");
+
+  //   // check if the left list has been filtered
+  //   const list = screen.getByRole("list");
+  //   const { getAllByRole } = within(list);
+  //   const items = getAllByRole("listitem1");
+  //   expect(items[0].textContent).toBe("Apples");
+  //   expect(items[1].textContent).toBe("Pears");
+  // });
+
+  // test("Can select a list item", async () => {
+  //   // render component
+  //   const user = userEvent.setup();
+  //   const onChange = vi.fn();
+  //   render(
+  //     <SelectedItemsWithState
+  //       onChange={onChange}
+  //       items={["Apples", "Pears", "Oranges"]}
+  //       selectedItems={[]}
+  //     />
+  //   );
+
+  //   // select item
+  //   const list = screen.getByRole("list");
+  //   const { getAllByRole } = within(list);
+  //   const items = getAllByRole("listitem1");
+  //   await user.click(items[1]);
+
+  //   // check if the item has been selected
+  //   expect(onChange).toHaveBeenCalledWith(["Pears"]);
+  // });
+
+  // it("Can remove a list item selection", async () => {
+  //   // render component
+  //   const user = userEvent.setup();
+  //   const onChange = vi.fn();
+  //   render(
+  //     <SelectedItemsWithState
+  //       onChange={onChange}
+  //       items={["Apples", "Pears", "Oranges"]}
+  //       selectedItems={[]}
+  //     />
+  //   );
+
+  //   // select item
+  //   const list = screen.getByRole("list");
+  //   const { getAllByRole } = within(list);
+  //   const items = getAllByRole("listitem1");
+  //   await user.click(items[1]);
+
+  //   // check if the item has been selected
+  //   expect(onChange).toHaveBeenCalledWith(["Pears"]);
+
+  //   // find the IconButton by its data-testid attribute
+  //   const deleteButtons = screen.getAllByTestId("close");
+
+  //   // trigger a click event on the IconButton
+  //   fireEvent.click(deleteButtons[0]);
+
+  //   // check if the onChange function was called with an empty array (selection removed)
+  //   expect(onChange).toHaveBeenCalledWith([]);
+
+  //   // check if the "None Selected" text is displayed
+  //   expect(screen.getByTestId("none-selected")).toBeInTheDocument();
+  // });
 });

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -7,9 +7,9 @@ import userEvent from "@testing-library/user-event";
 
 // item array using the default object array structure
 const defaultItemArray = [
-  { id: "Apples", label: "Apples" },
-  { id: "Pears", label: "Pears" },
-  { id: "Oranges", label: "Oranges" }
+  { id: "Apples", primaryLabel: "Apples" },
+  { id: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+  { id: "Oranges", primaryLabel: "Oranges" }
 ];
 
 // item array using strings
@@ -23,7 +23,8 @@ const customItemArray = [
   },
   {
     fruit: "Pears",
-    key: "b"
+    key: "b",
+    type: "Conference"
   },
   {
     fruit: "Oranges",
@@ -51,7 +52,7 @@ describe("TransferList", () => {
 
     // test existence of correct list items
     expect(items[0].textContent).toBe("Apples");
-    expect(items[1].textContent).toBe("Pears");
+    expect(items[1].textContent).toBe("PearsConference");
     expect(items[2].textContent).toBe("Oranges");
   });
 
@@ -116,7 +117,7 @@ describe("TransferList", () => {
 
     // get initially rendered list
     expect(items[0].textContent).toBe("Apples");
-    expect(items[1].textContent).toBe("Pears");
+    expect(items[1].textContent).toBe("PearsConference");
     expect(items[2].textContent).toBe("Oranges");
 
     // Filter the list
@@ -175,7 +176,7 @@ describe("TransferList", () => {
     // check if the source list has been unfiltered
     const items = getAllByRole("source-list-item");
     expect(items[0].textContent).toBe("Apples");
-    expect(items[1].textContent).toBe("Pears");
+    expect(items[1].textContent).toBe("PearsConference");
     expect(items[2].textContent).toBe("Oranges");
   });
 
@@ -196,7 +197,7 @@ describe("TransferList", () => {
     const sourceItems = within(sourceList).getAllByRole("source-list-item");
 
     // test existence of source list items
-    expect(sourceItems[0].textContent).toBe("Pears");
+    expect(sourceItems[0].textContent).toBe("PearsConference");
     expect(sourceItems[1].textContent).toBe("Oranges");
 
     // test selected items heading remains the same
@@ -280,7 +281,7 @@ describe("TransferList", () => {
     // click first two items in list
     expect(sourceItems.length).toBe(3);
     expect(sourceItems[0].textContent).toBe("Apples");
-    expect(sourceItems[1].textContent).toBe("Pears");
+    expect(sourceItems[1].textContent).toBe("PearsConference");
     expect(sourceItems[2].textContent).toBe("Oranges");
     await user.click(sourceItems[0]);
     await user.click(sourceItems[1]);
@@ -293,7 +294,7 @@ describe("TransferList", () => {
     const targetItems = within(targetList).getAllByRole("target-list-item");
     expect(targetItems.length).toBe(2);
     expect(targetItems[0].textContent).toBe("Apples");
-    expect(targetItems[1].textContent).toBe("Pears");
+    expect(targetItems[1].textContent).toBe("PearsConference");
 
     // check updated source entries
     const updatedSourceList = screen.getByRole("source-list");
@@ -579,7 +580,10 @@ describe("TransferList", () => {
     render(
       <TransferList
         filterKey={item => item.key}
-        itemLabel={item => item.fruit}
+        itemProps={{
+          primaryLabel: item => item.fruit,
+          secondaryLabel: item => item.type || ""
+        }}
         items={customItemArray}
         onTransfer={transferFn}
         targetListKeys={["a", "b", "c"]}

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -370,7 +370,10 @@ describe("TransferList", () => {
     const unchangedTargetItems = within(targetList).queryAllByRole("listitem");
 
     // test onChange was called with the correct items
-    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears"]);
+    expect(transferFn).toHaveBeenCalledWith([
+      { key: "Apples", primaryLabel: "Apples" },
+      { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" }
+    ]);
 
     // test the list lengths remain the same
     expect(unchangedSourceItems.length).toBe(3);
@@ -665,7 +668,11 @@ describe("TransferList", () => {
     await user.click(transferToTargetButton);
 
     // check the callback data
-    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
+    expect(transferFn).toHaveBeenCalledWith([
+      { key: "Apples", primaryLabel: "Apples" },
+      { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+      { key: "Oranges", primaryLabel: "Oranges" }
+    ]);
   });
 
   test("transfer to source fires onChange callback with selected items array", async () => {
@@ -704,9 +711,10 @@ describe("TransferList", () => {
     expect(transferFn).toHaveBeenCalledWith([]);
   });
 
-  test("accepts array of strings as items", async () => {
+  test("accepts array of strings as items and returns them", async () => {
     // render component
     const user = userEvent.setup();
+
     // transfer function
     const transferFn = vi.fn();
 
@@ -714,28 +722,28 @@ describe("TransferList", () => {
       <TransferList
         items={stringItemArray}
         onChange={transferFn}
-        selectedItems={["Apples", "Pears", "Oranges"]}
         sourceListLabel="Source List Label"
         targetListLabel="Target List Label"
       />
     );
 
-    const selectAllTargetCheckbox = within(
-      screen.getByLabelText("select all target list items")
+    // get all source checkbox
+    const selectAllSourceCheckbox = within(
+      screen.getByLabelText("select all source list items")
     ).getByRole("checkbox");
 
     // select all the target list items
-    await user.click(selectAllTargetCheckbox);
+    await user.click(selectAllSourceCheckbox);
 
     // get transfer to source button
-    const transferToSourceButton = screen.getByLabelText(
-      "transfer to source list"
+    const transferToTargetButton = screen.getByLabelText(
+      "transfer to target list"
     );
 
     // transfer all target list items to source
-    await user.click(transferToSourceButton);
+    await user.click(transferToTargetButton);
 
     // check the callback data
-    expect(transferFn).toHaveBeenCalledWith([]);
+    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
   });
 });

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -5,14 +5,17 @@ import React from "react";
 import TransferList from ".";
 import userEvent from "@testing-library/user-event";
 
+// item array using the default object array structure
 const defaultItemArray = [
   { id: "Apples", label: "Apples" },
   { id: "Pears", label: "Pears" },
   { id: "Oranges", label: "Oranges" }
 ];
 
+// item array using strings
 const stringItemArray = ["Apples", "Pears", "Oranges"];
 
+// item array using custom object array structure
 const customItemArray = [
   {
     fruit: "Apples",
@@ -29,7 +32,7 @@ const customItemArray = [
 ];
 
 describe("TransferList", () => {
-  test("Renders a list of unfiltered items in the source list", () => {
+  test("list of unfiltered items in the source list", () => {
     // render component
     render(
       <TransferList
@@ -41,17 +44,18 @@ describe("TransferList", () => {
 
     // get list
     const list = screen.getByRole("source-list");
+
     // get all list entries
     const { getAllByRole } = within(list);
     const items = getAllByRole("source-list-item");
 
-    // test existence of list items
+    // test existence of correct list items
     expect(items[0].textContent).toBe("Apples");
     expect(items[1].textContent).toBe("Pears");
     expect(items[2].textContent).toBe("Oranges");
   });
 
-  test("Renders correct heading text", () => {
+  test("list heading text", () => {
     // render component
     render(
       <TransferList
@@ -61,16 +65,16 @@ describe("TransferList", () => {
       />
     );
 
-    // test existence of list items
+    // test the source list heading and subheading
     expect(screen.getByText("My Source List"));
     expect(screen.getByText("0/3 selected"));
 
-    // test existence of list items
+    // test the target list heading and subheading
     expect(screen.getByText("My Target List"));
     expect(screen.getByText("0/0 selected"));
   });
 
-  test("Renders disabled transfer buttons by default", () => {
+  test("transfer buttons are disabled by default", () => {
     // render component
     render(
       <TransferList
@@ -91,7 +95,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("Source search filters the source list", async () => {
+  test("source search bar filters the source list", async () => {
     // render component
     const user = userEvent.setup();
     render(
@@ -126,7 +130,7 @@ describe("TransferList", () => {
     expect(screen.getByText("0/3 selected"));
   });
 
-  test("Search only appears when the list has entries", () => {
+  test("search bar only appears when the list has entries", () => {
     render(
       <TransferList
         items={defaultItemArray}
@@ -143,7 +147,7 @@ describe("TransferList", () => {
     expect(inputs.length).toBe(1);
   });
 
-  test("Clearing the source filter brings back the full source list", async () => {
+  test("clearing the source filter brings back the full source list", async () => {
     // render component
     const user = userEvent.setup();
     render(
@@ -155,7 +159,7 @@ describe("TransferList", () => {
     );
 
     // get search bar
-    const input = screen.getAllByPlaceholderText("Search");
+    const input = screen.getAllByLabelText("Search");
 
     // get list entries
     const list = screen.getByRole("source-list");
@@ -175,7 +179,7 @@ describe("TransferList", () => {
     expect(items[2].textContent).toBe("Oranges");
   });
 
-  test("Renders items in target list and not source list if keys provided in prop", () => {
+  test("renders items in target list and not source list if keys provided in prop", () => {
     // render component
     render(
       <TransferList
@@ -208,7 +212,7 @@ describe("TransferList", () => {
     expect(screen.getByText("0/1 selected"));
   });
 
-  test("Clicked items check correctly, enable transfer and update the heading", async () => {
+  test("clicked items check correctly, enable transfer button and update the heading", async () => {
     // render component
     const user = userEvent.setup();
     render(
@@ -222,8 +226,6 @@ describe("TransferList", () => {
     // get list entries
     const list = screen.getByRole("source-list");
     const { getAllByRole } = within(list);
-
-    // check if the source list has been unfiltered
     const items = getAllByRole("source-list-item");
 
     // click first two items in list
@@ -249,12 +251,15 @@ describe("TransferList", () => {
       "checked",
       false
     );
+
+    // test subheading is correct
     expect(screen.getByText("2/3 selected"));
   });
 
-  test("Checked items transfer from source to target and uncheck", async () => {
+  test("checked items transfer from source to target list and uncheck", async () => {
     // render component
     const user = userEvent.setup();
+
     render(
       <TransferList
         items={defaultItemArray}
@@ -313,7 +318,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("Check all checkboxes are disabled unless the list has entries", () => {
+  test("header check all checkboxes are disabled unless the list has entries", () => {
     // render component
     render(
       <TransferList
@@ -323,9 +328,11 @@ describe("TransferList", () => {
       />
     );
 
+    // get both check all checkboxes
     const selectAllSourceCheckbox = within(
       screen.getByLabelText("select all source list items")
     ).getByRole("checkbox");
+
     const selectAllTargetCheckbox = within(
       screen.getByLabelText("select all target list items")
     ).getByRole("checkbox");
@@ -335,7 +342,7 @@ describe("TransferList", () => {
     expect(selectAllTargetCheckbox).toHaveProperty("disabled", true);
   });
 
-  test("Source list check all checks all the source list items", async () => {
+  test("source list check all checkbox selects all the source list items", async () => {
     // render component
     const user = userEvent.setup();
 
@@ -351,14 +358,11 @@ describe("TransferList", () => {
     const selectAllSourceCheckbox = within(
       screen.getByLabelText("select all source list items")
     ).getByRole("checkbox");
-    const selectAllTargetCheckbox = within(
-      screen.getByLabelText("select all target list items")
-    ).getByRole("checkbox");
 
     // test transfer buttons exist and are disabled and enabled correctly
     expect(selectAllSourceCheckbox).toHaveProperty("disabled", false);
-    expect(selectAllTargetCheckbox).toHaveProperty("disabled", true);
 
+    // click select all source checkbox
     await user.click(selectAllSourceCheckbox);
 
     // check updated source entries
@@ -380,7 +384,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("Target list check all checks all the target list items", async () => {
+  test("target list check all checks all the target list items", async () => {
     // render component
     const user = userEvent.setup();
 
@@ -394,17 +398,14 @@ describe("TransferList", () => {
     );
 
     // get checkboxes
-    const selectAllSourceCheckbox = within(
-      screen.getByLabelText("select all source list items")
-    ).getByRole("checkbox");
     const selectAllTargetCheckbox = within(
       screen.getByLabelText("select all target list items")
     ).getByRole("checkbox");
 
     // test transfer buttons exist and are disabled and enabled correctly
-    expect(selectAllSourceCheckbox).toHaveProperty("disabled", true);
     expect(selectAllTargetCheckbox).toHaveProperty("disabled", false);
 
+    // click select all target checkbox
     await user.click(selectAllTargetCheckbox);
 
     // check updated source entries
@@ -416,17 +417,19 @@ describe("TransferList", () => {
       "checked",
       true
     );
+
     expect(within(targetItems[1]).getByRole("checkbox")).toHaveProperty(
       "checked",
       true
     );
+
     expect(within(targetItems[2]).getByRole("checkbox")).toHaveProperty(
       "checked",
       true
     );
   });
 
-  test("Calls onTransfer callback with data and intent", async () => {
+  test("call onTransfer callback with data and intent", async () => {
     // render component
     const user = userEvent.setup();
     // transfer function
@@ -446,6 +449,7 @@ describe("TransferList", () => {
     const selectAllSourceCheckbox = within(
       screen.getByLabelText("select all source list items")
     ).getByRole("checkbox");
+
     const selectAllTargetCheckbox = within(
       screen.getByLabelText("select all target list items")
     ).getByRole("checkbox");
@@ -489,7 +493,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("Calls handleTransfer callback with data and intent", async () => {
+  test("call handleTransfer callback with data and intent", async () => {
     // render component
     const user = userEvent.setup();
     // transfer function
@@ -505,6 +509,7 @@ describe("TransferList", () => {
       />
     );
 
+    // get select all target checkbox
     const selectAllTargetCheckbox = within(
       screen.getByLabelText("select all target list items")
     ).getByRole("checkbox");
@@ -583,6 +588,7 @@ describe("TransferList", () => {
       />
     );
 
+    // get select all target checkbox
     const selectAllTargetCheckbox = within(
       screen.getByLabelText("select all target list items")
     ).getByRole("checkbox");

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -489,6 +489,44 @@ describe("TransferList", () => {
     );
   });
 
+  test("Calls handleTransfer callback with data and intent", async () => {
+    // render component
+    const user = userEvent.setup();
+    // transfer function
+    const transferFn = vi.fn();
+
+    render(
+      <TransferList
+        items={defaultItemArray}
+        handleTransfer={transferFn}
+        targetListKeys={["Apples", "Pears", "Oranges"]}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    const selectAllTargetCheckbox = within(
+      screen.getByLabelText("select all target list items")
+    ).getByRole("checkbox");
+
+    // select all the target list items
+    await user.click(selectAllTargetCheckbox);
+
+    // get transfer to source button
+    const transferToSourceButton = screen.getByLabelText(
+      "transfer to source list"
+    );
+
+    // transfer all target list items to source
+    await user.click(transferToSourceButton);
+
+    // check the callback data
+    expect(transferFn).toHaveBeenCalledWith(
+      ["Apples", "Pears", "Oranges"],
+      "toSource"
+    );
+  });
+
   test("accepts array of strings as items", async () => {
     // render component
     const user = userEvent.setup();

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -7,9 +7,9 @@ import userEvent from "@testing-library/user-event";
 
 // item array using the default object array structure
 const defaultItemArray = [
-  { id: "Apples", primaryLabel: "Apples" },
-  { id: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
-  { id: "Oranges", primaryLabel: "Oranges" }
+  { key: "Apples", primaryLabel: "Apples" },
+  { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
+  { key: "Oranges", primaryLabel: "Oranges" }
 ];
 
 // item array using strings

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -126,9 +126,6 @@ describe("TransferList", () => {
     // check if the source list has been filtered
     const filteredItems = getAllByRole("source-list-item");
     expect(filteredItems[2]).toBeUndefined();
-
-    // check that the selected items title remains the same
-    expect(screen.getByText("0/3 selected"));
   });
 
   test("search bar only appears when the list has entries", () => {
@@ -180,7 +177,7 @@ describe("TransferList", () => {
     expect(items[2].textContent).toBe("Oranges");
   });
 
-  test("renders items in target list and not source list if keys provided in prop", () => {
+  test("renders items in the target list and not the source list if target list keys are provided", () => {
     // render component
     render(
       <TransferList
@@ -213,7 +210,7 @@ describe("TransferList", () => {
     expect(screen.getByText("0/1 selected"));
   });
 
-  test("clicked items check correctly, enable transfer button and update the heading", async () => {
+  test("clicked items check correctly, enable the relevant transfer button and update the heading", async () => {
     // render component
     const user = userEvent.setup();
     render(
@@ -319,7 +316,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("header check all checkboxes are disabled unless the list has entries", () => {
+  test("select all checkboxes are disabled unless the relevant list has entries", () => {
     // render component
     render(
       <TransferList
@@ -329,7 +326,7 @@ describe("TransferList", () => {
       />
     );
 
-    // get both check all checkboxes
+    // get both checkboxes in the headers
     const selectAllSourceCheckbox = within(
       screen.getByLabelText("select all source list items")
     ).getByRole("checkbox");
@@ -343,7 +340,7 @@ describe("TransferList", () => {
     expect(selectAllTargetCheckbox).toHaveProperty("disabled", true);
   });
 
-  test("source list check all checkbox selects all the source list items", async () => {
+  test("source list header checkbox selects all the source list items", async () => {
     // render component
     const user = userEvent.setup();
 
@@ -430,7 +427,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("call onTransfer callback with data and intent", async () => {
+  test("onTransfer callback fires with data and intent", async () => {
     // render component
     const user = userEvent.setup();
     // transfer function
@@ -494,7 +491,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("call handleTransfer callback with data and intent", async () => {
+  test("handleTransfer callback fires with data and intent", async () => {
     // render component
     const user = userEvent.setup();
     // transfer function

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -15,23 +15,6 @@ const defaultItemArray = [
 // item array using strings
 const stringItemArray = ["Apples", "Pears", "Oranges"];
 
-// item array using custom object array structure
-const customItemArray = [
-  {
-    fruit: "Apples",
-    key: "a"
-  },
-  {
-    fruit: "Pears",
-    key: "b",
-    type: "Conference"
-  },
-  {
-    fruit: "Oranges",
-    key: "c"
-  }
-];
-
 describe("TransferList", () => {
   test("list of unfiltered items in the source list", () => {
     // render component
@@ -566,46 +549,5 @@ describe("TransferList", () => {
       ["Apples", "Pears", "Oranges"],
       "toSource"
     );
-  });
-
-  test("accepts any object type with a filterKey and item label function", async () => {
-    // render component
-    const user = userEvent.setup();
-    // transfer function
-    const transferFn = vi.fn();
-
-    render(
-      <TransferList
-        filterKey={item => item.key}
-        itemProps={{
-          primaryLabel: item => item.fruit,
-          secondaryLabel: item => item.type || ""
-        }}
-        items={customItemArray}
-        onTransfer={transferFn}
-        targetListKeys={["a", "b", "c"]}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
-      />
-    );
-
-    // get select all target checkbox
-    const selectAllTargetCheckbox = within(
-      screen.getByLabelText("select all target list items")
-    ).getByRole("checkbox");
-
-    // select all the target list items
-    await user.click(selectAllTargetCheckbox);
-
-    // get transfer to source button
-    const transferToSourceButton = screen.getByLabelText(
-      "transfer to source list"
-    );
-
-    // transfer all target list items to source
-    await user.click(transferToSourceButton);
-
-    // check the callback data
-    expect(transferFn).toHaveBeenCalledWith(["a", "b", "c"], "toSource");
   });
 });

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -115,7 +115,7 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        targetListKeys={["Apples", "Pears", "Oranges"]}
+        selectedItems={["Apples", "Pears", "Oranges"]}
         sourceListLabel="My Source List"
         targetListLabel="My Target List"
       />
@@ -165,7 +165,7 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        targetListKeys={["Apples"]}
+        selectedItems={["Apples"]}
         sourceListLabel="My Source List"
         targetListLabel="My Target List"
       />
@@ -372,7 +372,7 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        targetListKeys={["Apples", "Pears", "Oranges"]}
+        selectedItems={["Apples", "Pears", "Oranges"]}
         sourceListLabel="My Source List"
         targetListLabel="My Target List"
       />
@@ -410,7 +410,7 @@ describe("TransferList", () => {
     );
   });
 
-  test("onTransfer callback fires with data and intent", async () => {
+  test("onChange callback fires with data and intent", async () => {
     // render component
     const user = userEvent.setup();
     // transfer function
@@ -419,8 +419,8 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        onTransfer={transferFn}
-        targetListKeys={["Apples", "Pears", "Oranges"]}
+        onChange={transferFn}
+        selectedItems={["Apples", "Pears", "Oranges"]}
         sourceListLabel="My Source List"
         targetListLabel="My Target List"
       />
@@ -451,10 +451,7 @@ describe("TransferList", () => {
     await user.click(transferToSourceButton);
 
     // check the callback data
-    expect(transferFn).toHaveBeenCalledWith(
-      ["Apples", "Pears", "Oranges"],
-      "toSource"
-    );
+    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
 
     // select all the source list items
     await user.click(selectAllSourceCheckbox);
@@ -468,13 +465,10 @@ describe("TransferList", () => {
     await user.click(transferToTargetButton);
 
     // check the callback data
-    expect(transferFn).toHaveBeenCalledWith(
-      ["Apples", "Pears", "Oranges"],
-      "toTarget"
-    );
+    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
   });
 
-  test("handleTransfer callback fires with data and intent", async () => {
+  test("handleChange callback fires with data and intent", async () => {
     // render component
     const user = userEvent.setup();
     // transfer function
@@ -483,8 +477,8 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        handleTransfer={transferFn}
-        targetListKeys={["Apples", "Pears", "Oranges"]}
+        handleChange={transferFn}
+        selectedItems={["Apples", "Pears", "Oranges"]}
         sourceListLabel="My Source List"
         targetListLabel="My Target List"
       />
@@ -507,10 +501,7 @@ describe("TransferList", () => {
     await user.click(transferToSourceButton);
 
     // check the callback data
-    expect(transferFn).toHaveBeenCalledWith(
-      ["Apples", "Pears", "Oranges"],
-      "toSource"
-    );
+    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
   });
 
   test("accepts array of strings as items", async () => {
@@ -522,8 +513,8 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={stringItemArray}
-        onTransfer={transferFn}
-        targetListKeys={["Apples", "Pears", "Oranges"]}
+        onChange={transferFn}
+        selectedItems={["Apples", "Pears", "Oranges"]}
         sourceListLabel="My Source List"
         targetListLabel="My Target List"
       />
@@ -545,9 +536,6 @@ describe("TransferList", () => {
     await user.click(transferToSourceButton);
 
     // check the callback data
-    expect(transferFn).toHaveBeenCalledWith(
-      ["Apples", "Pears", "Oranges"],
-      "toSource"
-    );
+    expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
   });
 });

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import TransferList from ".";
 import userEvent from "@testing-library/user-event";
 
-// item array using the default object array structure
+// item array using an object array structure
 const defaultItemArray = [
   { key: "Apples", primaryLabel: "Apples" },
   { key: "Pears", primaryLabel: "Pears", secondaryLabel: "Conference" },
@@ -21,17 +21,17 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
     // get list
-    const list = screen.getByRole("source-list");
+    const list = screen.getByLabelText("Source List Label");
 
     // get all list entries
     const { getAllByRole } = within(list);
-    const items = getAllByRole("source-list-item");
+    const items = getAllByRole("listitem");
 
     // test existence of correct list items
     expect(items[0].textContent).toBe("Apples");
@@ -44,17 +44,17 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
     // test the source list heading and subheading
-    expect(screen.getByText("My Source List"));
+    expect(screen.getByText("Source List Label"));
     expect(screen.getByText("0/3 selected"));
 
     // test the target list heading and subheading
-    expect(screen.getByText("My Target List"));
+    expect(screen.getByText("Target List Label"));
     expect(screen.getByText("0/0 selected"));
   });
 
@@ -63,8 +63,8 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
@@ -85,8 +85,8 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
@@ -94,9 +94,9 @@ describe("TransferList", () => {
     const input = screen.getAllByLabelText("Search");
 
     // get list entries
-    const list = screen.getByRole("source-list");
+    const list = screen.getByLabelText("Source List Label");
     const { getAllByRole } = within(list);
-    const items = getAllByRole("source-list-item");
+    const items = getAllByRole("listitem");
 
     // get initially rendered list
     expect(items[0].textContent).toBe("Apples");
@@ -107,7 +107,7 @@ describe("TransferList", () => {
     await user.type(input[0], "p");
 
     // check if the source list has been filtered
-    const filteredItems = getAllByRole("source-list-item");
+    const filteredItems = getAllByRole("listitem");
     expect(filteredItems[2]).toBeUndefined();
   });
 
@@ -115,9 +115,9 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        selectedItems={["Apples", "Pears", "Oranges"]}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        defaultSelectedItems={["Apples", "Pears", "Oranges"]}
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
@@ -134,8 +134,8 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
@@ -143,7 +143,7 @@ describe("TransferList", () => {
     const input = screen.getAllByLabelText("Search");
 
     // get list entries
-    const list = screen.getByRole("source-list");
+    const list = screen.getByLabelText("Source List Label");
     const { getAllByRole } = within(list);
 
     // filter the list
@@ -154,7 +154,7 @@ describe("TransferList", () => {
     await user.click(clearButton);
 
     // check if the source list has been unfiltered
-    const items = getAllByRole("source-list-item");
+    const items = getAllByRole("listitem");
     expect(items[0].textContent).toBe("Apples");
     expect(items[1].textContent).toBe("PearsConference");
     expect(items[2].textContent).toBe("Oranges");
@@ -165,16 +165,16 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        selectedItems={["Apples"]}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        defaultSelectedItems={["Apples"]}
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
     // get source list
-    const sourceList = screen.getByRole("source-list");
+    const sourceList = screen.getByLabelText("Source List Label");
     // get all list entries
-    const sourceItems = within(sourceList).getAllByRole("source-list-item");
+    const sourceItems = within(sourceList).getAllByRole("listitem");
 
     // test existence of source list items
     expect(sourceItems[0].textContent).toBe("PearsConference");
@@ -184,9 +184,9 @@ describe("TransferList", () => {
     expect(screen.getByText("0/2 selected"));
 
     // get target list
-    const targetList = screen.getByRole("target-list");
+    const targetList = screen.getByLabelText("Target List Label");
     // get all list entries
-    const targetItems = within(targetList).getAllByRole("target-list-item");
+    const targetItems = within(targetList).getAllByRole("listitem");
 
     // test existence of target list items
     expect(targetItems[0].textContent).toBe("Apples");
@@ -199,15 +199,15 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
     // get list entries
-    const list = screen.getByRole("source-list");
+    const list = screen.getByLabelText("Source List Label");
     const { getAllByRole } = within(list);
-    const items = getAllByRole("source-list-item");
+    const items = getAllByRole("listitem");
 
     // click first two items in list
     await user.click(items[0]);
@@ -244,14 +244,14 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
     // get list entries
-    const sourceList = screen.getByRole("source-list");
-    const sourceItems = within(sourceList).getAllByRole("source-list-item");
+    const sourceList = screen.getByLabelText("Source List Label");
+    const sourceItems = within(sourceList).getAllByRole("listitem");
 
     // get transfer to target button
     const transferToTargetButton = screen.getByLabelText(
@@ -270,16 +270,16 @@ describe("TransferList", () => {
     await user.click(transferToTargetButton);
 
     // get target entries
-    const targetList = screen.getByRole("target-list");
-    const targetItems = within(targetList).getAllByRole("target-list-item");
+    const targetList = screen.getByLabelText("Target List Label");
+    const targetItems = within(targetList).getAllByRole("listitem");
     expect(targetItems.length).toBe(2);
     expect(targetItems[0].textContent).toBe("Apples");
     expect(targetItems[1].textContent).toBe("PearsConference");
 
     // check updated source entries
-    const updatedSourceList = screen.getByRole("source-list");
+    const updatedSourceList = screen.getByLabelText("Source List Label");
     const updatedSourceItems =
-      within(updatedSourceList).getAllByRole("source-list-item");
+      within(updatedSourceList).getAllByRole("listitem");
 
     expect(updatedSourceItems.length).toBe(1);
     expect(updatedSourceItems[0].textContent).toBe("Oranges");
@@ -304,8 +304,8 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={[]}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
@@ -330,8 +330,8 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
@@ -347,8 +347,8 @@ describe("TransferList", () => {
     await user.click(selectAllSourceCheckbox);
 
     // check updated source entries
-    const sourceList = screen.getByRole("source-list");
-    const sourceItems = within(sourceList).getAllByRole("source-list-item");
+    const sourceList = screen.getByLabelText("Source List Label");
+    const sourceItems = within(sourceList).getAllByRole("listitem");
 
     // all source list elements should be checked
     expect(within(sourceItems[0]).getByRole("checkbox")).toHaveProperty(
@@ -372,9 +372,9 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        selectedItems={["Apples", "Pears", "Oranges"]}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        defaultSelectedItems={["Apples", "Pears", "Oranges"]}
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
@@ -390,8 +390,8 @@ describe("TransferList", () => {
     await user.click(selectAllTargetCheckbox);
 
     // check updated source entries
-    const targetList = screen.getByRole("target-list");
-    const targetItems = within(targetList).getAllByRole("target-list-item");
+    const targetList = screen.getByLabelText("Target List Label");
+    const targetItems = within(targetList).getAllByRole("listitem");
 
     // all source list elements should be checked
     expect(within(targetItems[0]).getByRole("checkbox")).toHaveProperty(
@@ -420,9 +420,9 @@ describe("TransferList", () => {
       <TransferList
         items={defaultItemArray}
         onChange={transferFn}
-        selectedItems={["Apples", "Pears", "Oranges"]}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        defaultSelectedItems={["Apples", "Pears", "Oranges"]}
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
@@ -477,10 +477,10 @@ describe("TransferList", () => {
     render(
       <TransferList
         items={defaultItemArray}
-        handleChange={transferFn}
+        onChange={transferFn}
         selectedItems={["Apples", "Pears", "Oranges"]}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 
@@ -515,8 +515,8 @@ describe("TransferList", () => {
         items={stringItemArray}
         onChange={transferFn}
         selectedItems={["Apples", "Pears", "Oranges"]}
-        sourceListLabel="My Source List"
-        targetListLabel="My Target List"
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
       />
     );
 

--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -103,7 +103,7 @@ describe("TransferList", () => {
     );
 
     // get search bar
-    const input = screen.getAllByPlaceholderText("Search");
+    const input = screen.getAllByLabelText("Search");
 
     // get list entries
     const list = screen.getByRole("source-list");
@@ -124,6 +124,23 @@ describe("TransferList", () => {
 
     // check that the selected items title remains the same
     expect(screen.getByText("0/3 selected"));
+  });
+
+  test("Search only appears when the list has entries", () => {
+    render(
+      <TransferList
+        items={defaultItemArray}
+        targetListKeys={["Apples", "Pears", "Oranges"]}
+        sourceListLabel="My Source List"
+        targetListLabel="My Target List"
+      />
+    );
+
+    // get search bar
+    const inputs = screen.getAllByLabelText("Search");
+
+    // Check that only one search bar is rendered
+    expect(inputs.length).toBe(1);
   });
 
   test("Clearing the source filter brings back the full source list", async () => {

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -15,7 +15,7 @@ import SearchBar from "../SearchBar";
 export default function TransferList<T>({
   filterKey: customFilterKey,
   handleTransfer,
-  initialTargetItemKeys = [],
+  targetListKeys = [],
   items = [],
   itemLabel,
   onTransfer,
@@ -29,9 +29,8 @@ export default function TransferList<T>({
   // Target list search filter
   const [targetFilter, setTargetFilter] = useState<string>("");
   // All item keys
-  const [targetItemKeys, setTargetItemKeys] = useState<string[]>(
-    initialTargetItemKeys
-  );
+  const [targetItemKeys, setTargetItemKeys] =
+    useState<string[]>(targetListKeys);
 
   /**
    * Get item label from any item structure
@@ -264,6 +263,7 @@ export default function TransferList<T>({
           }}
         >
           <Checkbox
+            aria-label="select all source list items"
             checked={sourceItemsToTransfer.length > 0}
             disabled={allSourceItems.length === 0}
             disableRipple
@@ -290,9 +290,11 @@ export default function TransferList<T>({
           </Box>
         </Box>
 
-        <Box sx={{ px: 3 }}>
-          <Search title="source-filter" onChange={setSourceFilter} />
-        </Box>
+        {allSourceItems.length > 0 ? (
+          <Box sx={{ px: 3 }}>
+            <Search title="source-filter" onChange={setSourceFilter} />
+          </Box>
+        ) : null}
 
         <Box
           sx={{
@@ -321,6 +323,7 @@ export default function TransferList<T>({
         p={2}
       >
         <Button
+          aria-label={"transfer to target list"}
           variant="outlined"
           size="small"
           sx={{ m: 0.5 }}
@@ -330,6 +333,7 @@ export default function TransferList<T>({
           &gt;
         </Button>
         <Button
+          aria-label={"transfer to source list"}
           variant="outlined"
           size="small"
           sx={{ m: 0.5 }}
@@ -360,6 +364,7 @@ export default function TransferList<T>({
           }}
         >
           <Checkbox
+            aria-label="select all target list items"
             checked={targetItemsToTransfer.length > 0}
             disabled={allTargetItems.length === 0}
             disableRipple
@@ -386,9 +391,12 @@ export default function TransferList<T>({
           </Box>
         </Box>
 
-        <Box sx={{ px: 3 }}>
-          <Search title="target-filter" onChange={setTargetFilter} />
-        </Box>
+        {allTargetItems.length > 0 ? (
+          <Box sx={{ px: 3 }}>
+            <Search title="target-filter" onChange={setTargetFilter} />
+          </Box>
+        ) : null}
+
         <Box
           sx={{
             height: "100%",
@@ -468,7 +476,7 @@ const SingleList = ({
           return (
             <ListItem
               key={value}
-              role="listitem1"
+              role={`${role}-item`}
               sx={{ py: 0.5 }}
               onClick={() => handleToggle(value)}
               disablePadding

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -198,14 +198,9 @@ export default function TransferList<T>({
    * Transfer items to the source list
    */
   const transferToSource = () => {
-    // get checked Items
-    const checkedTargetItems = targetItemKeys.filter(
-      item => !targetItemsToTransfer.includes(item)
-    );
-
     // Call handle hook if using controlled
     if (handleTransfer) {
-      handleTransfer(checkedTargetItems, "toSource");
+      handleTransfer(targetItemsToTransfer, "toSource");
       return;
     }
 
@@ -216,6 +211,7 @@ export default function TransferList<T>({
     setTargetItemKeys(
       targetItemKeys.filter(item => !targetItemsToTransfer.includes(item))
     );
+
     // Uncheck all items
     setChecked([]);
   };

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -33,16 +33,21 @@ export default function TransferList<T>({
     initialTargetItemKeys
   );
 
-  // Get item label from any item structure
+  /**
+   * Get item label from any item structure
+   **/
   const getItemLabel = (item: TransferListItem | T) => {
+    // If item is a string return it
     if (typeof item === "string") {
       return item;
     }
 
+    // If item is default object, return the label property
     if (typeof item === "object" && item !== null && "label" in item) {
       return item.label;
     }
 
+    // If item is a custom T use the provided function to return the label
     if (itemLabel) {
       return itemLabel(item as T);
     }
@@ -52,15 +57,21 @@ export default function TransferList<T>({
     );
   };
 
+  /**
+   * Get key from any item structure
+   **/
   const filterKey = (item: TransferListItem | T) => {
+    // If item is a string return it as an id
     if (typeof item === "string") {
       return item;
     }
 
+    // If item is a default object return the id
     if (typeof item === "object" && item !== null && "id" in item) {
       return item.id;
     }
 
+    // If item is a custom object use the provided function to get a key
     if (customFilterKey) {
       return customFilterKey(item);
     }
@@ -126,11 +137,12 @@ export default function TransferList<T>({
       ? setChecked(
           checked.filter(item => !sourceItemsToTransfer.includes(item))
         )
-      : setChecked(
-          items
+      : setChecked([
+          ...checked.filter(item => !sourceItemsToTransfer.includes(item)),
+          ...items
             .map(item => filterKey(item))
             .filter(item => !targetItemKeys.includes(item))
-        );
+        ]);
   };
 
   /**
@@ -143,11 +155,12 @@ export default function TransferList<T>({
       ? setChecked(
           checked.filter(item => !targetItemsToTransfer.includes(item))
         )
-      : setChecked(
-          items
+      : setChecked([
+          ...checked.filter(item => !targetItemsToTransfer.includes(item)),
+          ...items
             .map(item => filterKey(item))
             .filter(item => targetItemKeys.includes(item))
-        );
+        ]);
   };
 
   /**
@@ -234,6 +247,7 @@ export default function TransferList<T>({
       <Box
         sx={{
           border: theme => `1px solid ${theme.palette.divider}`,
+          borderRadius: 1,
           display: "flex",
           flexDirection: "column",
           height: "100%",
@@ -245,7 +259,8 @@ export default function TransferList<T>({
             alignItems: "center",
             borderBottom: theme => `1px solid ${theme.palette.divider}`,
             display: "flex",
-            p: 2
+            px: 2,
+            py: 1.5
           }}
         >
           <Checkbox
@@ -328,6 +343,7 @@ export default function TransferList<T>({
       <Box
         sx={{
           border: theme => `1px solid ${theme.palette.divider}`,
+          borderRadius: 1,
           display: "flex",
           flexDirection: "column",
           height: "100%",
@@ -339,7 +355,8 @@ export default function TransferList<T>({
             alignItems: "center",
             borderBottom: theme => `1px solid ${theme.palette.divider}`,
             display: "flex",
-            p: 2
+            px: 2,
+            py: 1.5
           }}
         >
           <Checkbox

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -76,7 +76,6 @@ export default function TransferList<T>({
 
     // If item is a custom object use the provided function to get a key
     if (customFilterKey) {
-      console.log(customFilterKey(item));
       return customFilterKey(item);
     }
 
@@ -311,9 +310,10 @@ export default function TransferList<T>({
         >
           <SingleList
             checked={sourceItemsToTransfer}
-            filterKey={filterKey}
-            items={filteredSourceItems}
-            itemLabel={getItemLabel}
+            items={filteredSourceItems.map(item => ({
+              key: filterKey(item),
+              label: getItemLabel(item)
+            }))}
             handleToggle={handleToggle}
             role="source-list"
           />
@@ -414,10 +414,11 @@ export default function TransferList<T>({
         >
           <Box>
             <SingleList
-              filterKey={filterKey}
               checked={targetItemsToTransfer}
-              items={filteredTargetItems}
-              itemLabel={getItemLabel}
+              items={filteredTargetItems.map(item => ({
+                key: filterKey(item),
+                label: getItemLabel(item)
+              }))}
               handleToggle={handleToggle}
               role="target-list"
             />
@@ -458,14 +459,7 @@ const Search = ({ onChange }: { onChange: (value: string) => void }) => {
   );
 };
 
-function SingleList<T>({
-  checked,
-  filterKey,
-  items,
-  itemLabel,
-  handleToggle,
-  role
-}: SingleListProps<T>) {
+function SingleList({ checked, items, handleToggle, role }: SingleListProps) {
   return (
     <Box
       sx={{
@@ -476,17 +470,14 @@ function SingleList<T>({
         {items.map(item => {
           return (
             <ListItem
-              key={filterKey(item)}
+              key={item.key}
               role={`${role}-item`}
               sx={{ py: 0.5 }}
-              onClick={() => handleToggle(filterKey(item))}
+              onClick={() => handleToggle(item.key)}
               disablePadding
             >
-              <Checkbox
-                checked={checked.includes(filterKey(item))}
-                disableRipple
-              />
-              <ListItemText sx={{ pl: 1 }} primary={itemLabel(item)} />
+              <Checkbox checked={checked.includes(item.key)} disableRipple />
+              <ListItemText sx={{ pl: 1 }} primary={item.label} />
             </ListItem>
           );
         })}

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -7,25 +7,22 @@ import {
   ListItemText,
   Typography
 } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
+import SearchBar, { SearchBarProps } from "../SearchBar";
 import {
   SingleListProps,
   TransferListItem,
   TransferListProps
 } from "./TransferList.types";
 
-import SearchBar from "../SearchBar";
-
-export default function TransferList<T>({
-  filterKey: customFilterKey,
+export default function TransferList({
   handleTransfer,
   targetListKeys = [],
   items = [],
-  itemProps,
   onTransfer,
   sourceListLabel,
   targetListLabel
-}: TransferListProps<T>) {
+}: TransferListProps) {
   // All checked item keys
   const [checked, setChecked] = useState<string[]>([]);
   // Source list search filter
@@ -40,78 +37,37 @@ export default function TransferList<T>({
    * Get item label from any item structure
    **/
   const getItemLabel = (
-    item: TransferListItem | T,
+    item: TransferListItem | string,
     type: "primary" | "secondary" = "primary"
   ) => {
-    const itemIsObject = typeof item === "object" && item !== null;
-
-    // If getting a primary label
-    if (type === "primary") {
-      // If item is a string return the item
-      if (typeof item === "string") {
-        return item;
-      }
-
-      // Check the primaryLabel prop
-      // If it exists return the primaryLabel prop
-      if (itemIsObject && "primaryLabel" in item) {
-        return item.primaryLabel;
-      }
-
-      // If the object is a custom shape and item props exist return the primary label function
-      if (itemProps) {
-        return itemProps.primaryLabel(item as T);
-      }
-    }
-
     // If getting a secondary label
     if (type === "secondary") {
       // If item is a string secondary label is ignored
       if (typeof item === "string") {
         return "";
-      }
-
-      // Check the secondary label prop
-      // If it exists return the secondary label prop
-      if (itemIsObject) {
-        return "secondaryLabel" in item && item.secondaryLabel
-          ? item.secondaryLabel
-          : "";
-      }
-
-      // If the object is a custom shape  and itemProps exist use the get label function
-      if (itemProps && itemProps.secondaryLabel) {
-        return itemProps?.secondaryLabel(item as T);
+      } else {
+        return item.secondaryLabel || "";
       }
     }
 
-    throw new Error(
-      "Item is missing a primaryLabel property or a label function is not defined"
-    );
+    // Return a primary label
+    if (typeof item === "string") {
+      return item;
+    } else {
+      return item.primaryLabel;
+    }
   };
 
   /**
    * Get key from any item structure
    **/
-  const filterKey = (item: TransferListItem | T) => {
+  const filterKey = (item: TransferListItem | string) => {
     // If item is a string return it as an id
     if (typeof item === "string") {
       return item;
     }
 
-    // If item is a default object return the id
-    if (typeof item === "object" && item !== null && "id" in item) {
-      return item.id;
-    }
-
-    // If item is a custom object use the provided function to get a key
-    if (customFilterKey) {
-      return customFilterKey(item);
-    }
-
-    throw new Error(
-      "Item is missing an 'id' property or a filterKey function is not defined"
-    );
+    return item.id;
   };
 
   /**
@@ -457,22 +413,17 @@ export default function TransferList<T>({
   );
 }
 
+/**
+ * Search bar for the transfer list
+ */
 const Search = ({ onChange }: { onChange: (value: string) => void }) => {
   const [search, setSearch] = useState("");
 
   // handle change
-  const handleChange = (event: {
-    target: {
-      value: string;
-    };
-  }) => {
+  const handleChange: SearchBarProps["onChange"] = event => {
     setSearch(event.target.value);
+    onChange(event.target.value);
   };
-
-  // Call on change on every search
-  useEffect(() => {
-    onChange(search);
-  }, [onChange, search]);
 
   return (
     <Box
@@ -487,6 +438,9 @@ const Search = ({ onChange }: { onChange: (value: string) => void }) => {
   );
 };
 
+/**
+ * Single list component for the transfer list
+ */
 function SingleList({ checked, items, handleToggle, role }: SingleListProps) {
   return (
     <Box

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -7,7 +7,7 @@ import {
   ListItemText,
   Typography
 } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useLayoutEffect, useState } from "react";
 import SearchBar, { SearchBarProps } from "../SearchBar";
 import {
   SingleListProps,
@@ -34,13 +34,13 @@ export default function TransferList({
 
   // All item keys
   const [selectedItemKeys, setSelectedItemKeys] = useState<string[]>(
-    defaultSelectedItems || selectedItems || []
+    defaultSelectedItems || []
   );
 
   /**
    * useEffect unselects items in the controlled component
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     setChecked([]);
   }, [selectedItems]);
 
@@ -263,6 +263,7 @@ export default function TransferList({
     >
       <Box
         sx={{
+          backgroundColor: "background.paper",
           border: theme => `1px solid ${theme.palette.divider}`,
           borderRadius: 1,
           display: "flex",
@@ -370,6 +371,7 @@ export default function TransferList({
 
       <Box
         sx={{
+          backgroundColor: "background.paper",
           border: theme => `1px solid ${theme.palette.divider}`,
           borderRadius: 1,
           display: "flex",
@@ -495,7 +497,7 @@ function SingleList({ checked, id, items, handleToggle }: SingleListProps) {
             >
               <Checkbox checked={checked.includes(item.key)} disableRipple />
               <ListItemText
-                sx={{ pl: 1 }}
+                sx={{ pl: 1, wordBreak: "break-word" }}
                 primary={item.primaryLabel}
                 secondary={item.secondaryLabel}
               />

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -73,7 +73,7 @@ export default function TransferList({
       return item;
     }
 
-    return item.id;
+    return item.key;
   };
 
   /**

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -2,22 +2,19 @@ import {
   Box,
   Button,
   Checkbox,
-  IconButton,
-  InputBase,
   List,
   ListItem,
-  ListItemIcon,
   ListItemText,
   Typography
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { TransferListItem, TransferListProps } from "./TransferList.types";
 
-import CloseIcon from "@mui/icons-material/Close";
-import SearchIcon from "@mui/icons-material/Search";
+import SearchBar from "../SearchBar";
 
 export default function TransferList<T>({
   filterKey: customFilterKey,
+  handleTransfer,
   initialTargetItemKeys = [],
   items = [],
   itemLabel,
@@ -157,7 +154,18 @@ export default function TransferList<T>({
    * Transfer items to the target list
    */
   const transferToTarget = () => {
-    // Call the onTransfer callback
+    // Get checked items
+    const checkedSourceItems = checked.filter(
+      item => !targetItemKeys.includes(item)
+    );
+
+    // Call handle hook if using controlled
+    if (handleTransfer) {
+      handleTransfer(checkedSourceItems, "ltr");
+      return;
+    }
+
+    // Call the onTransfer callback if using optimistic updates
     onTransfer &&
       onTransfer(
         checked.filter(item => !targetItemKeys.includes(item)),
@@ -174,7 +182,18 @@ export default function TransferList<T>({
    * Transfer items to the source list
    */
   const transferToSource = () => {
-    // Call the onTransfer callback
+    // get checked Items
+    const checkedTargetItems = targetItemKeys.filter(
+      item => !targetItemsToTransfer.includes(item)
+    );
+
+    // Call handle hook if using controlled
+    if (handleTransfer) {
+      handleTransfer(checkedTargetItems, "rtl");
+      return;
+    }
+
+    // Call the onTransfer callback if using optimistic
     onTransfer && onTransfer(targetItemsToTransfer, "rtl");
 
     // Remove the checked items from the target list
@@ -207,7 +226,6 @@ export default function TransferList<T>({
   return (
     <Box
       sx={{
-        border: theme => `1px solid ${theme.palette.divider}`,
         display: "flex",
         height: "100%",
         width: "100%"
@@ -215,6 +233,7 @@ export default function TransferList<T>({
     >
       <Box
         sx={{
+          border: theme => `1px solid ${theme.palette.divider}`,
           display: "flex",
           flexDirection: "column",
           height: "100%",
@@ -224,42 +243,48 @@ export default function TransferList<T>({
         <Box
           sx={{
             alignItems: "center",
+            borderBottom: theme => `1px solid ${theme.palette.divider}`,
             display: "flex",
-            py: 2
+            p: 2
           }}
         >
           <Checkbox
-            onClick={handleCheckAllSource}
             checked={sourceItemsToTransfer.length > 0}
+            disabled={allSourceItems.length === 0}
+            disableRipple
             indeterminate={
               sourceItemsToTransfer.length > 0 &&
               allSourceItems.length !== sourceItemsToTransfer.length
             }
-            disableRipple
+            onClick={handleCheckAllSource}
+            sx={{ pl: 1 }}
           />
           <Box
             sx={{
               display: "flex",
               flexDirection: "column",
-              justifyContent: "center"
+              justifyContent: "center",
+              pl: 1
             }}
           >
             <Typography variant="body1">{sourceListLabel}</Typography>
-            <Typography variant="body2">{`${sourceItemsToTransfer.length}/${allSourceItems.length} selected`}</Typography>
+            <Typography
+              variant="body2"
+              sx={{ color: "text.secondary" }}
+            >{`${sourceItemsToTransfer.length}/${allSourceItems.length} selected`}</Typography>
           </Box>
         </Box>
 
-        <Box sx={{ p: 2 }}>
+        <Box sx={{ px: 3 }}>
           <Search title="source-filter" onChange={setSourceFilter} />
         </Box>
 
         <Box
           sx={{
-            borderRight: theme => `1px solid ${theme.palette.divider}`,
             height: "100%",
             overflowX: "hidden",
             overflowY: "auto",
-            width: "100%"
+            px: 2
           }}
         >
           <SingleList
@@ -302,6 +327,7 @@ export default function TransferList<T>({
 
       <Box
         sx={{
+          border: theme => `1px solid ${theme.palette.divider}`,
           display: "flex",
           flexDirection: "column",
           height: "100%",
@@ -311,32 +337,39 @@ export default function TransferList<T>({
         <Box
           sx={{
             alignItems: "center",
+            borderBottom: theme => `1px solid ${theme.palette.divider}`,
             display: "flex",
-            py: 2
+            p: 2
           }}
         >
           <Checkbox
-            onClick={handleCheckAllTarget}
             checked={targetItemsToTransfer.length > 0}
+            disabled={allTargetItems.length === 0}
+            disableRipple
             indeterminate={
               targetItemsToTransfer.length > 0 &&
               allTargetItems.length !== targetItemsToTransfer.length
             }
-            disableRipple
+            onClick={handleCheckAllTarget}
+            sx={{ pl: 1 }}
           />
           <Box
             sx={{
               display: "flex",
               flexDirection: "column",
-              justifyContent: "center"
+              justifyContent: "center",
+              pl: 1
             }}
           >
             <Typography variant="body1">{targetListLabel}</Typography>
-            <Typography variant="body2">{`${targetItemsToTransfer.length}/${allTargetItems.length} selected`}</Typography>
+            <Typography
+              variant="body2"
+              sx={{ color: "text.secondary" }}
+            >{`${targetItemsToTransfer.length}/${allTargetItems.length} selected`}</Typography>
           </Box>
         </Box>
 
-        <Box sx={{ p: 2 }}>
+        <Box sx={{ px: 3 }}>
           <Search title="target-filter" onChange={setTargetFilter} />
         </Box>
         <Box
@@ -344,14 +377,10 @@ export default function TransferList<T>({
             height: "100%",
             overflowX: "hidden",
             overflowY: "auto",
-            width: "100%"
+            px: 2
           }}
         >
-          <Box
-            sx={{
-              width: "100%"
-            }}
-          >
+          <Box>
             <SingleList
               checked={targetItemsToTransfer}
               items={filteredTargetItems.map(item => getItemLabel(item))}
@@ -391,30 +420,11 @@ const Search = ({
     <Box
       sx={{
         alignItems: "center",
-        border: theme => `1px solid ${theme.palette.divider}`,
         display: "flex",
         width: "100%"
       }}
     >
-      <InputBase
-        title={title}
-        placeholder="Search..."
-        value={search}
-        onChange={handleChange}
-        size="small"
-        sx={{
-          flex: 1,
-          pl: 1,
-          pt: 0.5
-        }}
-      />
-      {search.length > 0 ? (
-        <IconButton onClick={() => setSearch("")}>
-          <CloseIcon />
-        </IconButton>
-      ) : (
-        <SearchIcon color="action" sx={{ mr: 1 }} />
-      )}
+      <SearchBar value={search} onChange={handleChange} />
     </Box>
   );
 };
@@ -436,22 +446,18 @@ const SingleList = ({
         width: "100%"
       }}
     >
-      <List dense component="div" role={role}>
+      <List dense component="div" role={role} sx={{ py: 0 }}>
         {items.map(value => {
           return (
             <ListItem
               key={value}
               role="listitem1"
+              sx={{ py: 0.5 }}
               onClick={() => handleToggle(value)}
               disablePadding
             >
-              <ListItemIcon>
-                <Checkbox
-                  checked={checked.indexOf(value) !== -1}
-                  disableRipple
-                />
-              </ListItemIcon>
-              <ListItemText primary={value} />
+              <Checkbox checked={checked.indexOf(value) !== -1} disableRipple />
+              <ListItemText sx={{ pl: 1 }} primary={value} />
             </ListItem>
           );
         })}

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -7,7 +7,7 @@ import {
   ListItemText,
   Typography
 } from "@mui/material";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import SearchBar, { SearchBarProps } from "../SearchBar";
 import {
   SingleListProps,
@@ -25,13 +25,22 @@ export default function TransferList({
 }: TransferListProps) {
   // All checked item keys
   const [checked, setChecked] = useState<string[]>([]);
+
   // Source list search filter
   const [sourceFilter, setSourceFilter] = useState<string>("");
+
   // Target list search filter
   const [targetFilter, setTargetFilter] = useState<string>("");
+
   // All item keys
   const [targetItemKeys, setTargetItemKeys] =
     useState<string[]>(targetListKeys);
+
+  // Update target keys state when the prop updates and uncheck
+  useEffect(() => {
+    setTargetItemKeys(targetListKeys);
+    setChecked([]);
+  }, [targetListKeys]);
 
   /**
    * Get primary label from item

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -11,13 +11,13 @@ import {
   Typography
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
+import { TransferListItem, TransferListProps } from "./TransferList.types";
 
 import CloseIcon from "@mui/icons-material/Close";
 import SearchIcon from "@mui/icons-material/Search";
-import { TransferListProps } from "./TransferList.types";
 
 export default function TransferList<T>({
-  filterKey,
+  filterKey: customFilterKey,
   initialTargetItemKeys = [],
   items = [],
   itemLabel,
@@ -36,6 +36,43 @@ export default function TransferList<T>({
     initialTargetItemKeys
   );
 
+  // Get item label from any item structure
+  const getItemLabel = (item: TransferListItem | T) => {
+    if (typeof item === "string") {
+      return item;
+    }
+
+    if (typeof item === "object" && item !== null && "label" in item) {
+      return item.label;
+    }
+
+    if (itemLabel) {
+      return itemLabel(item as T);
+    }
+
+    throw new Error(
+      "Item is missing a 'label' property or an itemLabel function is not defined"
+    );
+  };
+
+  const filterKey = (item: TransferListItem | T) => {
+    if (typeof item === "string") {
+      return item;
+    }
+
+    if (typeof item === "object" && item !== null && "id" in item) {
+      return item.id;
+    }
+
+    if (customFilterKey) {
+      return customFilterKey(item);
+    }
+
+    throw new Error(
+      "Item is missing an 'id' property or a filterKey function is not defined"
+    );
+  };
+
   /**
    * Source list logic
    */
@@ -47,7 +84,7 @@ export default function TransferList<T>({
 
   // Filtered source items
   const filteredSourceItems = allSourceItems.filter(item =>
-    itemLabel(item).toLowerCase().includes(sourceFilter.toLowerCase())
+    getItemLabel(item).toLowerCase().includes(sourceFilter.toLowerCase())
   );
 
   // All checked source list items
@@ -70,7 +107,7 @@ export default function TransferList<T>({
 
   // Filtered target items
   const filteredTargetItems = allTargetItems.filter(item =>
-    itemLabel(item).toLowerCase().includes(targetFilter.toLowerCase())
+    getItemLabel(item).toLowerCase().includes(targetFilter.toLowerCase())
   );
 
   // All checked target list items
@@ -227,7 +264,7 @@ export default function TransferList<T>({
         >
           <SingleList
             checked={sourceItemsToTransfer}
-            items={filteredSourceItems.map(item => itemLabel(item))}
+            items={filteredSourceItems.map(item => getItemLabel(item))}
             handleToggle={handleToggle}
             role="source-list"
           />
@@ -317,7 +354,7 @@ export default function TransferList<T>({
           >
             <SingleList
               checked={targetItemsToTransfer}
-              items={filteredTargetItems.map(item => itemLabel(item))}
+              items={filteredTargetItems.map(item => getItemLabel(item))}
               handleToggle={handleToggle}
               role="target-list"
             />

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -7,7 +7,7 @@ import {
   ListItemText,
   Typography
 } from "@mui/material";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import SearchBar, { SearchBarProps } from "../SearchBar";
 import {
   SingleListProps,
@@ -36,6 +36,13 @@ export default function TransferList({
   const [selectedItemKeys, setSelectedItemKeys] = useState<string[]>(
     defaultSelectedItems || selectedItems || []
   );
+
+  /**
+   * useEffect unselects items in the controlled component
+   */
+  useEffect(() => {
+    setChecked([]);
+  }, [selectedItems]);
 
   /**
    * Get primary label from item
@@ -158,15 +165,13 @@ export default function TransferList({
     // Updated target list keys
     const updatedTargetList = [...keys, ...checkedSourceItems];
 
-    // Call handle hook if using controlled
+    // Call the onChange callback
+    onChange && onChange(updatedTargetList);
+
+    // If component is controlled, end the function
     if (selectedItems) {
-      onChange(updatedTargetList);
-      setChecked([]);
       return;
     }
-
-    // Call the onChange callback if using optimistic updates
-    onChange && onChange(updatedTargetList);
 
     // Add the checked items to the target list
     setSelectedItemKeys(updatedTargetList);
@@ -184,15 +189,13 @@ export default function TransferList({
       item => !targetItemsToTransfer.includes(item)
     );
 
-    // Call handle hook if using controlled
+    // Call the onChange callback
+    onChange && onChange(newTargetSelection);
+
+    // If component is controlled, end the function
     if (selectedItems) {
-      onChange(newTargetSelection);
-      setChecked([]);
       return;
     }
-
-    // Call the onChange callback if using optimistic
-    onChange && onChange(newTargetSelection);
 
     // Remove the checked items from the target list
     setSelectedItemKeys(newTargetSelection);

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -34,22 +34,9 @@ export default function TransferList({
     useState<string[]>(targetListKeys);
 
   /**
-   * Get item label from any item structure
+   * Get primary label from item
    **/
-  const getItemLabel = (
-    item: TransferListItem | string,
-    type: "primary" | "secondary" = "primary"
-  ) => {
-    // If getting a secondary label
-    if (type === "secondary") {
-      // If item is a string secondary label is ignored
-      if (typeof item === "string") {
-        return "";
-      } else {
-        return item.secondaryLabel || "";
-      }
-    }
-
+  const getPrimaryLabel = (item: TransferListItem | string) => {
     // Return a primary label
     if (typeof item === "string") {
       return item;
@@ -59,7 +46,17 @@ export default function TransferList({
   };
 
   /**
-   * Get key from any item structure
+   * Get secondary label from item
+   **/
+  const getSecondaryLabel = (item: TransferListItem | string) => {
+    // Return a primary label
+    if (typeof item !== "string") {
+      return item.secondaryLabel;
+    }
+  };
+
+  /**
+   * Get key from from item
    **/
   const filterKey = (item: TransferListItem | string) => {
     // If item is a string return it as an id
@@ -81,7 +78,7 @@ export default function TransferList({
 
   // Filtered source items
   const filteredSourceItems = allSourceItems.filter(item =>
-    getItemLabel(item).toLowerCase().includes(sourceFilter.toLowerCase())
+    getPrimaryLabel(item).toLowerCase().includes(sourceFilter.toLowerCase())
   );
 
   // All checked source list items
@@ -104,7 +101,7 @@ export default function TransferList({
 
   // Filtered target items
   const filteredTargetItems = allTargetItems.filter(item =>
-    getItemLabel(item).toLowerCase().includes(targetFilter.toLowerCase())
+    getPrimaryLabel(item).toLowerCase().includes(targetFilter.toLowerCase())
   );
 
   // All checked target list items
@@ -294,8 +291,8 @@ export default function TransferList({
             checked={sourceItemsToTransfer}
             items={filteredSourceItems.map(item => ({
               key: filterKey(item),
-              primaryLabel: getItemLabel(item),
-              secondaryLabel: getItemLabel(item, "secondary")
+              primaryLabel: getPrimaryLabel(item),
+              secondaryLabel: getSecondaryLabel(item)
             }))}
             handleToggle={handleToggle}
             role="source-list"
@@ -400,8 +397,8 @@ export default function TransferList({
               checked={targetItemsToTransfer}
               items={filteredTargetItems.map(item => ({
                 key: filterKey(item),
-                primaryLabel: getItemLabel(item),
-                secondaryLabel: getItemLabel(item, "secondary")
+                primaryLabel: getPrimaryLabel(item),
+                secondaryLabel: getSecondaryLabel(item)
               }))}
               handleToggle={handleToggle}
               role="target-list"

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -156,6 +156,30 @@ export default function TransferList({
   };
 
   /**
+   * Determine with items are an array of objects or strings
+   */
+  const itemsAreStrings = (
+    items: string[] | TransferListItem[]
+  ): items is string[] => {
+    return items.every(item => typeof item === "string");
+  };
+
+  /**
+   * Get transferred items
+   */
+  const getTransferredItems = (
+    items: string[] | TransferListItem[],
+    selectedKeys: string[]
+  ) => {
+    // Return transferred items if they are strings or objects
+    if (itemsAreStrings(items)) {
+      return items.filter(item => selectedKeys.includes(item));
+    } else {
+      return items.filter(item => selectedKeys.includes(item.key));
+    }
+  };
+
+  /**
    * Transfer items to the target list
    */
   const transferToTarget = () => {
@@ -165,8 +189,11 @@ export default function TransferList({
     // Updated target list keys
     const updatedTargetList = [...keys, ...checkedSourceItems];
 
+    // Get the items that have been transferred
+    const updatedSelectedItems = getTransferredItems(items, updatedTargetList);
+
     // Call the onChange callback
-    onChange && onChange(updatedTargetList);
+    onChange && onChange(updatedSelectedItems);
 
     // If component is controlled, end the function
     if (selectedItems) {
@@ -189,8 +216,11 @@ export default function TransferList({
       item => !targetItemsToTransfer.includes(item)
     );
 
+    // Get the items that have been transferred
+    const updatedSelectedItems = getTransferredItems(items, newTargetSelection);
+
     // Call the onChange callback
-    onChange && onChange(newTargetSelection);
+    onChange && onChange(updatedSelectedItems);
 
     // If component is controlled, end the function
     if (selectedItems) {

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -13,53 +13,160 @@ import {
 import React, { useEffect, useState } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
-import DeletableList from "../DeletableList/DeletableList";
 import SearchIcon from "@mui/icons-material/Search";
 import { TransferListProps } from "./TransferList.types";
 
-export default function TransferList({
+export default function TransferList<T>({
+  filterKey,
+  initialTargetItemKeys = [],
   items = [],
-  onChange = () => null,
-  selectedItems = []
-}: TransferListProps) {
-  // search state
-  const [filteredItems, setFilteredItems] = useState<string[]>([]);
-  const [search, setSearch] = useState("");
+  itemLabel,
+  onTransfer,
+  sourceListLabel,
+  targetListLabel
+}: TransferListProps<T>) {
+  // All checked item keys
+  const [checked, setChecked] = useState<string[]>([]);
+  // Source list search filter
+  const [sourceFilter, setSourceFilter] = useState<string>("");
+  // Target list search filter
+  const [targetFilter, setTargetFilter] = useState<string>("");
+  // All item keys
+  const [targetItemKeys, setTargetItemKeys] = useState<string[]>(
+    initialTargetItemKeys
+  );
 
-  // update filtered items when search state changes
-  useEffect(() => {
-    if (search.length === 0) {
-      // no search so show all items
-      setFilteredItems(items);
-    } else {
-      // only show items that contain the search
-      setFilteredItems(
-        items.filter(item => item.toLowerCase().includes(search.toLowerCase()))
+  /**
+   * Source list logic
+   */
+
+  // All source items
+  const allSourceItems = items.filter(
+    item => !targetItemKeys.includes(filterKey(item))
+  );
+
+  // Filtered source items
+  const filteredSourceItems = allSourceItems.filter(item =>
+    itemLabel(item).toLowerCase().includes(sourceFilter.toLowerCase())
+  );
+
+  // All checked source list items
+  const sourceItemsToTransfer = checked.filter(
+    item => !targetItemKeys.includes(item)
+  );
+
+  // Boolean to indicate if all items are checked
+  const allSourceItemsChecked =
+    allSourceItems.length === sourceItemsToTransfer.length;
+
+  /**
+   * Target list logic
+   */
+
+  // All target items
+  const allTargetItems = items.filter(item =>
+    targetItemKeys.includes(filterKey(item))
+  );
+
+  // Filtered target items
+  const filteredTargetItems = allTargetItems.filter(item =>
+    itemLabel(item).toLowerCase().includes(targetFilter.toLowerCase())
+  );
+
+  // All checked target list items
+  const targetItemsToTransfer = checked.filter(item =>
+    targetItemKeys.includes(item)
+  );
+
+  // Boolean to indicate if all target items are checked
+  const allTargetItemsChecked =
+    allTargetItems.length === targetItemsToTransfer.length;
+
+  /**
+   * Handle check all items in the source list
+   */
+  const handleCheckAllSource = () => {
+    // If all items are checked, uncheck them
+    // Otherwise, check all items
+    allSourceItemsChecked
+      ? setChecked(
+          checked.filter(item => !sourceItemsToTransfer.includes(item))
+        )
+      : setChecked(
+          items
+            .map(item => filterKey(item))
+            .filter(item => !targetItemKeys.includes(item))
+        );
+  };
+
+  /**
+   * Handle check all items in the target list
+   */
+  const handleCheckAllTarget = () => {
+    // If all items are checked, uncheck them
+    // Otherwise, check all items
+    allTargetItemsChecked
+      ? setChecked(
+          checked.filter(item => !targetItemsToTransfer.includes(item))
+        )
+      : setChecked(
+          items
+            .map(item => filterKey(item))
+            .filter(item => targetItemKeys.includes(item))
+        );
+  };
+
+  /**
+   * Transfer items to the target list
+   */
+  const transferToTarget = () => {
+    // Call the onTransfer callback
+    onTransfer &&
+      onTransfer(
+        checked.filter(item => !targetItemKeys.includes(item)),
+        "ltr"
       );
-    }
-  }, [items, search]);
 
-  // handle search change
-  const handleSearch = (event: {
-    target: {
-      value: string;
-    };
-  }) => {
-    setSearch(event.target.value);
+    // Add the checked items to the target list
+    setTargetItemKeys([...targetItemKeys, ...sourceItemsToTransfer]);
+    // Uncheck all items
+    setChecked([]);
   };
 
-  // handle list item toggle
+  /**
+   * Transfer items to the source list
+   */
+  const transferToSource = () => {
+    // Call the onTransfer callback
+    onTransfer && onTransfer(targetItemsToTransfer, "rtl");
+
+    // Remove the checked items from the target list
+    setTargetItemKeys(
+      targetItemKeys.filter(item => !targetItemsToTransfer.includes(item))
+    );
+    // Uncheck all items
+    setChecked([]);
+  };
+
+  /**
+   * Handle toggle of item checkboxes
+   */
   const handleToggle = (value: string) => {
-    const currentIndex = selectedItems.indexOf(value);
-    const newSelectedItems = [...selectedItems];
+    // Current index of the item
+    const currentIndex = checked.indexOf(value);
+    // New checked items
+    const newChecked = [...checked];
+    // If the item is not checked, add it to the list
     if (currentIndex === -1) {
-      newSelectedItems.push(value);
+      newChecked.push(value);
     } else {
-      newSelectedItems.splice(currentIndex, 1);
+      // If the item is checked, remove it from the list
+      newChecked.splice(currentIndex, 1);
     }
-    onChange(newSelectedItems.sort());
+    // Update the checked items
+    setChecked(newChecked);
   };
-  // define list components
+
   return (
     <Box
       sx={{
@@ -79,33 +186,36 @@ export default function TransferList({
       >
         <Box
           sx={{
-            borderBottom: theme => `1px solid ${theme.palette.divider}`,
-            borderRight: theme => `1px solid ${theme.palette.divider}`,
+            alignItems: "center",
             display: "flex",
-            height: "50px",
-            width: "100%"
+            py: 2
           }}
         >
-          <InputBase
-            placeholder="Search..."
-            value={search}
-            onChange={handleSearch}
-            sx={{ flex: 1, pl: 1, pt: 0.5 }}
+          <Checkbox
+            onClick={handleCheckAllSource}
+            checked={sourceItemsToTransfer.length > 0}
+            indeterminate={
+              sourceItemsToTransfer.length > 0 &&
+              allSourceItems.length !== sourceItemsToTransfer.length
+            }
+            disableRipple
           />
-          {search.length > 0 ? (
-            <IconButton
-              onClick={() => setSearch("")}
-              sx={{ padding: theme => theme.spacing(1) }}
-            >
-              <CloseIcon />
-            </IconButton>
-          ) : (
-            <SearchIcon
-              color="action"
-              sx={{ margin: theme => theme.spacing(1) }}
-            />
-          )}
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center"
+            }}
+          >
+            <Typography variant="body1">{sourceListLabel}</Typography>
+            <Typography variant="body2">{`${sourceItemsToTransfer.length}/${allSourceItems.length} selected`}</Typography>
+          </Box>
         </Box>
+
+        <Box sx={{ p: 2 }}>
+          <Search title="source-filter" onChange={setSourceFilter} />
+        </Box>
+
         <Box
           sx={{
             borderRight: theme => `1px solid ${theme.palette.divider}`,
@@ -115,36 +225,44 @@ export default function TransferList({
             width: "100%"
           }}
         >
-          <Box
-            sx={{
-              width: "100%"
-            }}
-          >
-            <List dense component="div" role="list">
-              {filteredItems.map(value => {
-                return (
-                  <ListItem
-                    key={value}
-                    role="listitem1"
-                    button
-                    onClick={() => handleToggle(value)}
-                    disablePadding
-                  >
-                    <ListItemIcon>
-                      <Checkbox
-                        checked={selectedItems.indexOf(value) !== -1}
-                        disableRipple
-                      />
-                    </ListItemIcon>
-                    <ListItemText primary={value} />
-                  </ListItem>
-                );
-              })}
-              <ListItem />
-            </List>
-          </Box>
+          <SingleList
+            checked={sourceItemsToTransfer}
+            items={filteredSourceItems.map(item => itemLabel(item))}
+            handleToggle={handleToggle}
+            role="source-list"
+          />
         </Box>
       </Box>
+
+      <Box
+        height="100%"
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        flexGrow={1}
+        p={2}
+      >
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{ m: 0.5 }}
+          onClick={transferToTarget}
+          disabled={sourceItemsToTransfer.length === 0}
+        >
+          &gt;
+        </Button>
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{ m: 0.5 }}
+          onClick={transferToSource}
+          disabled={targetItemsToTransfer.length === 0}
+        >
+          &lt;
+        </Button>
+      </Box>
+
       <Box
         sx={{
           display: "flex",
@@ -155,33 +273,34 @@ export default function TransferList({
       >
         <Box
           sx={{
-            borderBottom: theme => `1px solid ${theme.palette.divider}`,
-            disply: "flex",
-            flexDirection: "column",
-            height: "50px",
-            position: "relative",
-            width: "100%"
+            alignItems: "center",
+            display: "flex",
+            py: 2
           }}
         >
-          {selectedItems.length === 0 ? (
-            <Typography data-testid="none-selected" sx={{ pl: 1, pt: 1 }}>
-              None Selected
-            </Typography>
-          ) : (
-            <Box>
-              <Typography sx={{ pl: 1, pt: 1 }}>
-                {`${selectedItems.length} selected`}
-              </Typography>
-              <Button
-                data-testid="clear-all-button"
-                variant="text"
-                sx={{ position: "absolute", right: 2, top: 2 }}
-                onClick={() => onChange([])}
-              >
-                Clear All
-              </Button>
-            </Box>
-          )}
+          <Checkbox
+            onClick={handleCheckAllTarget}
+            checked={targetItemsToTransfer.length > 0}
+            indeterminate={
+              targetItemsToTransfer.length > 0 &&
+              allTargetItems.length !== targetItemsToTransfer.length
+            }
+            disableRipple
+          />
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center"
+            }}
+          >
+            <Typography variant="body1">{targetListLabel}</Typography>
+            <Typography variant="body2">{`${targetItemsToTransfer.length}/${allTargetItems.length} selected`}</Typography>
+          </Box>
+        </Box>
+
+        <Box sx={{ p: 2 }}>
+          <Search title="target-filter" onChange={setTargetFilter} />
         </Box>
         <Box
           sx={{
@@ -196,10 +315,111 @@ export default function TransferList({
               width: "100%"
             }}
           >
-            <DeletableList items={selectedItems} onDelete={handleToggle} />
+            <SingleList
+              checked={targetItemsToTransfer}
+              items={filteredTargetItems.map(item => itemLabel(item))}
+              handleToggle={handleToggle}
+              role="target-list"
+            />
           </Box>
         </Box>
       </Box>
     </Box>
   );
 }
+
+const Search = ({
+  title,
+  onChange
+}: {
+  title: string;
+  onChange: (value: string) => void;
+}) => {
+  const [search, setSearch] = useState("");
+
+  // handle change
+  const handleChange = (event: {
+    target: {
+      value: string;
+    };
+  }) => {
+    setSearch(event.target.value);
+  };
+
+  useEffect(() => {
+    onChange(search);
+  }, [onChange, search]);
+
+  return (
+    <Box
+      sx={{
+        alignItems: "center",
+        border: theme => `1px solid ${theme.palette.divider}`,
+        display: "flex",
+        width: "100%"
+      }}
+    >
+      <InputBase
+        title={title}
+        placeholder="Search..."
+        value={search}
+        onChange={handleChange}
+        size="small"
+        sx={{
+          flex: 1,
+          pl: 1,
+          pt: 0.5
+        }}
+      />
+      {search.length > 0 ? (
+        <IconButton onClick={() => setSearch("")}>
+          <CloseIcon />
+        </IconButton>
+      ) : (
+        <SearchIcon color="action" sx={{ mr: 1 }} />
+      )}
+    </Box>
+  );
+};
+
+const SingleList = ({
+  checked,
+  items,
+  handleToggle,
+  role
+}: {
+  checked: string[];
+  items: string[];
+  handleToggle: (x: string) => void;
+  role: string;
+}) => {
+  return (
+    <Box
+      sx={{
+        width: "100%"
+      }}
+    >
+      <List dense component="div" role={role}>
+        {items.map(value => {
+          return (
+            <ListItem
+              key={value}
+              role="listitem1"
+              onClick={() => handleToggle(value)}
+              disablePadding
+            >
+              <ListItemIcon>
+                <Checkbox
+                  checked={checked.indexOf(value) !== -1}
+                  disableRipple
+                />
+              </ListItemIcon>
+              <ListItemText primary={value} />
+            </ListItem>
+          );
+        })}
+        <ListItem />
+      </List>
+    </Box>
+  );
+};

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -16,10 +16,10 @@ import {
 } from "./TransferList.types";
 
 export default function TransferList({
-  handleChange,
-  selectedItems = [],
+  defaultSelectedItems,
   items = [],
   onChange,
+  selectedItems,
   sourceListLabel,
   targetListLabel
 }: TransferListProps) {
@@ -33,14 +33,9 @@ export default function TransferList({
   const [targetFilter, setTargetFilter] = useState<string>("");
 
   // All item keys
-  const [selectedItemKeys, setSelectedItemKeys] =
-    useState<string[]>(selectedItems);
-
-  // // Update target keys state when the prop updates and uncheck
-  // useEffect(() => {
-  //   setSelectedItemKeys(selectedItems);
-  //   setChecked([]);
-  // }, [selectedItems]);
+  const [selectedItemKeys, setSelectedItemKeys] = useState<string[]>(
+    defaultSelectedItems || selectedItems || []
+  );
 
   /**
    * Get primary label from item
@@ -77,7 +72,7 @@ export default function TransferList({
   };
 
   // Keys to be used for updates
-  const keys = handleChange ? selectedItems : selectedItemKeys;
+  const keys = selectedItems || selectedItemKeys;
 
   /**
    * Source list logic
@@ -164,8 +159,8 @@ export default function TransferList({
     const updatedTargetList = [...keys, ...checkedSourceItems];
 
     // Call handle hook if using controlled
-    if (handleChange) {
-      handleChange(updatedTargetList);
+    if (selectedItems) {
+      onChange(updatedTargetList);
       setChecked([]);
       return;
     }
@@ -190,8 +185,8 @@ export default function TransferList({
     );
 
     // Call handle hook if using controlled
-    if (handleChange) {
-      handleChange(newTargetSelection);
+    if (selectedItems) {
+      onChange(newTargetSelection);
       setChecked([]);
       return;
     }
@@ -272,7 +267,9 @@ export default function TransferList({
               pl: 1
             }}
           >
-            <Typography variant="body1">{sourceListLabel}</Typography>
+            <Typography id="source-list-label" variant="body1">
+              {sourceListLabel}
+            </Typography>
             <Typography
               variant="body2"
               sx={{ color: "text.secondary" }}
@@ -296,13 +293,13 @@ export default function TransferList({
         >
           <SingleList
             checked={sourceItemsToTransfer}
+            id="source-list"
             items={filteredSourceItems.map(item => ({
               key: filterKey(item),
               primaryLabel: getPrimaryLabel(item),
               secondaryLabel: getSecondaryLabel(item)
             }))}
             handleToggle={handleToggle}
-            role="source-list"
           />
         </Box>
       </Box>
@@ -377,7 +374,9 @@ export default function TransferList({
               pl: 1
             }}
           >
-            <Typography variant="body1">{targetListLabel}</Typography>
+            <Typography id="target-list-label" variant="body1">
+              {targetListLabel}
+            </Typography>
             <Typography
               variant="body2"
               sx={{ color: "text.secondary" }}
@@ -402,13 +401,13 @@ export default function TransferList({
           <Box>
             <SingleList
               checked={targetItemsToTransfer}
+              id="target-list"
               items={filteredTargetItems.map(item => ({
                 key: filterKey(item),
                 primaryLabel: getPrimaryLabel(item),
                 secondaryLabel: getSecondaryLabel(item)
               }))}
               handleToggle={handleToggle}
-              role="target-list"
             />
           </Box>
         </Box>
@@ -445,19 +444,18 @@ const Search = ({ onChange }: { onChange: (value: string) => void }) => {
 /**
  * Single list component for the transfer list
  */
-function SingleList({ checked, items, handleToggle, role }: SingleListProps) {
+function SingleList({ checked, id, items, handleToggle }: SingleListProps) {
   return (
     <Box
       sx={{
         width: "100%"
       }}
     >
-      <List dense component="div" role={role} sx={{ py: 0 }}>
+      <List aria-labelledby={`${id}-label`} dense sx={{ py: 0 }}>
         {items.map(item => {
           return (
             <ListItem
               key={item.key}
-              role={`${role}-item`}
               sx={{ py: 0.5 }}
               onClick={() => handleToggle(item.key)}
               disablePadding
@@ -471,7 +469,6 @@ function SingleList({ checked, items, handleToggle, role }: SingleListProps) {
             </ListItem>
           );
         })}
-        <ListItem />
       </List>
     </Box>
   );

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -35,11 +35,12 @@ export type TransferListProps<T> = {
   onTransfer?: (value: string[], intent: "toTarget" | "toSource") => void;
 };
 
-export type SingleListProps<T> = {
+export type SingleListProps = {
   checked: string[];
-  filterKey: (item: T) => string;
-  items: TransferListItem[] | T[];
-  itemLabel: (item: T) => string;
-  handleToggle: (x: string) => void;
+  items: {
+    key: string;
+    label: string;
+  }[];
+  handleToggle: (key: string) => void;
   role: string;
 };

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -4,30 +4,42 @@ export type TransferListItem = {
   key: string;
 };
 
-// Ensure selected items are provided if using handleChange
-type ControlledProps =
-  | {
-      /**
-       * Control the transfer of the items
-       */
-      handleChange: (value: string[]) => void;
-      /**
-       * Array of keys for the items on the right side.
-       */
-      selectedItems: string[];
-    }
-  | {
-      /**
-       * Control the transfer of the items
-       */
-      handleChange?: never;
-      /**
-       * Array of keys for the items on the right side.
-       */
-      selectedItems?: string[];
-    };
+// Controlled component props
+// Ensure onChange is required if using selected items
+// Ensure defaultSelectedItems and selectedItems cannot exist together
+type ControlledProps = {
+  /**
+   * Callback fired when the items are transferred.
+   */
+  onChange: (value: string[] | TransferListItem[]) => void;
+  /**
+   * Array of keys for the items on the right side for controlled use
+   */
+  selectedItems: string[];
+  /**
+   * Array of default keys to initialist the right hand side for uncontrolled use
+   */
+  defaultSelectedItems?: never;
+};
 
-export type TransferListProps = ControlledProps & {
+// Uncontrolled component props
+// Ensure selectedItems and defaultSelectedItems cannot exist together
+type UncontrolledProps = {
+  /**
+   * Callback fired when the items are transferred.
+   */
+  onChange?: (value: string[] | TransferListItem[]) => void;
+  /**
+   * Array of keys for the items on the right side for controlled use
+   */
+  selectedItems?: undefined;
+  /**
+   * Array of default keys to initialist the right hand side for uncontrolled use
+   */
+  defaultSelectedItems?: string[];
+};
+
+export type TransferListProps = (ControlledProps | UncontrolledProps) & {
   /**
    * Array of Items.
    */
@@ -40,10 +52,6 @@ export type TransferListProps = ControlledProps & {
    * Target list label
    */
   targetListLabel: string;
-  /**
-   * Callback fired when the items are transferred.
-   */
-  onChange?: (value: string[]) => void;
 };
 
 export type SingleListProps = {
@@ -51,6 +59,10 @@ export type SingleListProps = {
    * Checked items
    */
   checked: string[];
+  /**
+   * ID of the list is also used to get the list aria label
+   */
+  id: string;
   /**
    * Item array
    */
@@ -72,8 +84,4 @@ export type SingleListProps = {
    * Toggle function
    */
   handleToggle: (key: string) => void;
-  /**
-   * Role of the list
-   */
-  role: string;
 };

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -1,4 +1,6 @@
-export type TransferListItem = string | { label: string; id: string };
+export type TransferListItem =
+  | string
+  | { primaryLabel: string; secondaryLabel?: string; id: string };
 
 export type TransferListProps<T> = {
   /**
@@ -26,9 +28,18 @@ export type TransferListProps<T> = {
    */
   targetListLabel: string;
   /**
-   * The key to be used for the label.
+   * Props for the default item
    */
-  itemLabel?: (item: T) => string;
+  itemProps?: {
+    /**
+     * The key to be used for the primary label
+     */
+    primaryLabel: (item: T) => string;
+    /**
+     * The key to be used for the secondary label
+     */
+    secondaryLabel?: (item: T) => string;
+  };
   /**
    * Callback fired when the items are transferred.
    */
@@ -39,7 +50,8 @@ export type SingleListProps = {
   checked: string[];
   items: {
     key: string;
-    label: string;
+    primaryLabel: string;
+    secondaryLabel: string;
   }[];
   handleToggle: (key: string) => void;
   role: string;

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -8,11 +8,11 @@ export type TransferListProps<T> = {
   /**
    * Control the transfer of the items
    */
-  handleTransfer?: (value: string[], intent: "ltr" | "rtl") => void;
+  handleTransfer?: (value: string[], intent: "toTarget" | "toSource") => void;
   /**
    * Array of Items.
    */
-  items?: TransferListItem[] | T[];
+  items: TransferListItem[] | T[];
   /**
    * Array of keys for the items on the right side.
    */
@@ -32,5 +32,14 @@ export type TransferListProps<T> = {
   /**
    * Callback fired when the items are transferred.
    */
-  onTransfer?: (value: string[], intent: "ltr" | "rtl") => void;
+  onTransfer?: (value: string[], intent: "toTarget" | "toSource") => void;
+};
+
+export type SingleListProps<T> = {
+  checked: string[];
+  filterKey: (item: T) => string;
+  items: TransferListItem[] | T[];
+  itemLabel: (item: T) => string;
+  handleToggle: (x: string) => void;
+  role: string;
 };

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -1,7 +1,7 @@
 export type TransferListItem = {
   primaryLabel: string;
   secondaryLabel?: string;
-  id: string;
+  key: string;
 };
 
 export type TransferListProps = {

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -47,12 +47,33 @@ export type TransferListProps<T> = {
 };
 
 export type SingleListProps = {
+  /**
+   * Checked items
+   */
   checked: string[];
+  /**
+   * Item array
+   */
   items: {
+    /**
+     * Unique identifier
+     */
     key: string;
+    /**
+     * Primary label of the item
+     */
     primaryLabel: string;
+    /**
+     * Secondary label of the item
+     */
     secondaryLabel: string;
   }[];
+  /**
+   * Toggle function
+   */
   handleToggle: (key: string) => void;
+  /**
+   * Role of the list
+   */
   role: string;
 };

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -51,7 +51,7 @@ export type SingleListProps = {
     /**
      * Secondary label of the item
      */
-    secondaryLabel: string;
+    secondaryLabel?: string;
   }[];
   /**
    * Toggle function

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -6,6 +6,10 @@ export type TransferListProps<T> = {
    */
   filterKey?: (item: T) => string;
   /**
+   * Control the transfer of the items
+   */
+  handleTransfer?: (value: string[], intent: "ltr" | "rtl") => void;
+  /**
    * Array of Items.
    */
   items?: TransferListItem[] | T[];

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -4,19 +4,34 @@ export type TransferListItem = {
   key: string;
 };
 
-export type TransferListProps = {
-  /**
-   * Control the transfer of the items
-   */
-  handleChange?: (value: string[]) => void;
+// Ensure selected items are provided if using handleChange
+type ControlledProps =
+  | {
+      /**
+       * Control the transfer of the items
+       */
+      handleChange: (value: string[]) => void;
+      /**
+       * Array of keys for the items on the right side.
+       */
+      selectedItems: string[];
+    }
+  | {
+      /**
+       * Control the transfer of the items
+       */
+      handleChange?: never;
+      /**
+       * Array of keys for the items on the right side.
+       */
+      selectedItems?: string[];
+    };
+
+export type TransferListProps = ControlledProps & {
   /**
    * Array of Items.
    */
   items: string[] | TransferListItem[];
-  /**
-   * Array of keys for the items on the right side.
-   */
-  selectedItems?: string[];
   /**
    * Source list label
    */

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -1,12 +1,14 @@
+export type TransferListItem = string | { label: string; id: string };
+
 export type TransferListProps<T> = {
   /**
    * The key to be used for the filter.
    */
-  filterKey: (item: T) => string;
+  filterKey?: (item: T) => string;
   /**
    * Array of Items.
    */
-  items?: T[];
+  items?: TransferListItem[] | T[];
   /**
    * Array of keys for the items on the right side.
    */
@@ -26,7 +28,7 @@ export type TransferListProps<T> = {
   /**
    * The key to be used for the label.
    */
-  itemLabel: (item: T) => string;
+  itemLabel?: (item: T) => string;
   /**
    * Callback fired when the items are transferred.
    */

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -16,11 +16,7 @@ export type TransferListProps<T> = {
   /**
    * Array of keys for the items on the right side.
    */
-  initialTargetItemKeys?: string[];
-  /**
-   * Array of selectedItems.
-   */
-  selectedItems?: string[];
+  targetListKeys?: string[];
   /**
    * Source list label
    */

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -1,12 +1,10 @@
-export type TransferListItem =
-  | string
-  | { primaryLabel: string; secondaryLabel?: string; id: string };
+export type TransferListItem = {
+  primaryLabel: string;
+  secondaryLabel?: string;
+  id: string;
+};
 
-export type TransferListProps<T> = {
-  /**
-   * The key to be used for the filter.
-   */
-  filterKey?: (item: T) => string;
+export type TransferListProps = {
   /**
    * Control the transfer of the items
    */
@@ -14,7 +12,7 @@ export type TransferListProps<T> = {
   /**
    * Array of Items.
    */
-  items: TransferListItem[] | T[];
+  items: string[] | TransferListItem[];
   /**
    * Array of keys for the items on the right side.
    */
@@ -27,19 +25,6 @@ export type TransferListProps<T> = {
    * Target list label
    */
   targetListLabel: string;
-  /**
-   * Props for the default item
-   */
-  itemProps?: {
-    /**
-     * The key to be used for the primary label
-     */
-    primaryLabel: (item: T) => string;
-    /**
-     * The key to be used for the secondary label
-     */
-    secondaryLabel?: (item: T) => string;
-  };
   /**
    * Callback fired when the items are transferred.
    */

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -1,14 +1,34 @@
-export type TransferListProps = {
+export type TransferListProps<T> = {
+  /**
+   * The key to be used for the filter.
+   */
+  filterKey: (item: T) => string;
   /**
    * Array of Items.
    */
-  items?: string[];
+  items?: T[];
   /**
-   * Callback fired when the new item is selected.
+   * Array of keys for the items on the right side.
    */
-  onChange?: (value: string[]) => void;
+  initialTargetItemKeys?: string[];
   /**
    * Array of selectedItems.
    */
   selectedItems?: string[];
+  /**
+   * Source list label
+   */
+  sourceListLabel: string;
+  /**
+   * Target list label
+   */
+  targetListLabel: string;
+  /**
+   * The key to be used for the label.
+   */
+  itemLabel: (item: T) => string;
+  /**
+   * Callback fired when the items are transferred.
+   */
+  onTransfer?: (value: string[], intent: "ltr" | "rtl") => void;
 };

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -1,12 +1,21 @@
 export type TransferListItem = {
-  primaryLabel: string;
-  secondaryLabel?: string;
+  /**
+   * Unique key
+   */
   key: string;
+  /**
+   * Primary label rendered in an item
+   */
+  primaryLabel: string;
+  /**
+   * Secondary label rendered in an item
+   */
+  secondaryLabel?: string;
 };
 
 export type TransferListProps = {
   /**
-   * Array of default keys to initialist the right hand side for uncontrolled use
+   * Array of default keys to initialise the right hand side for uncontrolled use
    */
   defaultSelectedItems?: string[];
   /**

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -4,27 +4,15 @@ export type TransferListItem = {
   key: string;
 };
 
-// Controlled component props
-// Ensure onChange is required if using selected items
-// Ensure defaultSelectedItems and selectedItems cannot exist together
-type ControlledProps = {
-  /**
-   * Callback fired when the items are transferred.
-   */
-  onChange: (value: string[] | TransferListItem[]) => void;
-  /**
-   * Array of keys for the items on the right side for controlled use
-   */
-  selectedItems: string[];
+export type TransferListProps = {
   /**
    * Array of default keys to initialist the right hand side for uncontrolled use
    */
-  defaultSelectedItems?: never;
-};
-
-// Uncontrolled component props
-// Ensure selectedItems and defaultSelectedItems cannot exist together
-type UncontrolledProps = {
+  defaultSelectedItems?: string[];
+  /**
+   * Array of Items.
+   */
+  items: string[] | TransferListItem[];
   /**
    * Callback fired when the items are transferred.
    */
@@ -32,26 +20,15 @@ type UncontrolledProps = {
   /**
    * Array of keys for the items on the right side for controlled use
    */
-  selectedItems?: undefined;
-  /**
-   * Array of default keys to initialist the right hand side for uncontrolled use
-   */
-  defaultSelectedItems?: string[];
-};
-
-export type TransferListProps = (ControlledProps | UncontrolledProps) & {
-  /**
-   * Array of Items.
-   */
-  items: string[] | TransferListItem[];
+  selectedItems?: string[];
   /**
    * Source list label
    */
-  sourceListLabel: string;
+  sourceListLabel?: string;
   /**
    * Target list label
    */
-  targetListLabel: string;
+  targetListLabel?: string;
 };
 
 export type SingleListProps = {

--- a/src/TransferList/TransferList.types.ts
+++ b/src/TransferList/TransferList.types.ts
@@ -8,7 +8,7 @@ export type TransferListProps = {
   /**
    * Control the transfer of the items
    */
-  handleTransfer?: (value: string[], intent: "toTarget" | "toSource") => void;
+  handleChange?: (value: string[]) => void;
   /**
    * Array of Items.
    */
@@ -16,7 +16,7 @@ export type TransferListProps = {
   /**
    * Array of keys for the items on the right side.
    */
-  targetListKeys?: string[];
+  selectedItems?: string[];
   /**
    * Source list label
    */
@@ -28,7 +28,7 @@ export type TransferListProps = {
   /**
    * Callback fired when the items are transferred.
    */
-  onTransfer?: (value: string[], intent: "toTarget" | "toSource") => void;
+  onChange?: (value: string[]) => void;
 };
 
 export type SingleListProps = {


### PR DESCRIPTION
Closes [VE-160](https://sce.myjetbrains.com/youtrack/issue/VE-160/Update-TransferList-Component)

## Changes

This PR updates the TransferList to be used to replace the application specific implementations in Vehicle, ID, and Data.

- Removes the old method of transferring on check
- Items are now selected for transfer on click
- Items are transferred on clicking a transfer button
- Add secondary labels
- Updated style to match new figma design
- Client side optimistic transfer with a callback function
- Controlled transfer to ignore default functionality

## UI/UX

https://github.com/user-attachments/assets/804da284-0200-4d4d-b75c-45e2e6c0ad72

<img width="1416" alt="Screenshot 2024-11-04 at 10 09 48" src="https://github.com/user-attachments/assets/f35232ab-371a-44b5-bab5-342e8c252680">

<img width="1421" alt="Screenshot 2024-11-04 at 10 10 17" src="https://github.com/user-attachments/assets/54508a41-a334-4299-8aeb-75afdf65e94d">

## Testing notes

- Selected items transfer correctly
- Select all functions correctly
- The onTransfer callback is called correctly
- handleTransfer calls prop and does not change the UI
- Filtered items that have already been selected still transfer 
- Selected items should always reflect the unfiltered data

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- ~[ ] I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[ ] I have populated the deploy-preview with relevant test data.~
- [x] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
