### PR TITLE
TD-3416 add auto selection for gates for VehicleSelector in RUI

### DIFF
--- a/src/VehicleSelector/VehicleSelector.stories.tsx
+++ b/src/VehicleSelector/VehicleSelector.stories.tsx
@@ -250,3 +250,30 @@ export const Disabled = {
 
   render: Template
 };
+
+export const AutoSelectionWithGate = {
+  args: {
+    flexDirection: "column",
+    flexWrap: "nowrap",
+    gates: ["Gate 1"],
+    value: [
+      {
+        _id: "",
+        gate: "",
+        modelYear: "",
+        projectCode: "911",
+        variant: ""
+      }
+    ],
+    variants: [
+      {
+        _id: "1",
+        modelYear: "2015",
+        projectCode: "911",
+        variant: "Variant 1"
+      }
+    ]
+  },
+
+  render: Template
+};

--- a/src/VehicleSelector/VehicleSelector.test.tsx
+++ b/src/VehicleSelector/VehicleSelector.test.tsx
@@ -645,6 +645,7 @@ describe("VehicleSelector Gate Auto-Selection", () => {
     const projectInput = screen.getByRole("combobox", {
       name: /project code/i
     });
+
     await act(async () => {
       fireEvent.mouseDown(projectInput);
       await Promise.resolve();

--- a/src/VehicleSelector/VehicleSelector.test.tsx
+++ b/src/VehicleSelector/VehicleSelector.test.tsx
@@ -615,3 +615,64 @@ describe("VehicleSelector Auto-Selection Additional Scenarios", () => {
     });
   });
 });
+
+describe("VehicleSelector Gate Auto-Selection", () => {
+  it("auto-selects gate when there is exactly one gate option", async () => {
+    // Provide a single variant so both model year and variant auto-select can occur.
+    const autoGateVariants: VehicleSelectorProps["variants"] = [
+      { _id: "1", modelYear: "2015", projectCode: "911", variant: "NN" }
+    ];
+    // Set the gates prop to a single option.
+    const autoGateProps: VehicleSelectorProps = {
+      flexDirection: "column",
+      flexWrap: "nowrap",
+      gates: ["Gate 1"],
+      onChange: () => {},
+      value: [],
+      variants: autoGateVariants
+    };
+
+    // Create a mock change handler to capture changes.
+    const handleChange = vi.fn();
+    await act(async () => {
+      render(
+        <VehicleSelectorWithState {...autoGateProps} onChange={handleChange} />
+      );
+      await Promise.resolve();
+    });
+
+    // Open the Project Code dropdown and select "911".
+    const projectInput = screen.getByRole("combobox", {
+      name: /project code/i
+    });
+    await act(async () => {
+      fireEvent.mouseDown(projectInput);
+      await Promise.resolve();
+    });
+    const option911 = await screen.findByRole("option", { name: "911" });
+    await act(async () => {
+      fireEvent.click(option911);
+      await Promise.resolve();
+    });
+
+    // Wait for auto-selection of the model year.
+    await waitFor(() => {
+      const modelYearInput = screen.getByRole("combobox", {
+        name: /model year/i
+      });
+      expect(modelYearInput).toHaveValue("2015");
+    });
+
+    // Wait for auto-selection of the variant.
+    await waitFor(() => {
+      const variantInput = screen.getByRole("combobox", { name: /variant/i });
+      expect(variantInput).toHaveValue("NN");
+    });
+
+    // Finally, wait for auto-selection of the gate.
+    await waitFor(() => {
+      const gateInput = screen.getByRole("combobox", { name: /gate/i });
+      expect(gateInput).toHaveValue("Gate 1");
+    });
+  });
+});

--- a/src/VehicleSelector/VehicleSelector.tsx
+++ b/src/VehicleSelector/VehicleSelector.tsx
@@ -149,6 +149,44 @@ function VehicleSelector({
     onChange
   ]);
 
+  // auto selecting a gate if applicable.
+  useEffect(() => {
+    // Only auto-select if there are gate options available, one gate, one selected variant
+    if (
+      gates &&
+      gates.length === 1 &&
+      selectedVariants.length > 0 &&
+      selectedGates.length === 0
+    ) {
+      const autoGate = gates[0];
+      // Filter the vehicles based on the current selections.
+      const newVehicles = filterVehicles({
+        modelYear: selectedModelYear,
+        projectCode: selectedProject,
+        variants
+      }).filter(v => selectedVariants.includes(v.variant));
+
+      // Update each vehicle record with the auto-selected gate.
+      onChange(
+        newVehicles.map(v => ({
+          _id: v._id,
+          gate: autoGate,
+          modelYear: v.modelYear,
+          projectCode: v.projectCode,
+          variant: v.variant
+        }))
+      );
+    }
+  }, [
+    gates,
+    selectedVariants,
+    selectedGates,
+    selectedModelYear,
+    selectedProject,
+    variants,
+    onChange
+  ]);
+
   // create the selector components for project, model year, variant and gate with single select for project and model year and multi select for variant and gate
   return (
     <Box

--- a/src/VehicleSelector/VehicleSelector.tsx
+++ b/src/VehicleSelector/VehicleSelector.tsx
@@ -163,6 +163,7 @@ function VehicleSelector({
       !userClearedGate
     ) {
       const autoGate = gates[0];
+
       // Filter the vehicles based on the current selections.
       const newVehicles = filterVehicles({
         modelYear: selectedModelYear,
@@ -401,11 +402,13 @@ function VehicleSelector({
               // Normalize and update userClearedGate flag accordingly.
               if (!value || (Array.isArray(value) && value.length === 0)) {
                 setUserClearedGate(true);
+
                 const newVehicles = filterVehicles({
                   modelYear: selectedModelYear,
                   projectCode: selectedProject,
                   variants
                 }).filter(v => selectedVariants.includes(v.variant));
+
                 // if no gates selected keep the project, model year and variant but clear the gate in value
                 onChange(
                   newVehicles.map(v => ({


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Contributes [TD-3416](https://sce.myjetbrains.com/youtrack/issue/TD-3416/Gate-value-is-not-preselected-in-vehicle-selector-for-DATA-and-MODEL-when-there-is-just-one-gate)

## Changes

Ad auto selection if there is only one gate


## Dependencies

N/A

## UI/UX

Storybook, test VehicleSelector with gates

In Virto MODEL

https://github.com/user-attachments/assets/ba21b0cc-bd31-43fb-a3ee-5e722c694b35

In Virto DATA

https://github.com/user-attachments/assets/01d46da3-a32f-4169-83c0-6265e535d6dd

PROOF Gate still works with Multi Gates


https://github.com/user-attachments/assets/6de53646-4383-4860-bed4-9e8255776e2d


## Testing notes

Storybook, test VehicleSelector with gates
for Virto in MODEL & DATA

pnpm i github:IPG-Automotive-UK/react-ui#fe04f90ca361ab51dbcaaddc186736c04b4779aa

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
~~- [ ] I have populated the deploy-preview with relevant test data.~~
~~- [ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~~
