### PR TITLE
Add NoWrapTypography back into exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,10 @@ export {
   type UserAvatarProps
 } from "./UserAvatar";
 export {
+  default as NoWrapTypography,
+  type NoWrapTypographyProps
+} from "./NoWrapTypography";
+export {
   default as ModelButtonImage,
   type ModelButtonImageProps
 } from "./ModelButtonImage";


### PR DESCRIPTION
A brief description of what this pull request solves / introduces.

- Add the export back for NoWrapTypography that was removed

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~[x] I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[x] I have populated the deploy-preview with relevant test data.~
- [x] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
