### PR TITLE
VE-334 modeStorageKey name from "mui-theme" to "theme"

### DIFF
--- a/src/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/ThemeProvider/ThemeProvider.test.tsx
@@ -71,7 +71,7 @@ describe("ThemeProvider", () => {
   );
   test.each(["light", "dark"])("renders %s theme from local storage", mode => {
     // set the theme in local storage
-    window.localStorage.setItem("mui-mode", mode);
+    window.localStorage.setItem("theme", mode);
 
     // render the component
     render(
@@ -89,10 +89,7 @@ describe("ThemeProvider", () => {
     "renders %s theme when theme toggled",
     async mode => {
       // first set the theme to the opposite of the mode we want to test
-      window.localStorage.setItem(
-        "mui-mode",
-        mode === "light" ? "dark" : "light"
-      );
+      window.localStorage.setItem("theme", mode === "light" ? "dark" : "light");
 
       // render the toggle button
       render(

--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -252,7 +252,7 @@ export default function ThemeProvider({
 }: ThemeProviderProps) {
   // wrap mui theme provider and children in theme context
   return (
-    <MuiThemeProvider theme={theme} defaultMode="light">
+    <MuiThemeProvider theme={theme} defaultMode="light" modeStorageKey="theme">
       <ControlledThemeWrapper theme={controlledTheme}>
         {children}
       </ControlledThemeWrapper>


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Contributes [VE-334](https://sce.myjetbrains.com/youtrack/issue/VE-334/VIRTO-apps-and-Docs-theme-mode-not-in-sync)

## Changes

This PR is to fix the `modeStorageKey` key default from `mui-mode` to `theme` to fix syncing issue of VIRTO apps mode. Docusaurus was basically looking to update the `theme` key in the localStorage but in VIRTO apps this was set to `mui-mode`.

## UI/UX

On QA
![27](https://github.com/user-attachments/assets/fa421261-fd88-47fe-a51b-547be6064c58)


with changes from this branch
![26](https://github.com/user-attachments/assets/efda1692-8510-4d74-8fbc-3b5d50b3abb3)


## Testing notes

- Open the deploy-preview
- Open browser tools
- Go to Application tab
- Open Local Storage
- Check you can see new `theme` key
- Go to `VirtoAppLayout` and switch the modes, check the values updating still working properly
- Check changing modes in `StoryBook` also updates the `theme` key properly

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- [x] I have populated the deploy-preview with relevant test data.
- ~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
