### PR TITLE
TD-3377 Update overview tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "11.4.0",
+  "version": "11.5.0-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/DateLabel/DateLabel.stories.tsx
+++ b/src/DateLabel/DateLabel.stories.tsx
@@ -26,3 +26,11 @@ export const Default = {
   },
   render: Template
 };
+
+// Without Tooltip
+export const WithoutTooltip = {
+  args: {
+    label: "10-09-24 10:24:08"
+  },
+  render: Template
+};

--- a/src/DateLabel/DateLabel.stories.tsx
+++ b/src/DateLabel/DateLabel.stories.tsx
@@ -21,7 +21,8 @@ const Template: StoryFn<DateLabelProps> = args => {
 // Default
 export const Default = {
   args: {
-    label: "10-09-24 10:24:08"
+    label: "10-09-24 10:24:08",
+    tooltip: ""
   },
   render: Template
 };

--- a/src/DateLabel/DateLabel.stories.tsx
+++ b/src/DateLabel/DateLabel.stories.tsx
@@ -22,7 +22,7 @@ const Template: StoryFn<DateLabelProps> = args => {
 export const Default = {
   args: {
     label: "10-09-24 10:24:08",
-    tooltip: ""
+    tooltip: "Created at"
   },
   render: Template
 };

--- a/src/DateLabel/DateLabel.test.tsx
+++ b/src/DateLabel/DateLabel.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from "@testing-library/react";
 
 import DateLabel from "./DateLabel";
 import React from "react";
-import userEvent from "@testing-library/user-event";
 
 describe("`DateLabel` tests", () => {
   test("renders `DateLabel` with a href", () => {
@@ -20,28 +19,13 @@ describe("`DateLabel` tests", () => {
     expect(iconElement).toBeInTheDocument();
     expect(anchorElement).not.toBeInTheDocument();
   });
-  test("renders `DateLabel` with a tooltip on hover of the icon and hides it back on unhover", async () => {
+  test("should render `DateLabel` component with tooltip component if 'tooltip' prop is present", () => {
     render(<DateLabel label="10-09-24 10:24:08" tooltip="Tooltip Text" />);
 
-    // find the trigger element
-    const tooltipTriggerElement = screen.getByTestId("icon-tooltip");
+    // find the element of interest
+    const tooltip = screen.getByTestId("icon-tooltip");
 
-    // find the elements of interest and verify it's not in document yet
-    let tooltip = screen.queryByRole("tooltip");
-    expect(tooltip).not.toBeInTheDocument();
-
-    // simulate hover effect
-    await userEvent.hover(tooltipTriggerElement);
-
-    // check if tooltip appears and is visible
-    tooltip = await screen.findByRole("tooltip");
+    // check if tooltip appears
     expect(tooltip).toBeInTheDocument();
-    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("1");
-
-    // unhover the trigger element
-    await userEvent.unhover(tooltipTriggerElement);
-
-    // ensure tooltip still exists but is not visible
-    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("0");
   });
 });

--- a/src/DateLabel/DateLabel.test.tsx
+++ b/src/DateLabel/DateLabel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 
 import DateLabel from "./DateLabel";
 import React from "react";
+import userEvent from "@testing-library/user-event";
 
 describe("`DateLabel` tests", () => {
   test("renders `DateLabel` with a href", () => {
@@ -18,5 +19,29 @@ describe("`DateLabel` tests", () => {
     expect(iconWithLabelElement).toHaveTextContent("10-09-24 10:24:08");
     expect(iconElement).toBeInTheDocument();
     expect(anchorElement).not.toBeInTheDocument();
+  });
+  test("renders `DateLabel` with a tooltip on hover of the icon and hides it back on unhover", async () => {
+    render(<DateLabel label="10-09-24 10:24:08" tooltip="Tooltip Text" />);
+
+    // find the trigger element
+    const tooltipTriggerElement = screen.getByTestId("icon-tooltip");
+
+    // find the elements of interest and verify it's not in document yet
+    let tooltip = screen.queryByRole("tooltip");
+    expect(tooltip).not.toBeInTheDocument();
+
+    // simulate hover effect
+    await userEvent.hover(tooltipTriggerElement);
+
+    // check if tooltip appears and is visible
+    tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("1");
+
+    // unhover the trigger element
+    await userEvent.unhover(tooltipTriggerElement);
+
+    // ensure tooltip still exists but is not visible
+    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("0");
   });
 });

--- a/src/DateLabel/DateLabel.tsx
+++ b/src/DateLabel/DateLabel.tsx
@@ -7,7 +7,7 @@ import React from "react";
  * Component that renders a date icon and the date to the right
  * @param label The date string to be displayed
  */
-export default function DateLabel({ label, tooltip = "" }: DateLabelProps) {
+export default function DateLabel({ label, tooltip }: DateLabelProps) {
   return IconWithLabel({
     icon: (
       <DateRangeIcon data-testid="date-icon" sx={{ height: 20, width: 20 }} />

--- a/src/DateLabel/DateLabel.tsx
+++ b/src/DateLabel/DateLabel.tsx
@@ -7,11 +7,12 @@ import React from "react";
  * Component that renders a date icon and the date to the right
  * @param label The date string to be displayed
  */
-export default function DateLabel({ label }: DateLabelProps) {
+export default function DateLabel({ label, tooltip = "" }: DateLabelProps) {
   return IconWithLabel({
     icon: (
       <DateRangeIcon data-testid="date-icon" sx={{ height: 20, width: 20 }} />
     ),
-    label
+    label,
+    tooltip
   });
 }

--- a/src/IconWithLabel/IconWithLabel.stories.tsx
+++ b/src/IconWithLabel/IconWithLabel.stories.tsx
@@ -61,3 +61,13 @@ export const TruncatesLabel = {
   },
   render: Template
 };
+
+// Without tooltip
+export const WithoutTooltip = {
+  args: {
+    href: "https://example.com",
+    icon: <CarMakerLogo />,
+    label: "Example"
+  },
+  render: Template
+};

--- a/src/IconWithLabel/IconWithLabel.stories.tsx
+++ b/src/IconWithLabel/IconWithLabel.stories.tsx
@@ -38,7 +38,8 @@ export const Default = {
   args: {
     href: "https://example.com",
     icon: <CarMakerLogo />,
-    label: "Example"
+    label: "Example",
+    tooltip: "Random text"
   },
   render: Template
 };

--- a/src/IconWithLabel/IconWithLabel.test.tsx
+++ b/src/IconWithLabel/IconWithLabel.test.tsx
@@ -2,10 +2,8 @@ import { describe, expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import { CarMakerLogo } from "../SvgIcons";
-import DateLabel from "../DateLabel/DateLabel";
 import IconWithLabel from "./IconWithLabel";
 import React from "react";
-import UserLabel from "../UserLabel/UserLabel";
 import userEvent from "@testing-library/user-event";
 
 const defaultInputs = {
@@ -59,10 +57,10 @@ describe("IconWithLabel tests", () => {
     expect(textStyle.textOverflow).toBe("ellipsis");
     expect(parentStyle.minWidth).toBe("0");
   });
-  test("renders `IconWithLabel` component with `UserLabel` icon prop. Testing if tooltip is shown on hover of the icon and hides it back on unhover", async () => {
+  test("renders `IconWithLabel` component with optional tooltip. Should show and hide tooltip on hover and hover leave respectively", async () => {
     render(
       <IconWithLabel
-        icon={<UserLabel label="James Harper" color="#EC407A" />}
+        icon={<CarMakerLogo />}
         label="Example"
         tooltip="Tooltip Text"
       />
@@ -80,36 +78,7 @@ describe("IconWithLabel tests", () => {
     // check if tooltip appears and is visible
     tooltip = await screen.findByRole("tooltip");
     expect(tooltip).toBeInTheDocument();
-    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("1");
-
-    // unhover the trigger element
-    await userEvent.unhover(tooltipTriggerElement);
-
-    // ensure tooltip still exists but is not visible
-    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("0");
-  });
-
-  test("renders `IconWithLabel` component with `DateLabel` icon prop. Testing if tooltip is shown on hover of the icon and hides it back on unhover", async () => {
-    render(
-      <IconWithLabel
-        icon={<DateLabel label="10-09-24 10:24:08" />}
-        label="Example"
-        tooltip="Tooltip Text"
-      />
-    );
-
-    // find the trigger element
-    const tooltipTriggerElement = screen.getByTestId("icon-tooltip");
-
-    // find the elements of interest
-    let tooltip = screen.queryByRole("tooltip");
-
-    // simulate hover effect
-    await userEvent.hover(tooltipTriggerElement);
-
-    // check if tooltip appears and is visible
-    tooltip = await screen.findByRole("tooltip");
-    expect(tooltip).toBeInTheDocument();
+    expect(tooltip.firstChild).toHaveTextContent("Tooltip Text");
     expect(getComputedStyle(tooltip.children[0]).opacity).toBe("1");
 
     // unhover the trigger element

--- a/src/IconWithLabel/IconWithLabel.test.tsx
+++ b/src/IconWithLabel/IconWithLabel.test.tsx
@@ -2,8 +2,11 @@ import { describe, expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import { CarMakerLogo } from "../SvgIcons";
+import DateLabel from "../DateLabel/DateLabel";
 import IconWithLabel from "./IconWithLabel";
 import React from "react";
+import UserLabel from "../UserLabel/UserLabel";
+import userEvent from "@testing-library/user-event";
 
 const defaultInputs = {
   icon: <CarMakerLogo />,
@@ -55,5 +58,64 @@ describe("IconWithLabel tests", () => {
     expect(textStyle.overflow).toBe("hidden");
     expect(textStyle.textOverflow).toBe("ellipsis");
     expect(parentStyle.minWidth).toBe("0");
+  });
+  test("renders `IconWithLabel` component with `UserLabel` icon prop. Testing if tooltip is shown on hover of the icon and hides it back on unhover", async () => {
+    render(
+      <IconWithLabel
+        icon={<UserLabel label="James Harper" color="#EC407A" />}
+        label="Example"
+        tooltip="Tooltip Text"
+      />
+    );
+
+    // find the trigger element
+    const tooltipTriggerElement = screen.getByTestId("icon-tooltip");
+
+    // find the elements of interest
+    let tooltip = screen.queryByRole("tooltip");
+
+    // simulate hover effect
+    await userEvent.hover(tooltipTriggerElement);
+
+    // check if tooltip appears and is visible
+    tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("1");
+
+    // unhover the trigger element
+    await userEvent.unhover(tooltipTriggerElement);
+
+    // ensure tooltip still exists but is not visible
+    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("0");
+  });
+
+  test("renders `IconWithLabel` component with `DateLabel` icon prop. Testing if tooltip is shown on hover of the icon and hides it back on unhover", async () => {
+    render(
+      <IconWithLabel
+        icon={<DateLabel label="10-09-24 10:24:08" />}
+        label="Example"
+        tooltip="Tooltip Text"
+      />
+    );
+
+    // find the trigger element
+    const tooltipTriggerElement = screen.getByTestId("icon-tooltip");
+
+    // find the elements of interest
+    let tooltip = screen.queryByRole("tooltip");
+
+    // simulate hover effect
+    await userEvent.hover(tooltipTriggerElement);
+
+    // check if tooltip appears and is visible
+    tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("1");
+
+    // unhover the trigger element
+    await userEvent.unhover(tooltipTriggerElement);
+
+    // ensure tooltip still exists but is not visible
+    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("0");
   });
 });

--- a/src/IconWithLabel/IconWithLabel.tsx
+++ b/src/IconWithLabel/IconWithLabel.tsx
@@ -33,6 +33,9 @@ export default function IconWithLabel({
   };
   const customizedIcon = cloneElement(icon, iconProps);
 
+  // define icon with wrapper
+  const wrapperIcon = <Box sx={{ display: "flex" }}>{customizedIcon}</Box>;
+
   return (
     <Stack
       data-testid="icon-with-label"
@@ -45,10 +48,10 @@ export default function IconWithLabel({
     >
       {tooltip ? (
         <Tooltip data-testid="icon-tooltip" title={tooltip}>
-          <Box sx={{ display: "flex" }}>{customizedIcon}</Box>
+          {wrapperIcon}
         </Tooltip>
       ) : (
-        <Box sx={{ display: "flex" }}>{customizedIcon}</Box>
+        wrapperIcon
       )}
       <Box
         sx={{

--- a/src/IconWithLabel/IconWithLabel.tsx
+++ b/src/IconWithLabel/IconWithLabel.tsx
@@ -2,12 +2,13 @@ import {
   Box,
   Link,
   Stack,
+  SxProps,
   Theme,
   Tooltip,
   Typography,
   alpha
 } from "@mui/material";
-import React, { cloneElement } from "react";
+import React, { ReactElement, cloneElement } from "react";
 
 import { IconWithLabelProps } from "./IconWithLabel.types";
 
@@ -22,7 +23,7 @@ export default function IconWithLabel({
   icon,
   label,
   href,
-  tooltip = ""
+  tooltip = undefined
 }: IconWithLabelProps) {
   const iconProps = {
     sx: (theme: Theme) => ({
@@ -43,15 +44,13 @@ export default function IconWithLabel({
         gap: "4px"
       }}
     >
-      <Tooltip data-testid="icon-tooltip" title={tooltip}>
-        <Box
-          sx={{
-            display: "flex"
-          }}
-        >
-          {customizedIcon}
-        </Box>
-      </Tooltip>
+      {tooltip ? (
+        <Tooltip data-testid="icon-tooltip" title={tooltip}>
+          <Box sx={{ display: "flex" }}>{customizedIcon}</Box>
+        </Tooltip>
+      ) : (
+        <Box sx={{ display: "flex" }}>{customizedIcon}</Box>
+      )}
       <Box
         sx={{
           minWidth: 0

--- a/src/IconWithLabel/IconWithLabel.tsx
+++ b/src/IconWithLabel/IconWithLabel.tsx
@@ -2,13 +2,12 @@ import {
   Box,
   Link,
   Stack,
-  SxProps,
   Theme,
   Tooltip,
   Typography,
   alpha
 } from "@mui/material";
-import React, { ReactElement, cloneElement } from "react";
+import React, { cloneElement } from "react";
 
 import { IconWithLabelProps } from "./IconWithLabel.types";
 

--- a/src/IconWithLabel/IconWithLabel.tsx
+++ b/src/IconWithLabel/IconWithLabel.tsx
@@ -1,4 +1,12 @@
-import { Box, Link, Stack, Theme, Typography, alpha } from "@mui/material";
+import {
+  Box,
+  Link,
+  Stack,
+  Theme,
+  Tooltip,
+  Typography,
+  alpha
+} from "@mui/material";
 import React, { cloneElement } from "react";
 
 import { IconWithLabelProps } from "./IconWithLabel.types";
@@ -8,11 +16,13 @@ import { IconWithLabelProps } from "./IconWithLabel.types";
  * @param icon The icon to be displayed
  * @param label The label to render alongside the icon
  * @param href When defined the label is a clickable link to this url
+ * @param tooltip When defined it shows tooltip over the icon
  */
 export default function IconWithLabel({
   icon,
   label,
-  href
+  href,
+  tooltip = ""
 }: IconWithLabelProps) {
   const iconProps = {
     sx: (theme: Theme) => ({
@@ -33,13 +43,15 @@ export default function IconWithLabel({
         gap: "4px"
       }}
     >
-      <Box
-        sx={{
-          display: "flex"
-        }}
-      >
-        {customizedIcon}
-      </Box>
+      <Tooltip data-testid="icon-tooltip" title={tooltip}>
+        <Box
+          sx={{
+            display: "flex"
+          }}
+        >
+          {customizedIcon}
+        </Box>
+      </Tooltip>
       <Box
         sx={{
           minWidth: 0

--- a/src/IconWithLabel/IconWithLabel.types.ts
+++ b/src/IconWithLabel/IconWithLabel.types.ts
@@ -16,4 +16,8 @@ export type IconWithLabelProps = {
    * The url to which the user will be navigated in a new tab to on clicking the label
    */
   href?: string;
+  /**
+   * The tooltip showing additional text on icon hover
+   */
+  tooltip?: string;
 };

--- a/src/UserLabel/UserLabel.stories.tsx
+++ b/src/UserLabel/UserLabel.stories.tsx
@@ -31,7 +31,7 @@ const Template: StoryFn<UserLabelProps> = args => {
 export const Default = {
   args: {
     label: "James Harper",
-    tooltip: ""
+    tooltip: "Updated at"
   },
   render: Template
 };
@@ -54,11 +54,10 @@ export const LongName = {
   render: Template
 };
 
-// With Tooltip
-export const WithTooltip = {
+// Without Tooltip
+export const WithoutTooltip = {
   args: {
-    label: "John Doe",
-    tooltip: "Created by"
+    label: "John Doe"
   },
   render: Template
 };

--- a/src/UserLabel/UserLabel.stories.tsx
+++ b/src/UserLabel/UserLabel.stories.tsx
@@ -31,7 +31,7 @@ const Template: StoryFn<UserLabelProps> = args => {
 export const Default = {
   args: {
     label: "James Harper",
-    tooltip: "Updated at"
+    tooltip: "Created by"
   },
   render: Template
 };

--- a/src/UserLabel/UserLabel.stories.tsx
+++ b/src/UserLabel/UserLabel.stories.tsx
@@ -30,7 +30,8 @@ const Template: StoryFn<UserLabelProps> = args => {
 // Default
 export const Default = {
   args: {
-    label: "James Harper"
+    label: "James Harper",
+    tooltip: ""
   },
   render: Template
 };
@@ -47,7 +48,17 @@ export const CustomColor = {
 // Long Name
 export const LongName = {
   args: {
-    label: "James withAVeryLooooooooooongMiddleName Harper"
+    label: "James withAVeryLooooooooooongMiddleName Harper",
+    tooltip: "Created by"
+  },
+  render: Template
+};
+
+// With Tooltip
+export const WithTooltip = {
+  args: {
+    label: "John Doe",
+    tooltip: "Created by"
   },
   render: Template
 };

--- a/src/UserLabel/UserLabel.test.tsx
+++ b/src/UserLabel/UserLabel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 
 import React from "react";
 import UserLabel from "./UserLabel";
+import userEvent from "@testing-library/user-event";
 
 describe("`UserLabel` tests", () => {
   test("renders `UserLabel`", () => {
@@ -36,5 +37,31 @@ describe("`UserLabel` tests", () => {
     expect(iconElement).toBeInTheDocument();
     expect(iconElementStyle.backgroundColor).toBe("rgb(236, 64, 122)");
     expect(anchorElement).not.toBeInTheDocument();
+  });
+  test("renders `UserLabel` with a tooltip on hover of the icon and hides it back on unhover", async () => {
+    render(
+      <UserLabel label="James Harper" color="#EC407A" tooltip="Tooltip Text" />
+    );
+
+    // find the trigger element
+    const tooltipTriggerElement = screen.getByTestId("icon-tooltip");
+
+    // find the elements of interest and verify it's not in document yet
+    let tooltip = screen.queryByRole("tooltip");
+    expect(tooltip).not.toBeInTheDocument();
+
+    // simulate hover effect
+    await userEvent.hover(tooltipTriggerElement);
+
+    // check if tooltip appears and is visible
+    tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("1");
+
+    // unhover the trigger element
+    await userEvent.unhover(tooltipTriggerElement);
+
+    // ensure tooltip still exists but is not visible
+    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("0");
   });
 });

--- a/src/UserLabel/UserLabel.test.tsx
+++ b/src/UserLabel/UserLabel.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from "@testing-library/react";
 
 import React from "react";
 import UserLabel from "./UserLabel";
-import userEvent from "@testing-library/user-event";
 
 describe("`UserLabel` tests", () => {
   test("renders `UserLabel`", () => {
@@ -38,30 +37,16 @@ describe("`UserLabel` tests", () => {
     expect(iconElementStyle.backgroundColor).toBe("rgb(236, 64, 122)");
     expect(anchorElement).not.toBeInTheDocument();
   });
-  test("renders `UserLabel` with a tooltip on hover of the icon and hides it back on unhover", async () => {
+
+  test("should render `UserLabel` component with tooltip component if 'tooltip' prop is present", () => {
     render(
       <UserLabel label="James Harper" color="#EC407A" tooltip="Tooltip Text" />
     );
 
-    // find the trigger element
-    const tooltipTriggerElement = screen.getByTestId("icon-tooltip");
+    // find the element of interest
+    const tooltip = screen.getByTestId("icon-tooltip");
 
-    // find the elements of interest and verify it's not in document yet
-    let tooltip = screen.queryByRole("tooltip");
-    expect(tooltip).not.toBeInTheDocument();
-
-    // simulate hover effect
-    await userEvent.hover(tooltipTriggerElement);
-
-    // check if tooltip appears and is visible
-    tooltip = await screen.findByRole("tooltip");
+    // check if tooltip appears
     expect(tooltip).toBeInTheDocument();
-    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("1");
-
-    // unhover the trigger element
-    await userEvent.unhover(tooltipTriggerElement);
-
-    // ensure tooltip still exists but is not visible
-    expect(getComputedStyle(tooltip.children[0]).opacity).toBe("0");
   });
 });

--- a/src/UserLabel/UserLabel.tsx
+++ b/src/UserLabel/UserLabel.tsx
@@ -7,7 +7,11 @@ import { UserLabelProps } from "./UserLabel.types";
  * Component that renders a user avatar and the name of the user to the right
  * @param label The name of the user to be displayed
  */
-export default function UserLabel({ label, color }: UserLabelProps) {
+export default function UserLabel({
+  label,
+  color,
+  tooltip = ""
+}: UserLabelProps) {
   return IconWithLabel({
     icon: (
       <div>
@@ -18,6 +22,7 @@ export default function UserLabel({ label, color }: UserLabelProps) {
         />
       </div>
     ),
-    label
+    label,
+    tooltip
   });
 }

--- a/src/UserLabel/UserLabel.tsx
+++ b/src/UserLabel/UserLabel.tsx
@@ -7,11 +7,7 @@ import { UserLabelProps } from "./UserLabel.types";
  * Component that renders a user avatar and the name of the user to the right
  * @param label The name of the user to be displayed
  */
-export default function UserLabel({
-  label,
-  color,
-  tooltip = ""
-}: UserLabelProps) {
+export default function UserLabel({ label, color, tooltip }: UserLabelProps) {
   return IconWithLabel({
     icon: (
       <div>

--- a/src/UserLabel/UserLabel.types.ts
+++ b/src/UserLabel/UserLabel.types.ts
@@ -3,7 +3,7 @@ import { IconWithLabelProps } from "../IconWithLabel";
 /**
  * Prop type for a `UserLabel` component
  */
-export type UserLabelProps = Pick<IconWithLabelProps, "label"> & {
+export type UserLabelProps = Pick<IconWithLabelProps, "label" | "tooltip"> & {
   /**
    * The color of the background of the user avatar
    */


### PR DESCRIPTION
Contributes [TD-3377](https://sce.myjetbrains.com/youtrack/issue/TD-3377/Update-Overview-tab-content-with-the-values-and-details)
Contributes [TD-3376](https://sce.myjetbrains.com/youtrack/issue/TD-3376/Update-UI-structure-of-Data-Component-top-level)

## Changes

`This was meant to be implemented in TD-3376 in the Header component, but as it is merged it will be tested in the current TD-3377`. It makes no difference and just the tooltip have to be tested and it can be checked with the commit of this branch installed in VIRTO Data, [this branch here](https://github.com/IPG-Automotive-UK/virto/pull/1394)

![image](https://github.com/user-attachments/assets/a39d19ef-ce19-49eb-986f-11ed234e53f9)

Don't forget to add tooltip prop as here if you want to test the tooltip in virto data:
https://github.com/IPG-Automotive-UK/virto/blob/enhancement/TD-3377-update-overview-tab/apps/data/web/src/views/search/data/DataHeader.js#L77-L85

directory to install this branch of RUI, apps/data/web
pnpm install github:IPG-Automotive-UK/react-ui#97041d5f97f56dc2ad646f061d651b514cd00531

A brief description of what this pull request solves / introduces.

- Renders tooltip for UserLabel and DateLabel components, just for the Date icon and UserAvatar icon.
- The tooltip will always be there, just for the two components we will have the possibility to attach text, as it is optional
- Unit tests created to check whether the tooltip is rendered and shown and hidden in the html

## Dependencies

N/A

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->

## Testing notes

Check if the tooltip is rendered if it is applied on hover of the icon in the components mentioned above.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[ ] I have populated the deploy-preview with relevant test data.~
- ~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
