### PR TITLE
TD-3479 Vehicle Selector Errors

### DIFF
--- a/src/VehicleSelector/VehicleSelector.stories.tsx
+++ b/src/VehicleSelector/VehicleSelector.stories.tsx
@@ -327,3 +327,53 @@ export const WithExternalErrors = {
 
   render: Template
 };
+
+export const InitWithError = {
+  args: {
+    flexDirection: "column",
+    flexWrap: "nowrap",
+    gates: [],
+    validateOnInit: true,
+    value: [],
+    variants: [
+      {
+        _id: "1",
+        modelYear: "2015",
+        projectCode: "911",
+        variant: "MP - 3.6 l6 - 397kW - 7MT - R20"
+      },
+      {
+        _id: "2",
+        modelYear: "2019",
+        projectCode: "CrossoverEV",
+        variant: "Nicolas - FWD - BEV - 150KW - R17"
+      },
+      {
+        _id: "3",
+        modelYear: "2020",
+        projectCode: "CrossoverEV",
+        variant: "Option A"
+      },
+      {
+        _id: "4",
+        modelYear: "2020",
+        projectCode: "CrossoverEV",
+        variant: "Option B"
+      },
+      {
+        _id: "5",
+        modelYear: "2020",
+        projectCode: "CrossoverEV",
+        variant: "Option C"
+      },
+      {
+        _id: "6",
+        modelYear: "2018",
+        projectCode: "Mustang",
+        variant: "GT 5.0 V8"
+      }
+    ]
+  },
+
+  render: Template
+};

--- a/src/VehicleSelector/VehicleSelector.stories.tsx
+++ b/src/VehicleSelector/VehicleSelector.stories.tsx
@@ -278,62 +278,12 @@ export const AutoSelectionWithGate = {
   render: Template
 };
 
