### PR TITLE
TD-2230 Bug fix/td 2230 line plot re rendering issue

### DIFF
--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -10,7 +10,7 @@ import {
   ConfigProps,
   LinePlotProps
 } from "./LinePlot.types";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 
 import DialogTitle from "../DialogTitle";
 import Plotly from "react-plotly.js";
@@ -32,26 +32,26 @@ const LinePlot = ({
   const plotRef = useRef<HTMLDivElement>(null);
 
   // state to keep track of the size of the plot div
-  const [axisSize, setAxisSize] = useState({ height: 300, width: 400 });
+  const [axisSize] = useState({ height: 300, width: 400 });
 
   // state to keep track of whether the plot is in fullscreen mode
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   // effect to update the size of the plot div on window resize
-  useEffect(() => {
-    const updateSize = () => {
-      // if plotRef is not set, return early to avoid errors
-      if (!plotRef.current) return;
-      // get the bounding box of the plot div and set the axis size state
-      const boundingBox = plotRef.current.getBoundingClientRect();
-      setAxisSize({ height: boundingBox.height, width: boundingBox.width });
-    };
-    // add event listener for window resize event and call updateSize on mount
-    updateSize();
-    window.addEventListener("resize", updateSize);
-    // cleanup event listener on unmount and resize
-    return () => window.removeEventListener("resize", updateSize);
-  });
+  // useEffect(() => {
+  //   const updateSize = () => {
+  //     // if plotRef is not set, return early to avoid errors
+  //     if (!plotRef.current) return;
+  //     // get the bounding box of the plot div and set the axis size state
+  //     const boundingBox = plotRef.current.getBoundingClientRect();
+  //     setAxisSize({ height: boundingBox.height, width: boundingBox.width });
+  //   };
+  //   // add event listener for window resize event and call updateSize on mount
+  //   updateSize();
+  //   window.addEventListener("resize", updateSize);
+  //   // cleanup event listener on unmount and resize
+  //   return () => window.removeEventListener("resize", updateSize);
+  // });
 
   // helper function to get the maximum number of characters that can fit in the axis label
   const getMaxChars = (axisLength: number) => Math.floor(axisLength / 7);

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -28,7 +28,7 @@ const LinePlot = ({
   // theme hook
   const theme = useTheme();
 
-  // ref to get the size of the plot div for axis labels wrapping and resizing plot on window resize event listener
+  // ref to get the size of the plot div for axis labels wrapping
   const plotRef = useRef<HTMLDivElement>(null);
 
   // state to keep track of the size of the plot div
@@ -37,13 +37,12 @@ const LinePlot = ({
   // state to keep track of whether the plot is in fullscreen mode
   const [isFullscreen, setIsFullscreen] = useState(false);
 
-  // effect to update the size of the plot div on window resize
+  // effect to set the initial size of the plot div
   useEffect(() => {
-    // if plotRef is not set, return early to avoid errors
-    if (!plotRef.current) return;
-    // get the bounding box of the plot div and set the axis size state
-    const boundingBox = plotRef.current.getBoundingClientRect();
-    setAxisSize({ height: boundingBox.height, width: boundingBox.width });
+    if (plotRef.current) {
+      const boundingBox = plotRef.current.getBoundingClientRect();
+      setAxisSize({ height: boundingBox.height, width: boundingBox.width });
+    }
   }, []);
 
   // helper function to get the maximum number of characters that can fit in the axis label

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -10,7 +10,7 @@ import {
   ConfigProps,
   LinePlotProps
 } from "./LinePlot.types";
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import DialogTitle from "../DialogTitle";
 import Plotly from "react-plotly.js";
@@ -32,26 +32,19 @@ const LinePlot = ({
   const plotRef = useRef<HTMLDivElement>(null);
 
   // state to keep track of the size of the plot div
-  const [axisSize] = useState({ height: 300, width: 400 });
+  const [axisSize, setAxisSize] = useState({ height: 300, width: 400 });
 
   // state to keep track of whether the plot is in fullscreen mode
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   // effect to update the size of the plot div on window resize
-  // useEffect(() => {
-  //   const updateSize = () => {
-  //     // if plotRef is not set, return early to avoid errors
-  //     if (!plotRef.current) return;
-  //     // get the bounding box of the plot div and set the axis size state
-  //     const boundingBox = plotRef.current.getBoundingClientRect();
-  //     setAxisSize({ height: boundingBox.height, width: boundingBox.width });
-  //   };
-  //   // add event listener for window resize event and call updateSize on mount
-  //   updateSize();
-  //   window.addEventListener("resize", updateSize);
-  //   // cleanup event listener on unmount and resize
-  //   return () => window.removeEventListener("resize", updateSize);
-  // });
+  useEffect(() => {
+    // if plotRef is not set, return early to avoid errors
+    if (!plotRef.current) return;
+    // get the bounding box of the plot div and set the axis size state
+    const boundingBox = plotRef.current.getBoundingClientRect();
+    setAxisSize({ height: boundingBox.height, width: boundingBox.width });
+  }, []);
 
   // helper function to get the maximum number of characters that can fit in the axis label
   const getMaxChars = (axisLength: number) => Math.floor(axisLength / 7);


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Closes/Contributes [TD-2230](https://sce.myjetbrains.com/youtrack/issue/TD-2230/Result-plot-Y-axis-labelling-does-not-wrap)

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

A brief description of what this pull request solves / introduces.
- The event listeners for window resize have been removed, and the axis labels wrapping is calculated based on the initial size of the plot div.

## Dependencies
N/A

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->
This resolves re-rendering issue and navigating to other tabs in VIRTO.RESULT

https://github.com/user-attachments/assets/f84f0548-95d3-4ff9-baad-6533da5cee7d


## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [ ] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [ ] ~I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- [x] I have populated the deploy-preview with relevant test data.
- [ ] ~I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
