### PR TITLE
TD-3265 Do not ship sourcecode (.ts, .tsx)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
           cache: "pnpm"
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
+      - name: Test build
+        run: pnpm run build
       - name: Run tests
         run: pnpm run test:docker
       - name: "Report coverage"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "pnpm run clean && pnpm run copy-files && tsc --project ./tsconfig.production.json",
     "clean": "rimraf dist",
-    "copy-files": "copyfiles -e '**/*.test.**' -e '**/*.spec.**' -e '**/*.stories.**' -u 1 src/**/*.html src/**/*.css src/**/*.ts src/**/*.tsx src/**/*/*.svg dist/",
+    "copy-files": "copyfiles -e '**/*.test.**' -e '**/*.spec.**' -e '**/*.stories.**' -u 1 src/**/*.html src/**/*.css src/**/*/*.svg dist/",
     "prepublishOnly": "pnpm run build",
     "start": "microbundle-crl watch --no-compress --format modern,cjs --jsxFragment React.Fragment",
     "storybook": "storybook dev -p 6006",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "9.0.3",
+  "version": "9.0.4-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"


### PR DESCRIPTION
Contributes to [TD-3265](https://sce.myjetbrains.com/youtrack/issue/TD-3265/Plotly-incorrect-font)

## Changes

Until now we have shipped source code (.ts and .tsx) files as part of the build. We can't really remember why we did this because we also ship js code and .d.ts type decleration files generated by `tsc` which is all that should be needed. The result of shipping this source code is that running type-checks in consuming applications that set `skipLibCheck=true` also type checks raw typescript files in node_modules (but correctly skips .d.ts). This led to a number of false positives in the type-checking e.g. VIRTO.ID failing type-checks due to Plotly components that it does not use. This was fixed for example by installing type dependencies that the application itself did not need (but RUI did).

This PR removes the .ts and .tsx files from the build output. When integrated into VIRTO (see https://github.com/IPG-Automotive-UK/virto/pull/1219) we maintain application functionality, but are able to remove these extra unneeded dependencies and still pass type-checks.

## Testing notes

- Check that you can run `pnpm build`.
- Check that type-checks pass on all VIRTO apps that use RUI and the v9.0.4-0 pre-release. You can see this existing VIRTO PR https://github.com/IPG-Automotive-UK/virto/pull/1219 where this has been done.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~I have populated the deploy-preview with relevant test data.~
- ~I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
