### PR TITLE
TD-3243 Lazy loading ProjectCodeCard component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "9.0.0",
+  "version": "9.0.1-1",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/LazyLoadImage/LazyLoadImage.stories.tsx
+++ b/src/LazyLoadImage/LazyLoadImage.stories.tsx
@@ -143,32 +143,40 @@ const FlexSizeComponent: StoryFn<LazyLoadImageProps> = args => {
           width: "100%"
         }}
       >
-        <NoWrapTypography
-          variant="h5"
+        <Box>
+          <NoWrapTypography
+            variant="h5"
+            sx={{
+              fontWeight: 700
+            }}
+          >
+            {"Example project code"}
+          </NoWrapTypography>
+          <Typography color="text.secondary" variant="body2">
+            11 Prototype
+          </Typography>
+        </Box>
+        <Box
           sx={{
-            fontWeight: 700
+            height: "100%",
+            pt: 1
           }}
         >
-          {"Example project code"}
-        </NoWrapTypography>
-        <Typography color="text.secondary" variant="body2">
-          11 Prototype
-        </Typography>
-        <LazyLoadImage
-          src={"https://picsum.photos/336/197"}
-          alt={"Example project code"}
-          autoFitSkeleton={true}
-          ImgProps={{
-            style: {
-              display: "block",
-              margin: "auto",
-              maxHeight: "142px",
-              objectFit: "cover",
-              paddingTop: 1,
-              width: "100%"
-            }
-          }}
-        />
+          <LazyLoadImage
+            src={"https://picsum.photos/336/197"}
+            alt={"Example project code"}
+            autoFitSkeleton={true}
+            ImgProps={{
+              style: {
+                display: "block",
+                margin: "auto",
+                maxHeight: "142px",
+                objectFit: "cover",
+                width: "100%"
+              }
+            }}
+          />
+        </Box>
       </Box>
     </Grid>
   );

--- a/src/LazyLoadImage/LazyLoadImage.stories.tsx
+++ b/src/LazyLoadImage/LazyLoadImage.stories.tsx
@@ -1,7 +1,9 @@
+import { Box, Grid, Typography } from "@mui/material";
 import { Meta, StoryFn } from "@storybook/react";
 
 import LazyLoadImage from "./LazyLoadImage";
 import { LazyLoadImageProps } from "./LazyLoadImage.types";
