### PR TITLE
TD-3419 vehicle selector errors

### DIFF
--- a/src/VehicleSelector/VehicleSelector.stories.tsx
+++ b/src/VehicleSelector/VehicleSelector.stories.tsx
@@ -277,3 +277,53 @@ export const AutoSelectionWithGate = {
 
   render: Template
 };
+
+export const WithExternalErrors = {
+  args: {
+    errors: ["projectCode", "modelYear", "variant", "gate"],
+    flexDirection: "column",
+    flexWrap: "nowrap",
+    gates: [],
+    value: [],
+    variants: [
+      {
+        _id: "1",
+        modelYear: "2015",
+        projectCode: "911",
+        variant: "MP - 3.6 l6 - 397kW - 7MT - R20"
+      },
+      {
+        _id: "2",
+        modelYear: "2019",
+        projectCode: "CrossoverEV",
+        variant: "Nicolas - FWD - BEV - 150KW - R17"
+      },
+      {
+        _id: "3",
+        modelYear: "2020",
+        projectCode: "CrossoverEV",
+        variant: "Option A"
+      },
+      {
+        _id: "4",
+        modelYear: "2020",
+        projectCode: "CrossoverEV",
+        variant: "Option B"
+      },
+      {
+        _id: "5",
+        modelYear: "2020",
+        projectCode: "CrossoverEV",
+        variant: "Option C"
+      },
+      {
+        _id: "6",
+        modelYear: "2018",
+        projectCode: "Mustang",
+        variant: "GT 5.0 V8"
+      }
+    ]
+  },
+
+  render: Template
+};

--- a/src/VehicleSelector/VehicleSelector.test.tsx
+++ b/src/VehicleSelector/VehicleSelector.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "./VehicleSelector.utils";
 
 import VehicleSelector from "./VehicleSelector";
