### PR TITLE
TD-3161 Model Button Edit Styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.11.1-0",
+  "version": "8.11.1",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "8.12.0-7",
+  "version": "8.12.0-8",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/ModelButton/ModelButton.test.tsx
+++ b/src/ModelButton/ModelButton.test.tsx
@@ -50,11 +50,15 @@ describe("ModelButton", () => {
     expect(svgElement).toHaveAttribute("stroke-width", "2");
   });
 
-  // test when status different than 'none' icon is rendered
+  // test when no status property applied, icon is not rendered
   test("does show status icon", () => {
-    render(<ModelButton status="error" />);
+    render(<ModelButton />);
+    const successIcon = screen.queryByTestId("success-icon");
+    const warningIcon = screen.queryByTestId("warning-icon");
     const errorIcon = screen.queryByTestId("error-icon");
-    expect(errorIcon).toBeInTheDocument();
+    expect(successIcon).not.toBeInTheDocument();
+    expect(warningIcon).not.toBeInTheDocument();
+    expect(errorIcon).not.toBeInTheDocument();
   });
 
   // test status icon is correctly set
@@ -86,13 +90,20 @@ describe("ModelButton", () => {
     }
   );
 
-  // test when status different than 'none' appropriate background is added to icon button
-  test("does apply background color", () => {
-    render(<ModelButton status="error" />);
-    const svgElement = screen.getByTestId("background");
-    expect(svgElement).toBeInTheDocument();
-    expect(svgElement).toHaveAttribute("fill", "rgba(211, 47, 47, 0.04)");
-  });
+  // test when no status property is passed, status background is not added to icon button
+  test.each([
+    ["rgba(211, 47, 47)"],
+    ["rgb(237, 108, 2)"],
+    ["rgb(46, 125, 50)"]
+  ] as const)(
+    "does not apply one of the status backgrounds color to the svg fill",
+    color => {
+      render(<ModelButton />);
+      const svgElement = screen.queryByTestId("background");
+      expect(svgElement).toBeInTheDocument();
+      expect(svgElement).not.toHaveAttribute("fill", alpha(color, 0.04));
+    }
+  );
 
   // test that popup button is not shown when no children are provided
   test("does not show popup button when no children are provided", () => {

--- a/src/ModelButton/ModelButton.test.tsx
+++ b/src/ModelButton/ModelButton.test.tsx
@@ -82,7 +82,7 @@ describe("ModelButton", () => {
     ["warning", "rgb(237, 108, 2)"],
     ["success", "rgb(46, 125, 50)"]
   ] as const)(
-    "renrers correct background based on the status",
+    "renders correct background based on the status",
     (status, color) => {
       render(<ModelButton status={status} />);
       const svgElement = screen.getByTestId("background");

--- a/src/ModelButton/ModelButton.test.tsx
+++ b/src/ModelButton/ModelButton.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 
 import ModelButton from "./ModelButton";
 import React from "react";
+import { alpha } from "@mui/material";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
@@ -47,6 +48,50 @@ describe("ModelButton", () => {
     const svgElement = screen.getByTestId("background");
     expect(svgElement).toHaveAttribute("stroke", color);
     expect(svgElement).toHaveAttribute("stroke-width", "2");
+  });
+
+  // test when status different than 'none' icon is rendered
+  test("does show status icon", () => {
+    render(<ModelButton status="error" />);
+    const errorIcon = screen.queryByTestId("error-icon");
+    expect(errorIcon).toBeInTheDocument();
+  });
+
+  // test status icon is correctly set
+  test.each([
+    ["error", "rgb(211, 47, 47)"],
+    ["warning", "rgb(237, 108, 2)"],
+    ["success", "rgb(46, 125, 50)"]
+  ] as const)(
+    "renders correct status icon based on the status",
+    (status, color) => {
+      render(<ModelButton status={status} />);
+      const currentStatusIcon = screen.getByTestId(`${status}-icon`);
+      expect(currentStatusIcon).toBeInTheDocument();
+      expect(window.getComputedStyle(currentStatusIcon).color).toEqual(color);
+    }
+  );
+
+  // test background is correctly set to IconButton when status is other than 'none'
+  test.each([
+    ["error", "rgba(211, 47, 47)"],
+    ["warning", "rgb(237, 108, 2)"],
+    ["success", "rgb(46, 125, 50)"]
+  ] as const)(
+    "renrers correct background based on the status",
+    (status, color) => {
+      render(<ModelButton status={status} />);
+      const svgElement = screen.getByTestId("background");
+      expect(svgElement).toHaveAttribute("fill", alpha(color, 0.04));
+    }
+  );
+
+  // test when status different than 'none' appropriate background is added to icon button
+  test("does apply background color", () => {
+    render(<ModelButton status="error" />);
+    const svgElement = screen.getByTestId("background");
+    expect(svgElement).toBeInTheDocument();
+    expect(svgElement).toHaveAttribute("fill", "rgba(211, 47, 47, 0.04)");
   });
 
   // test that popup button is not shown when no children are provided

--- a/src/ModelButton/ModelButton.tsx
+++ b/src/ModelButton/ModelButton.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import {
   BackgroundProps,
+  CurrentIconBackgroundColorProps,
   ModelButtonPopupProps,
   ModelButtonProps
 } from "./ModelButton.types";
@@ -14,7 +15,7 @@ import {
   Typography,
   iconButtonClasses
 } from "@mui/material";
-import { Theme, alpha, useTheme } from "@mui/material/styles";
+import { alpha, useTheme } from "@mui/material/styles";
 
 import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
@@ -222,11 +223,11 @@ export default function ModelButton({
         >
           <Background
             borderColor={isHover ? borderColorHover : borderColor}
-            backgroundColor={getCurrentIconBackgroundColor(
+            backgroundColor={getCurrentIconBackgroundColor({
               isHover,
               status,
               theme
-            )}
+            })}
           />
           {icon
             ? React.cloneElement(icon, {
@@ -308,14 +309,18 @@ const ModelButtonPopup = ({
         sx={{
           "&:hover": {
             backgroundColor: theme =>
-              getCurrentIconBackgroundColor(true, status, theme),
+              getCurrentIconBackgroundColor({
+                isHover: true,
+                status,
+                theme
+              }),
             borderColor: colorHover
           },
           [`&.${iconButtonClasses.disabled}`]: {
             color
           },
           backgroundColor: theme =>
-            getCurrentIconBackgroundColor(false, status, theme),
+            getCurrentIconBackgroundColor({ isHover: false, status, theme }),
           border: "2px solid",
           borderColor: color,
           borderRadius: "50%",
@@ -359,11 +364,11 @@ const ModelButtonPopup = ({
 };
 
 /** Get the correct icon button background color, according to the theme and hover behaviour  */
-const getCurrentIconBackgroundColor = (
-  isHover: boolean,
-  status: string,
-  theme: Theme
-) => {
+const getCurrentIconBackgroundColor = ({
+  isHover,
+  status,
+  theme
+}: CurrentIconBackgroundColorProps) => {
   // calculate opacity depending on the hover
   const backgroundOpacity = isHover ? 0.12 : 0.04;
 

--- a/src/ModelButton/ModelButton.tsx
+++ b/src/ModelButton/ModelButton.tsx
@@ -16,6 +16,9 @@ import {
 } from "@mui/material";
 import { alpha, useTheme } from "@mui/material/styles";
 
+import CancelIcon from "@mui/icons-material/Cancel";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
 /**
@@ -101,6 +104,7 @@ export default function ModelButton({
 
   // set border color based on status
   let borderColor = theme.palette.text.secondary;
+
   if (disabled) {
     borderColor =
       theme.palette.mode === "light"
@@ -114,6 +118,9 @@ export default function ModelButton({
     borderColor = theme.palette.success.main;
   }
 
+  // set background color if status is different than 'none' and not disabled, background color equals border color
+  const backgroundColor = !disabled && status !== "none" ? borderColor : "";
+
   // ensure children are always an array
   const arrayChildren = React.Children.toArray(children);
   const hasChildren = arrayChildren && arrayChildren.length > 0;
@@ -121,8 +128,30 @@ export default function ModelButton({
   // is button being hovered over
   const [isHover, setIsHover] = React.useState(false);
 
+  // styles for icon which will be shown only when status is available
+  const iconStyles = {
+    color: isHover ? theme.palette.primary.main : backgroundColor,
+    height: "20px",
+    position: "absolute",
+    right: "6%",
+    top: "6%",
+    width: "20px"
+  };
+
   // which background to show. if there are nested children, show a cutout background, otherwise the normal background
   const Background = hasChildren ? CutOutBackground : CompleteBackground;
+
+  /** Get the correct icon for model button, according to the status  */
+  const getCurrentStatusIcon = () => {
+    switch (status) {
+      case "error":
+        return <CancelIcon sx={iconStyles} />;
+      case "success":
+        return <ErrorIcon sx={iconStyles} />;
+      case "warning":
+        return <CheckCircleIcon sx={iconStyles} />;
+    }
+  };
 
   // render component
   return (
@@ -177,10 +206,11 @@ export default function ModelButton({
         >
           <Background
             borderColor={isHover ? theme.palette.primary.main : borderColor}
-            backgroundColor={alpha(
-              theme.palette.primary.main,
-              isHover ? 0.04 : 0
-            )}
+            backgroundColor={
+              status !== "none"
+                ? alpha(backgroundColor, isHover ? 0.04 : 0.12)
+                : alpha(theme.palette.primary.main, isHover ? 0.04 : 0)
+            }
           />
           {icon
             ? React.cloneElement(icon, {
@@ -191,6 +221,7 @@ export default function ModelButton({
                     : theme.palette.common.white
               })
             : null}
+          {status !== "none" && getCurrentStatusIcon()}
         </IconButton>
         <Typography
           sx={{

--- a/src/ModelButton/ModelButton.tsx
+++ b/src/ModelButton/ModelButton.tsx
@@ -151,9 +151,9 @@ export default function ModelButton({
       case "error":
         return <CancelIcon data-testid="error-icon" sx={iconStyles} />;
       case "success":
-        return <ErrorIcon data-testid="success-icon" sx={iconStyles} />;
+        return <CheckCircleIcon data-testid="success-icon" sx={iconStyles} />;
       case "warning":
-        return <CheckCircleIcon data-testid="warning-icon" sx={iconStyles} />;
+        return <ErrorIcon data-testid="warning-icon" sx={iconStyles} />;
     }
   };
 

--- a/src/ModelButton/ModelButton.tsx
+++ b/src/ModelButton/ModelButton.tsx
@@ -343,8 +343,10 @@ const ModelButtonPopup = ({
         }}
         onClose={() => setPopperOpen(false)}
         open={popperOpen}
-        PaperProps={{
-          sx: { borderRadius: 2, padding: 2 }
+        slotProps={{
+          paper: {
+            sx: { borderRadius: 2, padding: 2 }
+          }
         }}
       >
         <Typography sx={{ fontSize: "14px", pb: 2 }}>{label}</Typography>

--- a/src/ModelButton/ModelButton.types.ts
+++ b/src/ModelButton/ModelButton.types.ts
@@ -1,3 +1,6 @@
+/**
+ * The props needed to define Background component
+ */
 type BackgroundProps = {
   /**
    * The color of the border
@@ -9,6 +12,9 @@ type BackgroundProps = {
   backgroundColor: string;
 };
 
+/**
+ * The props needed to define Model Button
+ */
 type ModelButtonProps = {
   /**
    * Children
@@ -39,15 +45,26 @@ type ModelButtonProps = {
   status?: "none" | "error" | "warning" | "success";
 };
 
+/**
+ * The props needed to define Model Button Popup
+ */
 type ModelButtonPopupProps = {
+  /**
+   * Current status
+   */
+  status: string;
   /**
    * Children
    */
   children?: React.ReactNode;
   /**
-   * The color of the button
+   * The color of the button border
    */
   color: string;
+  /**
+   * The color of the button border when hovered
+   */
+  colorHover: string;
   /**
    * If `true`, the button will be disabled. Default is `false`.
    */

--- a/src/ModelButton/ModelButton.types.ts
+++ b/src/ModelButton/ModelButton.types.ts
@@ -54,7 +54,7 @@ type ModelButtonPopupProps = {
   /**
    * Current status
    */
-  status: string;
+  status: ModelButtonProps["status"];
   /**
    * Children
    */

--- a/src/ModelButton/ModelButton.types.ts
+++ b/src/ModelButton/ModelButton.types.ts
@@ -1,3 +1,5 @@
+import { Theme } from "@mui/material";
+
 /**
  * The props needed to define Background component
  */
@@ -75,4 +77,27 @@ type ModelButtonPopupProps = {
   label: string;
 };
 
-export type { BackgroundProps, ModelButtonProps, ModelButtonPopupProps };
+/**
+ * The props needed to call getCurrentIconBackgroundColor function
+ */
+type CurrentIconBackgroundColorProps = {
+  /**
+   * Whether hover effect is available
+   */
+  isHover: boolean;
+  /**
+   * Status of the current ModelButton
+   */
+  status: ModelButtonProps["status"];
+  /**
+   * Theme refrence
+   */
+  theme: Theme;
+};
+
+export type {
+  BackgroundProps,
+  ModelButtonProps,
+  ModelButtonPopupProps,
+  CurrentIconBackgroundColorProps
+};


### PR DESCRIPTION
Closes [TD-3161](https://sce.myjetbrains.com/youtrack/issue/TD-3161/Edit-the-styles-of-ModelButton-in-React-UI)

## Changes

Updated ModelButton to show status icon on top right of the button. Borders and background color also updated to match the status colors defined in figma, with new hover behaviour as well. Popup button also has now outlined style, matching the colors and background from the ModelButton component.
The style of the component when no status is passed remains the same.

A brief description of what this pull request solves / introduces.

- Updated ModelButton with status icon and background + borders
- Updated ModelButtonPopup with status icon with background + borders
- Old styles for when button is disabled or no children are still the same

Here is the [ticket](https://github.com/IPG-Automotive-UK/virto/pull/1133), where these changes are visible in VIRTO FLEET and MODEL with pre-release.

## Dependencies

N/A

## UI/UX
Before
![image](https://github.com/user-attachments/assets/94760a63-8718-4576-9c45-d220d4d6f7f8)

After
![image](https://github.com/user-attachments/assets/9910c5c0-e5a1-46b4-95ce-5c6f52b83d74)
![image](https://github.com/user-attachments/assets/72c2164c-e792-42ae-b2ba-0e80502dea0e)
![image](https://github.com/user-attachments/assets/2924e61f-288f-4f2d-bfd0-a65e12a84bfb)
![image](https://github.com/user-attachments/assets/108f4e55-0951-4b83-b94d-2157ff012e4d)

[Figma prototype](https://www.figma.com/design/aFUbF9gTc2OfeLQnSf6BAF/VIRTO.BUILD?node-id=7574-26411&node-type=frame&t=DNhpHoaLpbedAS3p-0)

## Testing notes

The Model Button component should have the icon for the specific status in top right corner. The colors must match the colors from figma prototype above. The popup button should also match Model button border color and the checkmark inside.
Onhover effects, including background and and borders of the icons must match the onhover state in figma.
The border in ModelButtonPopup should be the same(2px) as in ModelButton.
When no status is passed to the component, there should not be icon in top right corner and changes of the colors(border or background).
The image inside of ModelButton should not be changed on hover and should stay black or white depending on the mode of the theme. When no status is passed then, we should be able to see the primary color changing  the white/black on hover.

## Author checklist

Before I request a review:

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[ ] I have populated the deploy-preview with relevant test data.~
- ~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~