-export const WithExternalErrors = {
-  args: {
-    errors: ["projectCode", "modelYear", "variant", "gate"],
-    flexDirection: "column",
-    flexWrap: "nowrap",
-    gates: [],
-    value: [],
-    variants: [
-      {
-        _id: "1",
-        modelYear: "2015",
-        projectCode: "911",
-        variant: "MP - 3.6 l6 - 397kW - 7MT - R20"
-      },
-      {
-        _id: "2",
-        modelYear: "2019",
-        projectCode: "CrossoverEV",
-        variant: "Nicolas - FWD - BEV - 150KW - R17"
-      },
-      {
-        _id: "3",
-        modelYear: "2020",
-        projectCode: "CrossoverEV",
-        variant: "Option A"
-      },
-      {
-        _id: "4",
-        modelYear: "2020",
-        projectCode: "CrossoverEV",
-        variant: "Option B"
-      },
-      {
-        _id: "5",
-        modelYear: "2020",
-        projectCode: "CrossoverEV",
-        variant: "Option C"
-      },
-      {
-        _id: "6",
-        modelYear: "2018",
-        projectCode: "Mustang",
-        variant: "GT 5.0 V8"
-      }
-    ]
-  },
-
-  render: Template
-};
-
-export const InitWithError = {
+export const Validate = {
   args: {
     flexDirection: "column",
     flexWrap: "nowrap",
     gates: [],
-    validateOnInit: true,
+    validate: true,
     value: [],
     variants: [
       {

--- a/src/VehicleSelector/VehicleSelector.test.tsx
+++ b/src/VehicleSelector/VehicleSelector.test.tsx
@@ -12,6 +12,7 @@ import {
   filterVehicles,
   shouldAutoSelect
 } from "./VehicleSelector.utils";
+import { describe, expect, it, vi } from "vitest";
 
 import VehicleSelector from "./VehicleSelector";
 import userEvent from "@testing-library/user-event";
@@ -22,6 +23,7 @@ const defaultProps: VehicleSelectorProps = {
   flexWrap: "nowrap",
   gates: ["Gate 1", "Gate 2", "Gate 3"],
   onChange: () => {},
+  validate: false,
   value: [],
   variants: [
     {
@@ -179,77 +181,8 @@ describe("VehicleSelector", () => {
     expect(gateInput.closest("div")).not.toHaveClass("Mui-error");
   });
 
-  it("shows errors when passed externally", async () => {
-    render(
-      <VehicleSelectorWithState
-        {...defaultProps}
-        errors={["projectCode", "modelYear", "variant", "gate"]}
-      />
-    );
-
-    // Test the project code field error is always visible when set externally
-    const projectCodeInput = screen.getByRole("combobox", {
-      name: /project code/i
-    });
-
-    expect(projectCodeInput.closest("div")).toHaveClass("Mui-error");
-
-    await userEvent.click(projectCodeInput);
-
-    const option911 = await screen.findByRole("option", { name: "911" });
-    await userEvent.click(option911);
-
-    expect(projectCodeInput.closest("div")).toHaveClass("Mui-error");
-
-    // Test the model year field error is always visible when set externally
-    const modelYearInput = screen.getByRole("combobox", {
-      name: /model year/i
-    });
-
-    expect(modelYearInput.closest("div")).toHaveClass("Mui-error");
-
-    await userEvent.click(modelYearInput);
-
-    const option2016 = await screen.findByRole("option", { name: "2016" });
-    await userEvent.click(option2016);
-
-    expect(modelYearInput.closest("div")).toHaveClass("Mui-error");
-
-    // Test the variant error is always visible when set externally
-
-    const variantInput = screen.getByRole("combobox", {
-      name: /variant/i
-    });
-
-    expect(variantInput.closest("div")).toHaveClass("Mui-error");
-
-    await userEvent.click(variantInput);
-
-    const optionMC = await screen.findByRole("option", { name: "MC" });
-    await userEvent.click(optionMC);
-
-    expect(variantInput.closest("div")).toHaveClass("Mui-error");
-
-    // Test the gate field error is always visible when set externally
-
-    const gateInput = screen.getByRole("combobox", {
-      name: /gate/i
-    });
-
-    expect(gateInput.closest("div")).toHaveClass("Mui-error");
-
-    await userEvent.click(gateInput);
-
-    const optionGate = await screen.findByRole("option", { name: "Gate 2" });
-    await userEvent.click(optionGate);
-
-    expect(gateInput.closest("div")).toHaveClass("Mui-error");
-  });
-
-  it("shows a project code error on initial render when initWithError prop is provided", async () => {
-    render(
-      <VehicleSelectorWithState {...defaultProps} validateOnInit={true} />
-    );
+  it("shows an error when validate is true if an active field has no value", async () => {
+    render(<VehicleSelectorWithState {...defaultProps} validate={true} />);
 
     // Test the project code field error is always visible when set externally
     const projectCodeInput = screen.getByRole("combobox", {
@@ -602,6 +535,7 @@ describe("VehicleSelector Auto-Selection", () => {
     flexWrap: "nowrap",
     gates: [],
     onChange: () => {},
+    validate: false,
     value: [],
     variants: autoSelectVariants
   };
@@ -660,6 +594,7 @@ describe("VehicleSelector Auto-Selection Additional Scenarios", () => {
       flexWrap: "nowrap",
       gates: [],
       onChange: () => {},
+      validate: false,
       value: [],
       variants: variantsMultipleVariants
     };
@@ -712,6 +647,7 @@ describe("VehicleSelector Auto-Selection Additional Scenarios", () => {
       flexWrap: "nowrap",
       gates: [],
       onChange: () => {},
+      validate: false,
       value: [],
       variants: variantsMixed
     };
@@ -795,6 +731,7 @@ describe("VehicleSelector Gate Auto-Selection", () => {
       flexWrap: "nowrap",
       gates: ["Gate 1"],
       onChange: () => {},
+      validate: false,
       value: [],
       variants: autoGateVariants
     };

--- a/src/VehicleSelector/VehicleSelector.test.tsx
+++ b/src/VehicleSelector/VehicleSelector.test.tsx
@@ -246,6 +246,26 @@ describe("VehicleSelector", () => {
     expect(gateInput.closest("div")).toHaveClass("Mui-error");
   });
 
+  it("shows a project code error on initial render when initWithError prop is provided", async () => {
+    render(
+      <VehicleSelectorWithState {...defaultProps} validateOnInit={true} />
+    );
+
+    // Test the project code field error is always visible when set externally
+    const projectCodeInput = screen.getByRole("combobox", {
+      name: /project code/i
+    });
+
+    expect(projectCodeInput.closest("div")).toHaveClass("Mui-error");
+
+    await userEvent.click(projectCodeInput);
+
+    const option911 = await screen.findByRole("option", { name: "911" });
+    await userEvent.click(option911);
+
+    expect(projectCodeInput.closest("div")).not.toHaveClass("Mui-error");
+  });
+
   it("applies flex direction and wrap styles", () => {
     render(
       <VehicleSelectorWithState

--- a/src/VehicleSelector/VehicleSelector.test.tsx
+++ b/src/VehicleSelector/VehicleSelector.test.tsx
@@ -23,7 +23,6 @@ const defaultProps: VehicleSelectorProps = {
   flexWrap: "nowrap",
   gates: ["Gate 1", "Gate 2", "Gate 3"],
   onChange: () => {},
-  validate: false,
   value: [],
   variants: [
     {
@@ -535,7 +534,6 @@ describe("VehicleSelector Auto-Selection", () => {
     flexWrap: "nowrap",
     gates: [],
     onChange: () => {},
-    validate: false,
     value: [],
     variants: autoSelectVariants
   };
@@ -594,7 +592,6 @@ describe("VehicleSelector Auto-Selection Additional Scenarios", () => {
       flexWrap: "nowrap",
       gates: [],
       onChange: () => {},
-      validate: false,
       value: [],
       variants: variantsMultipleVariants
     };
@@ -647,7 +644,6 @@ describe("VehicleSelector Auto-Selection Additional Scenarios", () => {
       flexWrap: "nowrap",
       gates: [],
       onChange: () => {},
-      validate: false,
       value: [],
       variants: variantsMixed
     };
@@ -731,7 +727,6 @@ describe("VehicleSelector Gate Auto-Selection", () => {
       flexWrap: "nowrap",
       gates: ["Gate 1"],
       onChange: () => {},
-      validate: false,
       value: [],
       variants: autoGateVariants
     };

--- a/src/VehicleSelector/VehicleSelector.tsx
+++ b/src/VehicleSelector/VehicleSelector.tsx
@@ -13,9 +13,8 @@ import { uniqueSortedArray } from "../utils/common";
 // component to select a vehicle
 function VehicleSelector({
   disabled = false,
-  errors,
   flexDirection = "column",
-  validateOnInit,
+  validate = false,
   limitTags = 1,
   flexWrap = "nowrap",
   gates = [],
@@ -25,31 +24,21 @@ function VehicleSelector({
   value = [],
   variants = []
 }: VehicleSelectorProps) {
-  // selector has errors
-  const hasErrors = errors && errors.length > 0;
-  // state to track errors
-  const projectCodeExternalError = hasErrors && errors.includes("projectCode");
-  const modelYearExternalError = hasErrors && errors.includes("modelYear");
-  const variantExternalError = hasErrors && errors.includes("variant");
-  const gateExternalError = hasErrors && errors.includes("gate");
-
   // flags indicating whether the user has manually cleared a field.
   const [userClearedModelYear, setUserClearedModelYear] = useState(false);
   const [userClearedVariant, setUserClearedVariant] = useState(false);
   const [userClearedGate, setUserClearedGate] = useState(false);
 
-  // state to track errors
-  const [gateError, setGateError] = useState<boolean | undefined>(
-    gateExternalError
-  );
+  // state to track errors - undefined is used to avoid setting errors on initial render
+  const [gateError, setGateError] = useState<boolean | undefined>(undefined);
   const [variantError, setVariantError] = useState<boolean | undefined>(
-    variantExternalError
+    undefined
   );
   const [modelYearError, setModelYearError] = useState<boolean | undefined>(
-    modelYearExternalError
+    undefined
   );
   const [projectCodeError, setProjectCodeError] = useState<boolean | undefined>(
-    validateOnInit || projectCodeExternalError
+    undefined
   );
 
   // derive state for selected project
@@ -220,30 +209,42 @@ function VehicleSelector({
   // set the error state for project code
   useEffect(() => {
     if (projectCodeError === undefined) return;
-    setProjectCodeError(!selectedProject || projectCodeExternalError);
-  }, [projectCodeExternalError, projectCodeError, selectedProject]);
+    setProjectCodeError(!selectedProject);
+  }, [projectCodeError, selectedProject]);
 
   // set the error state for model year
   useEffect(() => {
     if (modelYearError === undefined) return;
-    setModelYearError(!selectedModelYear || modelYearExternalError);
-  }, [modelYearError, modelYearExternalError, selectedModelYear]);
+    setModelYearError(!selectedModelYear);
+  }, [modelYearError, selectedModelYear]);
 
   // set the error state for variant
   useEffect(() => {
     if (variantError === undefined) return;
-    setVariantError(
-      !selectedVariants || selectedVariants.length === 0 || variantExternalError
-    );
-  }, [selectedVariants, variantError, variantExternalError]);
+    setVariantError(!selectedVariants || selectedVariants.length === 0);
+  }, [selectedVariants, variantError]);
 
   // set the error for gate
   useEffect(() => {
     if (gateError === undefined) return;
-    setGateError(
-      !selectedGates || selectedGates.length === 0 || gateExternalError
-    );
-  }, [gateError, gateExternalError, selectedGates]);
+    setGateError(!selectedGates || selectedGates.length === 0);
+  }, [gateError, selectedGates]);
+
+  // validate fields when validate is true
+  useEffect(() => {
+    if (validate) {
+      setProjectCodeError(!selectedProject);
+      setModelYearError(!selectedModelYear);
+      setVariantError(!selectedVariants || selectedVariants.length === 0);
+      setGateError(!selectedGates || selectedGates.length === 0);
+    }
+  }, [
+    selectedGates,
+    selectedModelYear,
+    selectedProject,
+    selectedVariants,
+    validate
+  ]);
 
   // check if the project, model year or variant fields are disabled
   const modelYearIsDisabled =

--- a/src/VehicleSelector/VehicleSelector.tsx
+++ b/src/VehicleSelector/VehicleSelector.tsx
@@ -15,6 +15,7 @@ function VehicleSelector({
   disabled = false,
   errors,
   flexDirection = "column",
+  validateOnInit,
   limitTags = 1,
   flexWrap = "nowrap",
   gates = [],
@@ -24,11 +25,13 @@ function VehicleSelector({
   value = [],
   variants = []
 }: VehicleSelectorProps) {
+  // selector has errors
+  const hasErrors = errors && errors.length > 0;
   // state to track errors
-  const projectCodeExternalError = errors && errors.includes("projectCode");
-  const modelYearExternalError = errors && errors.includes("modelYear");
-  const variantExternalError = errors && errors.includes("variant");
-  const gateExternalError = errors && errors.includes("gate");
+  const projectCodeExternalError = hasErrors && errors.includes("projectCode");
+  const modelYearExternalError = hasErrors && errors.includes("modelYear");
+  const variantExternalError = hasErrors && errors.includes("variant");
+  const gateExternalError = hasErrors && errors.includes("gate");
 
   // flags indicating whether the user has manually cleared a field.
   const [userClearedModelYear, setUserClearedModelYear] = useState(false);
@@ -46,7 +49,7 @@ function VehicleSelector({
     modelYearExternalError
   );
   const [projectCodeError, setProjectCodeError] = useState<boolean | undefined>(
-    projectCodeExternalError
+    validateOnInit || projectCodeExternalError
   );
 
   // derive state for selected project

--- a/src/VehicleSelector/VehicleSelector.types.ts
+++ b/src/VehicleSelector/VehicleSelector.types.ts
@@ -54,6 +54,10 @@ export type VehicleSelectorProps = {
    */
   onChange: (value: Vehicle[]) => void;
   /**
+   * Validate the field on initialization
+   */
+  validateOnInit: boolean;
+  /**
    * The currently selected vehicles
    */
   value: Vehicle[];

--- a/src/VehicleSelector/VehicleSelector.types.ts
+++ b/src/VehicleSelector/VehicleSelector.types.ts
@@ -54,9 +54,9 @@ export type VehicleSelectorProps = {
    */
   onChange: (value: Vehicle[]) => void;
   /**
-   * Validate the field on initialization
+   * Validate the fields
    */
-  validateOnInit: boolean;
+  validate: boolean;
   /**
    * The currently selected vehicles
    */

--- a/src/VehicleSelector/VehicleSelector.types.ts
+++ b/src/VehicleSelector/VehicleSelector.types.ts
@@ -33,11 +33,6 @@ export type VehicleSelectorProps = {
    */
   disabled?: boolean;
   /**
-   * The field errors if setting errors is required externally
-   * Errors will be set whether field has a value or not
-   */
-  errors?: ("projectCode" | "modelYear" | "variant" | "gate")[];
-  /**
    * FlexDirection of the component
    */
   flexDirection?: string;

--- a/src/VehicleSelector/VehicleSelector.types.ts
+++ b/src/VehicleSelector/VehicleSelector.types.ts
@@ -56,7 +56,7 @@ export type VehicleSelectorProps = {
   /**
    * Validate the fields
    */
-  validate: boolean;
+  validate?: boolean;
   /**
    * The currently selected vehicles
    */


### PR DESCRIPTION
Closes [TD-3479](https://sce.myjetbrains.com/youtrack/issue/TD-3479/VehicleSelector-error-handling)

## Changes

Ensures errors appear onBlur. Adds a prop to force the validation of all fields

- Add a "validate" prop to validate active fields
- Ensure fields are validated on blur
- When validate prop is true, set all error states

## Testing notes

In storybook, check that empty fields show an error on blur by default. Check that an error appears with the validate prop is set to true (there is a validate story). Check that errors disappear when the field has a valid value.

## Author checklist

Before I request a review:

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~[x] I have populated the deploy-preview with relevant test data.~
- [x] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
