### PR TITLE
TD-3527 Update VersionChip to support single digits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.5.0",
+  "version": "12.6.0-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/VersionChip/VersionChip.stories.tsx
+++ b/src/VersionChip/VersionChip.stories.tsx
@@ -26,7 +26,7 @@ export const Default = {
   render: Template
 };
 
-export const WholeNumber = {
+export const SingleDigit = {
   args: {
     selected: false,
     version: "1"
@@ -44,7 +44,7 @@ export const MinorVersion = {
   render: Template
 };
 
-export const WholeNumberSelected = {
+export const SingleDigitSelected = {
   args: {
     selected: true,
     version: "1"

--- a/src/VersionChip/VersionChip.stories.tsx
+++ b/src/VersionChip/VersionChip.stories.tsx
@@ -26,10 +26,28 @@ export const Default = {
   render: Template
 };
 
+export const WholeNumber = {
+  args: {
+    selected: false,
+    version: "1"
+  },
+
+  render: Template
+};
+
 export const MinorVersion = {
   args: {
     selected: false,
     version: "1.1"
+  },
+
+  render: Template
+};
+
+export const WholeNumberSelected = {
+  args: {
+    selected: true,
+    version: "1"
   },
 
   render: Template

--- a/src/VersionChip/VersionChip.test.tsx
+++ b/src/VersionChip/VersionChip.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 
 import React from "react";
@@ -58,24 +58,13 @@ describe("VersionChip", () => {
     expect(styles.border).toBe("1px solid rgba(0, 0, 0, 0.23)");
   });
 
-  // mock console.warn to suppress warnings in test output
-  const consoleWarnMock = vi
-    .spyOn(console, "warn")
-    .mockImplementation(() => {});
-
-  // Clear mock before each test
-  beforeEach(() => {
-    process.env.NODE_ENV = "development";
-    consoleWarnMock.mockClear();
-  });
-
-  // restore console.warn after all tests
-  afterAll(() => {
-    consoleWarnMock.mockRestore();
-  });
-
-  // Check if warning is logged for invalid version format
+  // check if warning is logged for invalid version format
   it("logs a warning for an invalid version format", async () => {
+    // mock console.warn to detect if a warning is logged
+    const consoleWarnMock = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
     render(<VersionChip version="invalid-version" />);
 
     await waitFor(() => {
@@ -83,5 +72,6 @@ describe("VersionChip", () => {
         'Invalid version format: "invalid-version". Expected format is "<major>" or <major>.<minor>" (e.g., "1" or "1.0").'
       );
     });
+    consoleWarnMock.mockRestore();
   });
 });

--- a/src/VersionChip/VersionChip.test.tsx
+++ b/src/VersionChip/VersionChip.test.tsx
@@ -6,9 +6,19 @@ import VersionChip from "./VersionChip";
 
 describe("VersionChip", () => {
   // test that the version chip renders
+  it("renders when version is single digit", () => {
+    render(<VersionChip version="1"></VersionChip>);
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+  // test that the version chip renders
   it("renders VersionChip", () => {
     render(<VersionChip version="1.0"></VersionChip>);
     expect(screen.getByText("1.0")).toBeInTheDocument();
+  });
+  // check single digit major version has correct svg
+  it("renders major svg", () => {
+    render(<VersionChip version="1"></VersionChip>);
+    expect(screen.getByTestId("LayersIcon")).toBeInTheDocument();
   });
   // check major version has correct svg
   it("renders major svg", () => {

--- a/src/VersionChip/VersionChip.test.tsx
+++ b/src/VersionChip/VersionChip.test.tsx
@@ -76,7 +76,7 @@ describe("VersionChip", () => {
 
   // Check if warning is logged for invalid version format
   it("logs a warning for an invalid version format", async () => {
-    render(<VersionChip version="ab" />);
+    render(<VersionChip version="invalid-version" />);
 
     await waitFor(() => {
       expect(consoleWarnMock).toHaveBeenCalledWith(

--- a/src/VersionChip/VersionChip.test.tsx
+++ b/src/VersionChip/VersionChip.test.tsx
@@ -45,7 +45,7 @@ describe("VersionChip", () => {
     const styles = window.getComputedStyle(chipElement);
     // passing resolved color from alpha(theme.palette.info.main, 0.12) and theme.palette.primary.main
     expect(styles.backgroundColor).toBe("rgba(2, 136, 209, 0.12)");
-    expect(styles.border).toBe("1px solid #1976d2"); //
+    expect(styles.border).toBe("1px solid #1976d2");
   });
 
   // check background color when the `selected` prop is false
@@ -58,7 +58,6 @@ describe("VersionChip", () => {
     expect(styles.border).toBe("1px solid rgba(0, 0, 0, 0.23)");
   });
 
-  // Check if warning is logged for invalid version format
   // mock console.warn to suppress warnings in test output
   const consoleWarnMock = vi
     .spyOn(console, "warn")
@@ -75,8 +74,9 @@ describe("VersionChip", () => {
     consoleWarnMock.mockRestore();
   });
 
+  // Check if warning is logged for invalid version format
   it("logs a warning for an invalid version format", async () => {
-    render(<VersionChip version="invalid-version" />);
+    render(<VersionChip version="ab" />);
 
     await waitFor(() => {
       expect(consoleWarnMock).toHaveBeenCalledWith(

--- a/src/VersionChip/VersionChip.test.tsx
+++ b/src/VersionChip/VersionChip.test.tsx
@@ -1,12 +1,14 @@
-import { describe, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 
 import React from "react";
 import VersionChip from "./VersionChip";
 
 describe("VersionChip", () => {
   // test that the version chip renders
-  it("renders when version is single digit", () => {
+  it("renders when version is a single digit", () => {
     render(<VersionChip version="1"></VersionChip>);
     expect(screen.getByText("1")).toBeInTheDocument();
   });
@@ -16,7 +18,7 @@ describe("VersionChip", () => {
     expect(screen.getByText("1.0")).toBeInTheDocument();
   });
   // check single digit major version has correct svg
-  it("renders major svg", () => {
+  it("renders major svg, when version is a single digit", () => {
     render(<VersionChip version="1"></VersionChip>);
     expect(screen.getByTestId("LayersIcon")).toBeInTheDocument();
   });
@@ -25,7 +27,7 @@ describe("VersionChip", () => {
     render(<VersionChip version="1.0"></VersionChip>);
     expect(screen.getByTestId("LayersIcon")).toBeInTheDocument();
   });
-  // check nothing is rendered if version wrong format
+  // check nothing is rendered if version format is wrong
   it("doesn't render when version is wrong format", () => {
     render(<VersionChip version="1.1.1"></VersionChip>);
     expect(screen.queryByText("1.1.1")).not.toBeInTheDocument();
@@ -34,5 +36,52 @@ describe("VersionChip", () => {
   it("renders minor svg", () => {
     render(<VersionChip version="1.1"></VersionChip>);
     expect(screen.getByTestId("AccountTreeIcon")).toBeInTheDocument();
+  });
+
+  // check background color when the `selected` prop is true
+  it("applies correct background color when `selected` is true", () => {
+    render(<VersionChip version="1.0" selected={true} />);
+    const chipElement = screen.getByTestId("version-chip");
+    const styles = window.getComputedStyle(chipElement);
+    // passing resolved color from alpha(theme.palette.info.main, 0.12) and theme.palette.primary.main
+    expect(styles.backgroundColor).toBe("rgba(2, 136, 209, 0.12)");
+    expect(styles.border).toBe("1px solid #1976d2"); //
+  });
+
+  // check background color when the `selected` prop is false
+  it("applies correct background color when `selected` is false", () => {
+    render(<VersionChip version="1.0" selected={false} />);
+    const chipElement = screen.getByTestId("version-chip");
+    const styles = window.getComputedStyle(chipElement);
+    // resolved color from alpha(theme.palette.divider, 0.23) and theme.palette.background.default
+    expect(styles.backgroundColor).toBe("rgb(255, 255, 255)");
+    expect(styles.border).toBe("1px solid rgba(0, 0, 0, 0.23)");
+  });
+
+  // Check if warning is logged for invalid version format
+  // mock console.warn to suppress warnings in test output
+  const consoleWarnMock = vi
+    .spyOn(console, "warn")
+    .mockImplementation(() => {});
+
+  // Clear mock before each test
+  beforeEach(() => {
+    process.env.NODE_ENV = "development";
+    consoleWarnMock.mockClear();
+  });
+
+  // restore console.warn after all tests
+  afterAll(() => {
+    consoleWarnMock.mockRestore();
+  });
+
+  it("logs a warning for an invalid version format", async () => {
+    render(<VersionChip version="invalid-version" />);
+
+    await waitFor(() => {
+      expect(consoleWarnMock).toHaveBeenCalledWith(
+        'Invalid version format: "invalid-version". Expected format is "<major>" or <major>.<minor>" (e.g., "1" or "1.0").'
+      );
+    });
   });
 });

--- a/src/VersionChip/VersionChip.tsx
+++ b/src/VersionChip/VersionChip.tsx
@@ -61,23 +61,26 @@ const VersionChip = ({ version, selected = false }: VersionChipProps) => {
 export default VersionChip;
 
 /**
- * A function that returns the minor version, will return `undefined` if format doesn't match number.number
+ * A function that returns the minor version,
+ * Returns `undefined` if the format is invalid.
+ * Accepts formats like "1" or "1.0" but not "1.1.1".
  */
 const getMinorVersion = (version: string) => {
-  // check format is number.number
-  const regex = /^\d+\.\d+$/;
+  // allow whole numbers or "major.minor" format (e.g., "1" or "1.0")
+  const regex = /^\d+(\.\d+)?$/;
+  console.log("Version being tested:", version);
 
-  // Check if the input matches the "number.number" format
+  // validate format
   if (!regex.test(version)) {
-    // check if dev environment and log warning
     if (process.env.NODE_ENV === "development") {
       console.warn(
-        `Version: ${version} is of a wrong format. Format expected is "<major>.<minor>" (e.g., "1.0").`
+        `Invalid version format: "${version}". Expected format is "<major>" or <major>.<minor>" (e.g., "1" or "1.0").`
       );
     }
-    // undefined indicates error (minor version could not be extracted)
+    // return undefined for invalid input
     return undefined;
   }
-  // return minor version
-  return version.split(".")[1];
+
+  // return minor version or "0" if missing
+  return version.split(".")[1] ?? "0";
 };

--- a/src/VersionChip/VersionChip.tsx
+++ b/src/VersionChip/VersionChip.tsx
@@ -68,7 +68,6 @@ export default VersionChip;
 const getMinorVersion = (version: string) => {
   // allow whole numbers or "major.minor" format (e.g., "1" or "1.0")
   const regex = /^\d+(\.\d+)?$/;
-  console.log("Version being tested:", version);
 
   // validate format
   if (!regex.test(version)) {

--- a/src/VersionChip/VersionChip.tsx
+++ b/src/VersionChip/VersionChip.tsx
@@ -72,7 +72,10 @@ const getMinorVersion = (version: string) => {
 
   // validate format
   if (!regex.test(version)) {
-    if (process.env.NODE_ENV === "development") {
+    if (
+      process.env.NODE_ENV === "development" ||
+      process.env.NODE_ENV === "test"
+    ) {
       console.warn(
         `Invalid version format: "${version}". Expected format is "<major>" or <major>.<minor>" (e.g., "1" or "1.0").`
       );

--- a/src/VersionChip/VersionChip.tsx
+++ b/src/VersionChip/VersionChip.tsx
@@ -22,6 +22,7 @@ const VersionChip = ({ version, selected = false }: VersionChipProps) => {
     // return VersionChip component
     return (
       <Chip
+        data-testid="version-chip"
         icon={versionType === "major" ? <Layers /> : <AccountTree />}
         label={version}
         variant="filled"
@@ -66,7 +67,7 @@ export default VersionChip;
  * Accepts formats like "1" or "1.0" but not "1.1.1".
  */
 const getMinorVersion = (version: string) => {
-  // allow whole numbers or "major.minor" format (e.g., "1" or "1.0")
+  // allow single digit or "major.minor" format (e.g., "1" or "1.0")
   const regex = /^\d+(\.\d+)?$/;
 
   // validate format


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Closes  [TD-3527](https://sce.myjetbrains.com/youtrack/issue/TD-3527/Update-VersionChip-to-Support-Whole-Numbers)

## Changes

<!-- Let the reviewer know the high-level and detailed changes to look out for -->
<!-- For a bug, this section could instead be bug description & resolution -->

A brief description of what this pull request solves / introduces.

Currently, the VersionChip only supports decimal formats like 1.2 ("major.minor"). Update the function to also allow whole numbers like 1.

1. Updated the regex to allow both whole numbers (1) and decimal numbers (1.2).

2. Modified the function to handle cases where the minor version is missing (defaulting it to "0" if needed).



## Dependencies

<!-- Does this branch need to be tested alongside branches from other apps? -->
<!-- Does this branch need to be merged after another Pull Request? -->
NA

## UI/UX

<!-- Add in screen grabs / screen recordings of the feature. Tag the UI/UX designer if you require specific feedback / approval -->
<!-- If this PR solves a bug, consider including a before and after so that the reviewer can reproduce and confirm fixed -->
NA

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

Run `pnpm Storybook` , Go to `VersionChip`, then test the below .

1. **Whole Number Support**  
   - Test with `1` → Should be accepted.

2. **Decimal Number Support**  
   - Test with `1.0` → Should be accepted.
   - Test with `1.2` → Should be accepted as is.  

4. **Invalid Format Handling**  
   - Test with `1.2.3` →  Should not be accepted and log a warning .
   - Test with `abc` →  Should not be accepted and log a warning.  


## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in ~Docker / a deploy-preview~ stroryBook.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
~[ ] I have populated the deploy-preview with relevant test data.~
~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
