### PR TITLE
Allow installing via git

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "11.1.0",
+  "version": "11.2.0-1",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:esm": "tsc --project ./tsconfig.esm.json",
     "clean": "rimraf dist",
     "copy-files": "copyfiles -e '**/*.test.**' -e '**/*.spec.**' -e '**/*.stories.**' -u 1 src/**/*.html src/**/*.css src/**/*/*.svg dist/esm/ && copyfiles -e '**/*.test.**' -e '**/*.spec.**' -e '**/*.stories.**' -u 1 src/**/*.html src/**/*.css src/**/*/*.svg dist/cjs/",
-    "prepublishOnly": "pnpm run build",
+    "prepare": "node -e \"if (require('fs').existsSync('src')) { require('child_process').execSync('pnpm run build', { stdio: 'inherit' }); }\"",
     "start": "microbundle-crl watch --no-compress --format modern,cjs --jsxFragment React.Fragment",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",


### PR DESCRIPTION
## Changes

This change removes the need for pre-releases of `@ipguk/react-ui` instead allowing developers to install this dependency via git for testing. This matches the "pre-release" behaviour of some of our other dependencies e.g. `virto-utils`.

e.g.
`pnpm i github:IPG-Automotive-UK/react-ui#9688c62ab1c50dc7664c131ccf5292b216ff218b`

where the identifier after the `#` can be any git identifier (commit sha, branch name, git tag). We would always recommend installing a specific commit sha.

## Testing notes

We're supporting two cases here:
- A developer installs a pre-release via git to test unpublished functionality.
- A developer installs a full-release via npm to integrate tested published functionality.

You can test installing via the commit hash in a VIRTO application. I tested in the remix-starter template but any application is good. This is the process we would use for testing "pre-releases" in VIRTO.
`pnpm i github:IPG-Automotive-UK/react-ui#9688c62ab1c50dc7664c131ccf5292b216ff218b`

You can also test installing via npm. I published a pre-release to npm. This tests the behaviour if installing a published release.
`pnpm i @ipguk/react-ui@11.2.0-1`

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~I have populated the deploy-preview with relevant test data.~
- ~I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
