### PR TITLE
TD-3359 TransferList update to have combined search and check functionality

### DIFF
--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -49,13 +49,15 @@ describe("TransferList", () => {
       />
     );
 
-    // test the source list heading and subheading
+    // test the source list heading
     expect(screen.getByText("Source List Label"));
-    expect(screen.getByText("0/3 selected"));
 
-    // test the target list heading and subheading
+    // test the target list heading
     expect(screen.getByText("Target List Label"));
-    expect(screen.getByText("0/0 selected"));
+
+    // test the subheadings under the two headings
+    const zeroSelectedHeadings = screen.getAllByText("0 selected");
+    expect(zeroSelectedHeadings.length).toBe(2);
   });
 
   test("transfer buttons are disabled by default", () => {
@@ -181,8 +183,9 @@ describe("TransferList", () => {
     expect(sourceItems[0].textContent).toBe("PearsConference");
     expect(sourceItems[1].textContent).toBe("Oranges");
 
-    // test selected items heading remains the same
-    expect(screen.getByText("0/2 selected"));
+    // test selected items heading remains the same and both headings for source and target are present
+    const zeroSelectedHeadings = screen.getAllByText("0 selected");
+    expect(zeroSelectedHeadings.length).toBe(2);
 
     // get target list
     const targetList = screen.getByLabelText("Target List Label");
@@ -191,7 +194,6 @@ describe("TransferList", () => {
 
     // test existence of target list items
     expect(targetItems[0].textContent).toBe("Apples");
-    expect(screen.getByText("0/1 selected"));
   });
 
   test("clicked items toggle correctly, enable the relevant transfer button and update the heading", async () => {
@@ -235,7 +237,7 @@ describe("TransferList", () => {
     );
 
     // test subheading is correct
-    expect(screen.getByText("2/3 selected"));
+    expect(screen.getByText("2 selected"));
 
     // click first two items in list for a second time
     await user.click(items[0]);
@@ -255,8 +257,9 @@ describe("TransferList", () => {
       false
     );
 
-    // test subheading is correct
-    expect(screen.getByText("0/3 selected"));
+    // test selected items heading are both the same for source and target with all items unselected
+    const zeroSelectedHeadings = screen.getAllByText("0 selected");
+    expect(zeroSelectedHeadings.length).toBe(2);
   });
 
   test("if uncontrolled, checked items transfer from source to target list and uncheck", async () => {
@@ -745,5 +748,63 @@ describe("TransferList", () => {
 
     // check the callback data
     expect(transferFn).toHaveBeenCalledWith(["Apples", "Pears", "Oranges"]);
+  });
+
+  test("search for an item, check it, clear search, and verify selection", async () => {
+    // render component
+    const user = userEvent.setup();
+
+    render(
+      <TransferList
+        items={defaultItemArray}
+        sourceListLabel="Source List Label"
+        targetListLabel="Target List Label"
+      />
+    );
+
+    // get search input
+    const searchInput = screen.getByLabelText("Search");
+
+    // search for "Pears"
+    await user.type(searchInput, "Pears");
+
+    // get filtered list
+    const sourceList = screen.getByLabelText("Source List Label");
+
+    // find the list item that contains "Pears"
+    const pearsItem = within(sourceList)
+      .getAllByRole("listitem")
+      .find(item => within(item).queryByText("Pears"));
+
+    if (pearsItem) {
+      // get the checkbox
+      const pearsCheckbox = within(pearsItem).getByRole("checkbox");
+
+      // check "Pears"
+      await user.click(pearsCheckbox);
+      expect(pearsCheckbox).toHaveProperty("checked", true);
+    }
+
+    // clear search
+    const clearButton = screen.getByLabelText("clear search");
+    await user.click(clearButton);
+
+    // get all items in source list after clearing search
+    const allItems = within(sourceList).getAllByRole("listitem");
+
+    // verify only "Pears" remains checked
+    allItems.forEach(item => {
+      // get the checkboxes
+      const checkbox = within(item).getByRole("checkbox");
+
+      // check for the item text content
+      if (item?.textContent?.includes("Pears")) {
+        // if the text is "Pears" the checkbox should be checked
+        expect(checkbox).toHaveProperty("checked", true);
+      } else {
+        // if the text is not "Pears" the checkbox should be false
+        expect(checkbox).toHaveProperty("checked", false);
+      }
+    });
   });
 });

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -8,12 +8,13 @@ import {
   Typography
 } from "@mui/material";
 import React, { useLayoutEffect, useState } from "react";
-import SearchBar, { SearchBarProps } from "../SearchBar";
 import {
   SingleListProps,
   TransferListItem,
   TransferListProps
 } from "./TransferList.types";
+
+import SearchBar from "../SearchBar";
 
 export default function TransferList({
   defaultSelectedItems,
@@ -96,10 +97,6 @@ export default function TransferList({
   // All checked source list items
   const sourceItemsToTransfer = checked.filter(item => !keys.includes(item));
 
-  // Boolean to indicate if all items are checked
-  const allSourceItemsChecked =
-    allSourceItems.length === sourceItemsToTransfer.length;
-
   /**
    * Target list logic
    */
@@ -115,44 +112,52 @@ export default function TransferList({
   // All checked target list items
   const targetItemsToTransfer = checked.filter(item => keys.includes(item));
 
-  // Boolean to indicate if all target items are checked
-  const allTargetItemsChecked =
-    allTargetItems.length === targetItemsToTransfer.length;
-
   /**
    * Handle check all items in the source list
    */
   const handleCheckAllSource = () => {
-    // If all source items are checked, uncheck them
-    // Otherwise, check all source items
-    allSourceItemsChecked
-      ? setChecked(
-          checked.filter(item => !sourceItemsToTransfer.includes(item))
-        )
-      : setChecked([
-          ...checked.filter(item => !sourceItemsToTransfer.includes(item)),
-          ...items
-            .map(item => filterKey(item))
-            .filter(item => !keys.includes(item))
-        ]);
+    // Get the items depending on if there is a search
+    const sourceItemsToCheck = sourceFilter
+      ? filteredSourceItems
+      : allSourceItems;
+
+    // Get the items keys
+    const sourceItemKeys = sourceItemsToCheck.map(item => filterKey(item));
+
+    if (sourceItemKeys.every(item => checked.includes(item))) {
+      // If all filtered items are checked, uncheck only those
+      setChecked(checked.filter(item => !sourceItemKeys.includes(item)));
+    } else {
+      // Otherwise, check all filtered items
+      setChecked([
+        ...checked,
+        ...sourceItemKeys.filter(item => !checked.includes(item))
+      ]);
+    }
   };
 
   /**
    * Handle check all items in the target list
    */
   const handleCheckAllTarget = () => {
-    // If all target items are checked, uncheck them
-    // Otherwise, check all target items
-    allTargetItemsChecked
-      ? setChecked(
-          checked.filter(item => !targetItemsToTransfer.includes(item))
-        )
-      : setChecked([
-          ...checked.filter(item => !targetItemsToTransfer.includes(item)),
-          ...items
-            .map(item => filterKey(item))
-            .filter(item => keys.includes(item))
-        ]);
+    // Get the items depending on if there is a search
+    const targetItemsToCheck = targetFilter
+      ? filteredTargetItems
+      : allTargetItems;
+
+    // Get the items keys
+    const targetItemKeys = targetItemsToCheck.map(item => filterKey(item));
+
+    if (targetItemKeys.every(item => checked.includes(item))) {
+      // If all filtered items are checked, uncheck only those
+      setChecked(checked.filter(item => !targetItemKeys.includes(item)));
+    } else {
+      // Otherwise, check all filtered items
+      setChecked([
+        ...checked,
+        ...targetItemKeys.filter(item => !checked.includes(item))
+      ]);
+    }
   };
 
   /**
@@ -186,6 +191,12 @@ export default function TransferList({
     // Get checked source items
     const checkedSourceItems = checked.filter(item => !keys.includes(item));
 
+    // Remove the source search string on transfer
+    setSourceFilter("");
+
+    // Remove the target search string on transfer
+    setTargetFilter("");
+
     // Updated target list keys
     const updatedTargetList = [...keys, ...checkedSourceItems];
 
@@ -215,6 +226,12 @@ export default function TransferList({
     const newTargetSelection = keys.filter(
       item => !targetItemsToTransfer.includes(item)
     );
+
+    // Remove the source search string on transfer
+    setSourceFilter("");
+
+    // Remove the target search string on transfer
+    setTargetFilter("");
 
     // Get the items that have been transferred
     const updatedSelectedItems = getTransferredItems(items, newTargetSelection);
@@ -307,13 +324,13 @@ export default function TransferList({
             <Typography
               variant="body2"
               sx={{ color: "text.secondary" }}
-            >{`${sourceItemsToTransfer.length}/${allSourceItems.length} selected`}</Typography>
+            >{`${sourceItemsToTransfer.length} selected`}</Typography>
           </Box>
         </Box>
 
         {allSourceItems.length > 0 ? (
           <Box sx={{ px: 3 }}>
-            <Search onChange={setSourceFilter} />
+            <Search value={sourceFilter} onChange={setSourceFilter} />
           </Box>
         ) : null}
 
@@ -415,13 +432,13 @@ export default function TransferList({
             <Typography
               variant="body2"
               sx={{ color: "text.secondary" }}
-            >{`${targetItemsToTransfer.length}/${allTargetItems.length} selected`}</Typography>
+            >{`${targetItemsToTransfer.length} selected`}</Typography>
           </Box>
         </Box>
 
         {allTargetItems.length > 0 ? (
           <Box sx={{ px: 3 }}>
-            <Search onChange={setTargetFilter} />
+            <Search value={targetFilter} onChange={setTargetFilter} />
           </Box>
         ) : null}
 
@@ -454,27 +471,17 @@ export default function TransferList({
 /**
  * Search bar for the transfer list
  */
-const Search = ({ onChange }: { onChange: (value: string) => void }) => {
-  const [search, setSearch] = useState("");
-
-  // handle change
-  const handleChange: SearchBarProps["onChange"] = event => {
-    setSearch(event.target.value);
-    onChange(event.target.value);
-  };
-
-  return (
-    <Box
-      sx={{
-        alignItems: "center",
-        display: "flex",
-        width: "100%"
-      }}
-    >
-      <SearchBar value={search} onChange={handleChange} />
-    </Box>
-  );
-};
+const Search = ({
+  value,
+  onChange
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) => (
+  <Box sx={{ alignItems: "center", display: "flex", width: "100%" }}>
+    <SearchBar value={value} onChange={e => onChange(e.target.value)} />
+  </Box>
+);
 
 /**
  * Single list component for the transfer list


### PR DESCRIPTION

Closes: [TD-3359](https://sce.myjetbrains.com/youtrack/issue/TD-3359)
Contributes to: [TD-3333](https://sce.myjetbrains.com/youtrack/issue/TD-3333)

## Changes
- Updated the handle check all logic for both the source and the target
- Updated the Search component in order to clear the state of the "SearchBox" on transfer
- Added one more test for the combined logic of the search and check functionality

## Dependencies
N/A

## UI/UX

Before:
![image](https://github.com/user-attachments/assets/b2e988cd-c360-4e4d-b883-27fc31ccd6ac)

After:
![image](https://github.com/user-attachments/assets/9c2ec555-226b-4e64-b96e-c72390c5bace)


## Testing notes
In the TransferList component:
- Check when we have search parameter if the check all checks only the searched values.
- Check when we have a seacrh parameter and we check only the searched values and then delete the search if the only checked items are the previously searched once.

## Author checklist

Before I request a review:

- [x] I have reviewed my own code-diff.
- [ ] ~I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [ ] I have checked that the Lint and Test workflows pass on Github.
- [ ] ~I have populated the deploy-preview with relevant test data.~
- [ ] ~I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
