### PR TITLE
TD-3355 - Fixes Clear button on Variant select when deselecting

### DIFF
--- a/src/VehicleSelector/VehicleSelector.test.tsx
+++ b/src/VehicleSelector/VehicleSelector.test.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Vehicle, VehicleSelectorProps } from "./VehicleSelector.types";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import VehicleSelector from "./VehicleSelector";
 
@@ -255,28 +255,44 @@ describe("VehicleSelector", () => {
       />
     );
 
-    // check the variant is initially selected
     expect(screen.getByRole("combobox", { name: /variant/i })).toHaveValue(
       "NN"
     );
 
-    // find and click the clear button
     const variantField = screen.getByRole("combobox", { name: /variant/i });
     const clearButton = variantField.parentElement?.querySelector(
       '[aria-label="Clear"]'
     );
 
     expect(clearButton).toBeInTheDocument();
-    clearButton?.click();
+    (clearButton as HTMLElement)?.click();
 
-    // wait until the clear button disappears
     await waitFor(() =>
       expect(
         variantField.parentElement?.querySelector('[aria-label="Clear"]')
       ).not.toBeInTheDocument()
     );
 
-    // Ensure the variant field is empty
     expect(variantField).toHaveValue("");
+  });
+
+  it("filters model years based on selected project", async () => {
+    render(<VehicleSelectorWithState {...defaultProps} />);
+
+    const projectInput = screen.getByRole("combobox", {
+      name: /project code/i
+    });
+    fireEvent.mouseDown(projectInput);
+    fireEvent.click(screen.getByText("911"));
+
+    const modelYearInput = screen.getByRole("combobox", {
+      name: /model year/i
+    });
+    fireEvent.mouseDown(modelYearInput);
+
+    await waitFor(() => {
+      expect(screen.getByText("2015")).toBeInTheDocument();
+      expect(screen.getByText("2016")).toBeInTheDocument();
+    });
   });
 });

--- a/src/VehicleSelector/VehicleSelector.test.tsx
+++ b/src/VehicleSelector/VehicleSelector.test.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Vehicle, VehicleSelectorProps } from "./VehicleSelector.types";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 
 import VehicleSelector from "./VehicleSelector";
 
@@ -234,5 +234,49 @@ describe("VehicleSelector", () => {
     ).toBeDisabled();
     expect(screen.getByRole("combobox", { name: /variant/i })).toBeDisabled();
     expect(screen.getByRole("combobox", { name: /gate/i })).toBeDisabled();
+  });
+
+  it("removes clear button when variant is deselected in single selection mode", async () => {
+    const value = [
+      {
+        _id: "64c8c4cccc8d6f00130b366b",
+        gate: "Gate 1",
+        modelYear: "2015",
+        projectCode: "911",
+        variant: "NN"
+      }
+    ];
+
+    render(
+      <VehicleSelectorWithState
+        {...defaultProps}
+        value={value}
+        multipleSelection={false}
+      />
+    );
+
+    // check the variant is initially selected
+    expect(screen.getByRole("combobox", { name: /variant/i })).toHaveValue(
+      "NN"
+    );
+
+    // find and click the clear button
+    const variantField = screen.getByRole("combobox", { name: /variant/i });
+    const clearButton = variantField.parentElement?.querySelector(
+      '[aria-label="Clear"]'
+    );
+
+    expect(clearButton).toBeInTheDocument();
+    clearButton?.click();
+
+    // wait until the clear button disappears
+    await waitFor(() =>
+      expect(
+        variantField.parentElement?.querySelector('[aria-label="Clear"]')
+      ).not.toBeInTheDocument()
+    );
+
+    // Ensure the variant field is empty
+    expect(variantField).toHaveValue("");
   });
 });

--- a/src/VehicleSelector/VehicleSelector.tsx
+++ b/src/VehicleSelector/VehicleSelector.tsx
@@ -223,7 +223,10 @@ function VehicleSelector({
             }
           }}
           size={size}
-          value={selectedVariants}
+          // if array is empty set to null to avoid rendereing the clear button
+          value={
+            multipleSelection ? selectedVariants : selectedVariants[0] || null
+          }
         />
       </Box>
 

--- a/src/VehicleSelector/VehicleSelector.tsx
+++ b/src/VehicleSelector/VehicleSelector.tsx
@@ -223,7 +223,7 @@ function VehicleSelector({
             }
           }}
           size={size}
-          // if array is empty set to null to avoid rendereing the clear button
+          // if array is empty, set value to null to avoid rendering the clear button
           value={
             multipleSelection ? selectedVariants : selectedVariants[0] || null
           }


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Close [TD-3355](https://sce.myjetbrains.com/youtrack/issue/TD-3355/Clear-Button-Remains-Visible-in-Variant-Autocomplete-After-Clearing-Selection-RUI)

## Changes
Removes the X close button when the variant select is cleared, it was only happening on the variant select
Adding UX @Sowbhagya-ipg 

## Dependencies
n/a

## UI/UX
before
![image](https://github.com/user-attachments/assets/9b8b6047-78c3-49ae-8588-7d65f94ca057)

After
![image](https://github.com/user-attachments/assets/0ce6869c-a277-42fd-b61b-abe5155f6b19)


## Testing notes


## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
~~- [ ] I have tested the changes in Docker / a deploy-preview.~~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
~~- [ ] I have included appropriate tests.~~
- [x] I have checked that the Lint and Test workflows pass on Github.
~~- [ ] I have populated the deploy-preview with relevant test data.~~
- [x] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
