### PR TITLE
TD-3383 Add disable functionality to the cancel button of the ActionDialog

### DIFF
--- a/src/ActionDialog/ActionDialog.stories.tsx
+++ b/src/ActionDialog/ActionDialog.stories.tsx
@@ -70,3 +70,40 @@ export const Default = {
   },
   render: Template
 };
+
+// cancel button and close icon disabled
+export const CancelDisabled = {
+  args: {
+    ...Default.args,
+    cancelDisabled: true
+  },
+  render: Template
+};
+
+// save button disabled
+export const SaveDisabled = {
+  args: {
+    ...Default.args,
+    saveDisabled: true
+  },
+  render: Template
+};
+
+// Both buttons disabled
+export const BothButtonsDisabled = {
+  args: {
+    ...Default.args,
+    cancelDisabled: true,
+    saveDisabled: true
+  },
+  render: Template
+};
+
+// dialog without close icon
+export const NoCloseIcon = {
+  args: {
+    ...Default.args,
+    showCloseIcon: false
+  },
+  render: Template
+};

--- a/src/ActionDialog/ActionDialog.stories.tsx
+++ b/src/ActionDialog/ActionDialog.stories.tsx
@@ -57,6 +57,7 @@ const Template: StoryFn<ActionDialogProps> = args => {
 
 export const Default = {
   args: {
+    cancelDisabled: false,
     cancelText: "cancel",
     content: <Typography>Content goes here</Typography>,
     onCancelClick: () => {},

--- a/src/ActionDialog/ActionDialog.test.tsx
+++ b/src/ActionDialog/ActionDialog.test.tsx
@@ -47,6 +47,12 @@ describe("ActionDialog", () => {
     render(<ActionDialog {...defaultInputs} open={true} saveDisabled={true} />);
     expect(screen.getByText("Save")).toBeDisabled();
   });
+  test("test dialog cancel button disabled", () => {
+    render(
+      <ActionDialog {...defaultInputs} open={true} cancelDisabled={true} />
+    );
+    expect(screen.getByText("cancel")).toBeDisabled();
+  });
   test("test dialog save button enabled", () => {
     render(
       <ActionDialog {...defaultInputs} open={true} saveDisabled={false} />

--- a/src/ActionDialog/ActionDialog.test.tsx
+++ b/src/ActionDialog/ActionDialog.test.tsx
@@ -43,15 +43,27 @@ describe("ActionDialog", () => {
     render(<ActionDialog {...defaultInputs} open={true} saveText="Save" />);
     expect(screen.getByText("Save")).toBeInTheDocument();
   });
-  test("test dialog save button disabled", () => {
-    render(<ActionDialog {...defaultInputs} open={true} saveDisabled={true} />);
-    expect(screen.getByText("Save")).toBeDisabled();
-  });
   test("test dialog cancel button disabled", () => {
     render(
       <ActionDialog {...defaultInputs} open={true} cancelDisabled={true} />
     );
+    const closeIcon = screen.getByTestId("close-icon");
+    expect(closeIcon).toBeInTheDocument();
+    expect(closeIcon).toBeDisabled();
     expect(screen.getByText("cancel")).toBeDisabled();
+  });
+  test("test dialog save button disabled", () => {
+    render(<ActionDialog {...defaultInputs} open={true} saveDisabled={true} />);
+    expect(screen.getByText("Save")).toBeDisabled();
+  });
+  test("test dialog cancel button enabled", () => {
+    render(
+      <ActionDialog {...defaultInputs} open={true} cancelDisabled={false} />
+    );
+    const closeIcon = screen.getByTestId("close-icon");
+    expect(closeIcon).toBeInTheDocument();
+    expect(closeIcon).toBeEnabled();
+    expect(screen.getByText("cancel")).toBeEnabled();
   });
   test("test dialog save button enabled", () => {
     render(

--- a/src/ActionDialog/ActionDialog.tsx
+++ b/src/ActionDialog/ActionDialog.tsx
@@ -58,6 +58,7 @@ export default function ActionDialog({
               right: 8,
               top: 8
             }}
+            disabled={cancelDisabled}
           >
             <CloseIcon />
           </IconButton>

--- a/src/ActionDialog/ActionDialog.tsx
+++ b/src/ActionDialog/ActionDialog.tsx
@@ -20,6 +20,7 @@ export default function ActionDialog({
   onCancelClick,
   onSaveClick,
   title = "Some title",
+  cancelDisabled = false,
   cancelText = "cancel",
   saveText = "Save",
   open = true,
@@ -66,7 +67,9 @@ export default function ActionDialog({
         <Stack spacing={3}>{content}</Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancelClick}>{cancelText}</Button>
+        <Button onClick={onCancelClick} disabled={cancelDisabled}>
+          {cancelText}
+        </Button>
         <Button
           variant="contained"
           onClick={onSaveClick}

--- a/src/ActionDialog/ActionDialog.types.ts
+++ b/src/ActionDialog/ActionDialog.types.ts
@@ -1,5 +1,9 @@
 export type ActionDialogProps = {
   /**
+   * If true, cancel button will be disabled.
+   */
+  cancelDisabled?: boolean;
+  /**
    * The text of the cancel button.
    * */
   cancelText?: string;


### PR DESCRIPTION

Closes: [TD-3383](https://sce.myjetbrains.com/youtrack/issue/TD-3383)
Contributes to: [TD-3369](https://sce.myjetbrains.com/youtrack/issue/TD-3369)

## Changes

 - Added disable property to the ActionDialog cancel button
 - Added test for the cancel button disabling
 - Added the property to the types and storybook

## Dependencies
N/A

## UI/UX

before:
![image](https://github.com/user-attachments/assets/61ff0a86-e984-4bdb-b3e3-b5191bf959c9)

after:
![image](https://github.com/user-attachments/assets/1bf0117e-f281-4727-b920-bdba757b433e)


## Testing notes

Check if the ActionDialog have disable for the cancel button - "cancelDisabled"
 property
## Author checklist

Before I request a review:

- [x] I have reviewed my own code-diff.
- [ ] ~I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- [ ] ~I have populated the deploy-preview with relevant test data.~
- [x] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
