### PR TITLE
TD-3264 Unable to navigate cards via tab button

### DIFF
--- a/src/Filter/SetFilterButton/SetFilterButton.tsx
+++ b/src/Filter/SetFilterButton/SetFilterButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography } from "@mui/material";
+import { Button, Typography, alpha } from "@mui/material";
 
 import { FilterList } from "@mui/icons-material";
 import React from "react";
@@ -20,7 +20,12 @@ export function SetFilterButton({
   return (
     <Button
       data-testid="filter-open-button"
-      sx={{ width: "fit-content" }}
+      sx={theme => ({
+        "&:focus-visible": {
+          border: `1px solid ${alpha(theme.palette.text.primary, 0.23)}`
+        },
+        width: "fit-content"
+      })}
       disableRipple
       onClick={onClick}
     >


### PR DESCRIPTION
Contributes [TD-3264](https://sce.myjetbrains.com/youtrack/issue/TD-3264)

## Changes

Added focus-visible pseudo class for the SelectFilterButton when targeting elements on the screen with tab button.
Currently in VIRTO the SidebarFilter can be accessed with tab, but doesn't show that it is targeted. This is the purpose of this PR. When Filter button is targeted it should appear with border.

A brief description of what this pull request solves / introduces.

- Border color for tab selection of Select Filter Button

Maybe a short description of what is not included and will come in future work where appropriate.

## Dependencies

N/A

## UI/UX
Before
![image](https://github.com/user-attachments/assets/ae00b9b4-5d0d-4019-9da3-cfb98dbe30d9)

After
![image](https://github.com/user-attachments/assets/c4d067c8-ddce-4964-9fe1-017990e5a2e8)
## Testing notes

- Click somewhere on the screen and start pressing Tab button on keyboard.
- When Filter button is selected via tab, it must appear with Gray border around.
- When enter is clicked it should open the Filters Menu.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- ~[ ] I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~[ ] I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[ ] I have populated the deploy-preview with relevant test data.~
- ~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~