### PR TITLE
TD-3264 Fix for tab focus jumping border

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "9.0.2",
+  "version": "9.0.3-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/Filter/SetFilterButton/SetFilterButton.tsx
+++ b/src/Filter/SetFilterButton/SetFilterButton.tsx
@@ -22,7 +22,7 @@ export function SetFilterButton({
       data-testid="filter-open-button"
       sx={theme => ({
         "&:focus-visible": {
-          border: `1px solid ${alpha(theme.palette.text.primary, 0.23)}`
+          outline: `1px solid ${alpha(theme.palette.text.primary, 0.23)}`
         },
         width: "fit-content"
       })}


### PR DESCRIPTION
Closes [TD-3264](https://sce.myjetbrains.com/youtrack/issue/TD-3264/Unable-to-navigate-cards-via-tab-key-when-grouped-by-project-code-Model-Year)

[Here the bug is linked
](https://github.com/IPG-Automotive-UK/virto/pull/1213#issuecomment-2511323751)
## Changes

Changed "border" property for focus-active pseudo class to "outline", so this will prevent border to jump and move other elements, for example the grid elements in Project code cards and Model year cards in prototypes index.

A brief description of what this pull request solves / introduces.

- Fix for jumping border of Filter button for SidebarFilter component


## Dependencies

N/A

## UI/UX
Before video:
[before-border-jumping.zip](https://github.com/user-attachments/files/17978320/before-border-jumping.zip)

After video:
[after-border-not-jumping.zip](https://github.com/user-attachments/files/17978323/after-border-not-jumping.zip)

## Testing notes

Navigate to SidebarFilter in storybook and click with the mouse outside of the component, example:
![image](https://github.com/user-attachments/assets/00cd5da9-85ec-45bc-9069-eafae24a9ea6)
Then Start navigating through the elements with tab button and after focused, the "Filter" button must not make the borders of the box jump up and down when focus is moved out of the Filter button.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- ~[ ] I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~[ ] I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[ ] I have populated the deploy-preview with relevant test data.~
- [x] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