+import userEvent from "@testing-library/user-event";
 
 // default props
 const defaultProps: VehicleSelectorProps = {
@@ -97,6 +98,152 @@ describe("VehicleSelector", () => {
     expect(screen.getByRole("combobox", { name: /gate/i })).toHaveValue(
       "Gate 1"
     );
+  });
+
+  it("shows error states on blur with no value", async () => {
+    render(<VehicleSelectorWithState {...defaultProps} />);
+
+    // Test the project code field errors
+    const projectCodeInput = screen.getByRole("combobox", {
+      name: /project code/i
+    });
+
+    await userEvent.click(projectCodeInput);
+    await userEvent.tab();
+
+    expect(projectCodeInput.closest("div")).toHaveClass("Mui-error");
+
+    // Test the project code error is removed when a value is selected
+    await userEvent.click(projectCodeInput);
+
+    const option911 = await screen.findByRole("option", { name: "911" });
+    await userEvent.click(option911);
+
+    expect(projectCodeInput.closest("div")).not.toHaveClass("Mui-error");
+
+    // Test the model year field errors
+    const modelYearInput = screen.getByRole("combobox", {
+      name: /model year/i
+    });
+
+    await userEvent.click(modelYearInput);
+    await userEvent.tab();
+
+    expect(modelYearInput.closest("div")).toHaveClass("Mui-error");
+
+    // Test the model year error is removed when a value is selected
+    await userEvent.click(modelYearInput);
+
+    const option2016 = await screen.findByRole("option", { name: "2016" });
+    await userEvent.click(option2016);
+
+    expect(modelYearInput.closest("div")).not.toHaveClass("Mui-error");
+
+    // Test the variant field errors
+
+    const variantInput = screen.getByRole("combobox", {
+      name: /variant/i
+    });
+
+    await userEvent.click(variantInput);
+    await userEvent.tab();
+
+    expect(variantInput.closest("div")).toHaveClass("Mui-error");
+
+    // Test the variant error is removed when a value is selected
+    await userEvent.click(variantInput);
+
+    const optionMC = await screen.findByRole("option", { name: "MC" });
+    await userEvent.click(optionMC);
+
+    expect(variantInput.closest("div")).not.toHaveClass("Mui-error");
+
+    // Test the gate field errors
+
+    const gateInput = screen.getByRole("combobox", {
+      name: /gate/i
+    });
+
+    await userEvent.click(gateInput);
+    await userEvent.tab();
+
+    expect(gateInput.closest("div")).toHaveClass("Mui-error");
+
+    // Test the gate error is removed when a value is selected
+
+    await userEvent.click(gateInput);
+
+    const optionGate = await screen.findByRole("option", { name: "Gate 2" });
+    await userEvent.click(optionGate);
+
+    expect(gateInput.closest("div")).not.toHaveClass("Mui-error");
+  });
+
+  it("shows errors when passed externally", async () => {
+    render(
+      <VehicleSelectorWithState
+        {...defaultProps}
+        errors={["projectCode", "modelYear", "variant", "gate"]}
+      />
+    );
+
+    // Test the project code field error is always visible when set externally
+    const projectCodeInput = screen.getByRole("combobox", {
+      name: /project code/i
+    });
+
+    expect(projectCodeInput.closest("div")).toHaveClass("Mui-error");
+
+    await userEvent.click(projectCodeInput);
+
+    const option911 = await screen.findByRole("option", { name: "911" });
+    await userEvent.click(option911);
+
+    expect(projectCodeInput.closest("div")).toHaveClass("Mui-error");
+
+    // Test the model year field error is always visible when set externally
+    const modelYearInput = screen.getByRole("combobox", {
+      name: /model year/i
+    });
+
+    expect(modelYearInput.closest("div")).toHaveClass("Mui-error");
+
+    await userEvent.click(modelYearInput);
+
+    const option2016 = await screen.findByRole("option", { name: "2016" });
+    await userEvent.click(option2016);
+
+    expect(modelYearInput.closest("div")).toHaveClass("Mui-error");
+
+    // Test the variant error is always visible when set externally
+
+    const variantInput = screen.getByRole("combobox", {
+      name: /variant/i
+    });
+
+    expect(variantInput.closest("div")).toHaveClass("Mui-error");
+
+    await userEvent.click(variantInput);
+
+    const optionMC = await screen.findByRole("option", { name: "MC" });
+    await userEvent.click(optionMC);
+
+    expect(variantInput.closest("div")).toHaveClass("Mui-error");
+
+    // Test the gate field error is always visible when set externally
+
+    const gateInput = screen.getByRole("combobox", {
+      name: /gate/i
+    });
+
+    expect(gateInput.closest("div")).toHaveClass("Mui-error");
+
+    await userEvent.click(gateInput);
+
+    const optionGate = await screen.findByRole("option", { name: "Gate 2" });
+    await userEvent.click(optionGate);
+
+    expect(gateInput.closest("div")).toHaveClass("Mui-error");
   });
 
   it("applies flex direction and wrap styles", () => {

--- a/src/VehicleSelector/VehicleSelector.types.ts
+++ b/src/VehicleSelector/VehicleSelector.types.ts
@@ -33,6 +33,11 @@ export type VehicleSelectorProps = {
    */
   disabled?: boolean;
   /**
+   * The field errors if setting errors is required externally
+   * Errors will be set whether field has a value or not
+   */
+  errors?: ("projectCode" | "modelYear" | "variant" | "gate")[];
+  /**
    * FlexDirection of the component
    */
   flexDirection?: string;


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Closes/Contributes [TD-3419](https://sce.myjetbrains.com/youtrack/issue/TD-3419/Project-Code-and-Prototype-name-mandatory-validations-missing-in-Build-and-Fleet)

## Changes

Added error handling and tests to VehicleSelector

## Testing notes

Check empty inputs  error on blur. Check fields always display errors when set externally.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- ~[ ] I have tested the changes in Docker / a deploy-preview.~
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- [x] I have populated the deploy-preview with relevant test data.
- [x] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