+import NoWrapTypography from "../NoWrapTypography/NoWrapTypography";
 import React from "react";
 
 /**
@@ -108,6 +110,70 @@ const Template: StoryFn<LazyLoadImageProps> = args => {
   );
 };
 
+const FlexSizeComponent: StoryFn<LazyLoadImageProps> = args => {
+  return (
+    <Grid
+      key={"Example project code"}
+      sx={theme => ({
+        "&:active": {
+          border: `2px solid ${theme.palette.primary.main}`
+        },
+        "&:hover": {
+          borderColor: theme.palette.primary.main
+        },
+        "&:hover > div > h5": {
+          color: theme.palette.primary.main,
+          transition: "color 0.1s"
+        },
+        backgroundColor: theme.palette.background.paper,
+        border: `1px solid`,
+        borderRadius: "6px",
+        cursor: "pointer",
+        height: "238px",
+        transition: "border-color 0.3s"
+      })}
+      container
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          px: 3,
+          py: 2,
+          width: "100%"
+        }}
+      >
+        <NoWrapTypography
+          variant="h5"
+          sx={{
+            fontWeight: 700
+          }}
+        >
+          {"Example project code"}
+        </NoWrapTypography>
+        <Typography color="text.secondary" variant="body2">
+          11 Prototype
+        </Typography>
+        <LazyLoadImage
+          src={"https://picsum.photos/336/197"}
+          alt={"Example project code"}
+          autoFitSkeleton={true}
+          ImgProps={{
+            style: {
+              display: "block",
+              margin: "auto",
+              maxHeight: "142px",
+              objectFit: "cover",
+              paddingTop: 1,
+              width: "100%"
+            }
+          }}
+        />
+      </Box>
+    </Grid>
+  );
+};
+
 export const Default = {
   args: {
     ImgProps: {
@@ -122,4 +188,14 @@ export const Default = {
   },
 
   render: Template
+};
+
+export const SkeletonSizeAdjustingToBoundingBox = {
+  args: {
+    alt: "alternative text 1",
+    autoFitSkeleton: true,
+    src: "https://picsum.photos/336/197"
+  },
+
+  render: FlexSizeComponent
 };

--- a/src/LazyLoadImage/LazyLoadImage.tsx
+++ b/src/LazyLoadImage/LazyLoadImage.tsx
@@ -8,14 +8,16 @@ import { Skeleton } from "@mui/material";
 /**
  * Lazy load wrapper for HTML image brackets. Used for lazy loading images.
  * @param LazyLoadImgProps The input object of the component
- * @param LazyLoadImgProps.src string Source of the image
  * @param LazyLoadImgProps.alt string Alternative text for the image
+ * @param LazyLoadImgProps.autoFitSkeleton boolean Flag to enable the skeleton adjusting size to the bounding element. Default is false.
  * @param LazyLoadImgProps.ImgProps object ImgProps Any other prop of the <img> component
+ * @param LazyLoadImgProps.src string Source of the image
  */
 export default function LazyLoadImage({
-  src,
   alt,
-  ImgProps = {}
+  autoFitSkeleton = false,
+  ImgProps = {},
+  src
 }: LazyLoadImageProps) {
   // state to track if the image is visible
   const [isVisible, setIsVisible] = useState(false);
@@ -70,9 +72,10 @@ export default function LazyLoadImage({
         <Skeleton
           sx={{
             borderRadius: 0,
-            height: dimensions.height,
+            display: "block",
+            height: autoFitSkeleton ? "100%" : dimensions.height,
             transform: "none",
-            width: dimensions.width
+            width: autoFitSkeleton ? "100%" : dimensions.width
           }}
         />
       ) : null}

--- a/src/LazyLoadImage/LazyLoadImage.types.ts
+++ b/src/LazyLoadImage/LazyLoadImage.types.ts
@@ -5,15 +5,19 @@ import React from "react";
  */
 export type LazyLoadImageProps = {
   /**
-   * Source of the image
-   */
-  src: string;
-  /**
    * Alternative text for the image
    */
   alt: string;
   /**
+   * Flag to enable the skeleton adjusting size to the bounding element. Default is false.
+   */
+  autoFitSkeleton?: boolean;
+  /**
    * Any other prop of the <img> component
    */
   ImgProps?: Omit<React.ComponentProps<"img">, "src" | "alt">;
+  /**
+   * Source of the image
+   */
+  src: string;
 };


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Contributes to [TD-3243](https://sce.myjetbrains.com/youtrack/issue/TD-3243/Lazy-Loading-ProjectCodeCard-component)

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

- The `LazyLoadImage` was initially only used in static sized images. However, the ProjectCodeCard component showed that a dynamic sized component causes issues for the skeleton which is showed while the image loads. If the component changed size, the skeleton stayed the old size
- adds the new optional `autoFitSkeleton` prop to the LazyLoadImage to address this issue, default set to false
- when `autoFitSkeleton` is set to true, the skeleton will fill the available space in the bounding element. When it is false, the skeleton uses static size
- created a new storybook element where the `LazyLoadImage` is used inside a dynamically sized element

## Dependencies

<!-- Does this branch need to be tested alongside branches from other apps? -->
<!-- Does this branch need to be merged after another Pull Request? -->

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

You can use the new storybook element to test the new prop on this [link](https://666c1309face6e7c27f20e04-dbxwvdzezm.chromatic.com/?path=/docs/general-lazyloadimage--docs#skeleton%20size%20adjusting%20to%20bounding%20box).

But I recommend testing it in the Virto PR using it: https://github.com/IPG-Automotive-UK/virto/pull/1181

Test steps for storybook:
- throttle the network speed in the browser's network tab and disable cache to be able to see the loading skeleton
- navigate to the new storybook element with dynamic size. [Link](https://666c1309face6e7c27f20e04-dbxwvdzezm.chromatic.com/?path=/docs/general-lazyloadimage--docs#skeleton%20size%20adjusting%20to%20bounding%20box)
- while the image is loading, a loading skeleton will be shown. While this is ongoing, change the size of the component by changing the window size. The skeleton should automatically adjust its size.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
~~- [ ] I have included appropriate tests.~~ -> we don't use tests for this specific component, because soon the end-to-end tests will be migrated to cypress, it will be done then for this one
- [x] I have checked that the Lint and Test workflows pass on Github.
~~- [ ] I have populated the deploy-preview with relevant test data.~~
~~- [ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~~ -> I tagged her on the related Virto PR
