### PR TITLE
TD-3461 Mode Storage Key to default

### DIFF
--- a/src/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/ThemeProvider/ThemeProvider.test.tsx
@@ -71,7 +71,7 @@ describe("ThemeProvider", () => {
   );
   test.each(["light", "dark"])("renders %s theme from local storage", mode => {
     // set the theme in local storage
-    window.localStorage.setItem("theme", mode);
+    window.localStorage.setItem("mui-mode", mode);
 
     // render the component
     render(
@@ -89,7 +89,10 @@ describe("ThemeProvider", () => {
     "renders %s theme when theme toggled",
     async mode => {
       // first set the theme to the opposite of the mode we want to test
-      window.localStorage.setItem("theme", mode === "light" ? "dark" : "light");
+      window.localStorage.setItem(
+        "mui-mode",
+        mode === "light" ? "dark" : "light"
+      );
 
       // render the toggle button
       render(

--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -334,7 +334,7 @@ export default function ThemeProvider({
 }: ThemeProviderProps) {
   // wrap mui theme provider and children in theme context
   return (
-    <MuiThemeProvider theme={theme} defaultMode="light" modeStorageKey="theme">
+    <MuiThemeProvider theme={theme} defaultMode="light">
       <ControlledThemeWrapper theme={controlledTheme}>
         {children}
       </ControlledThemeWrapper>


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Contributes
 [TD-3461](https://sce.myjetbrains.com/youtrack/issue/TD-3461/Documentation-preserves-light-mode-even-though-user-selects-system-mode-with-system-mode-being-setup-as-dark)
[TD-3462](https://sce.myjetbrains.com/youtrack/issue/TD-3462/When-System-Preference-is-selected-within-Virto-and-System-modedark-and-user-switches-the-system-mode-from-dark-to-light-the)

This PR resolves an issue with theme mode synchronization between VIRTO and the Docusaurus theme. Both were using the same localStorage key, theme, to set, update, and read the current theme mode.
Recently, we added support for the system mode in VIRTO, which is not supported by Docusaurus. This caused issues when switching to system mode while a document was open.
As an immediate fix, we are assigning different localStorage keys for VIRTO and Docusaurus allowing each to manage its own theme independently. Docusaurus uses `theme` by default and for VIRTO in `ThemeProvider` we are setting it to use default `mui-mode` . Docusaurus and VIRTO do not need to sync theme, this is confimed with @mattcorner @jegasriskantha 

## Changes

- Removed custom `modeStorageKey` - `theme` added to use default `mui-mode`
- Updated tests

## UI/UX

Before
![Screenshot 2025-03-11 121349](https://github.com/user-attachments/assets/688070cf-3735-40ef-bbfa-361388f86c85)

After
![Screenshot 2025-03-11 121302](https://github.com/user-attachments/assets/f518859a-19e5-4550-9a20-5d01bda8550c)

Tested on a VIRTO app
![30](https://github.com/user-attachments/assets/2cbfba7b-f63f-47ab-b023-c000c67efe28)


## Testing notes

- Check the localStorage key is been update to `mui-mode`
- Try changing the theme mode in `UserMenu` and verify the storage updating with correct values

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- [x] I have populated the deploy-preview with relevant test data.
- ~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
