### PR TITLE
TD-3529 LinePlot supports secondary data set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.5.0-0",
+  "version": "12.5.0-1",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.4.0",
+  "version": "12.5.0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.5.0",
+  "version": "12.5.0-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/LinePlot/LinePlot.stories.tsx
+++ b/src/LinePlot/LinePlot.stories.tsx
@@ -98,7 +98,6 @@ export const OverlayPlots = {
     fullscreenTitle: "A plot in fullscreen mode",
     legendNameFirst: "First Line Plot",
     legendNameSecond: "Second Line Plot",
-    showGrid: false,
     showMarkers: true,
     title: "",
     xdata: [0, 1, 2, 3, 4, 5],

--- a/src/LinePlot/LinePlot.stories.tsx
+++ b/src/LinePlot/LinePlot.stories.tsx
@@ -91,3 +91,22 @@ export const ScientificNotation = {
   },
   render: Template
 };
+
+// Overlay Plots
+export const OverlayPlots = {
+  args: {
+    fullscreenTitle: "A plot in fullscreen mode",
+    legendName1: "First Line Plot",
+    legendName2: "Second Line Plot",
+    showGrid: false,
+    showMarkers: true,
+    title: "",
+    xdata: [0, 1, 2, 3, 4, 5],
+    xdata2: [0, 1, 2, 3, 4, 5],
+    xlabel: "X label (rad)",
+    ydata: [0, 3, 6, 4, 5, 2],
+    ydata2: [0, 4, 7, 8, 3, 6],
+    ylabel: "Y label (Nm)"
+  },
+  render: Template
+};

--- a/src/LinePlot/LinePlot.stories.tsx
+++ b/src/LinePlot/LinePlot.stories.tsx
@@ -56,7 +56,7 @@ export const Default = {
     title: "",
     xdata: [0, 1, 2, 3, 4, 5],
     xlabel: "X label (rad)",
-    ydata: [0, 20, 30, 40, 50],
+    ydata: [0, 20, 30, 40, 50, 60],
     ylabel: "Y label (Nm)"
   },
   render: Template

--- a/src/LinePlot/LinePlot.stories.tsx
+++ b/src/LinePlot/LinePlot.stories.tsx
@@ -96,16 +96,16 @@ export const ScientificNotation = {
 export const OverlayPlots = {
   args: {
     fullscreenTitle: "A plot in fullscreen mode",
-    legendName1: "First Line Plot",
-    legendName2: "Second Line Plot",
+    legendNameFirst: "First Line Plot",
+    legendNameSecond: "Second Line Plot",
     showGrid: false,
     showMarkers: true,
     title: "",
     xdata: [0, 1, 2, 3, 4, 5],
-    xdata2: [0, 1, 2, 3, 4, 5],
+    xdataSecond: [0, 1, 2, 3, 4, 5],
     xlabel: "X label (rad)",
     ydata: [0, 3, 6, 4, 5, 2],
-    ydata2: [0, 4, 7, 8, 3, 6],
+    ydataSecond: [0, 4, 7, 8, 3, 6],
     ylabel: "Y label (Nm)"
   },
   render: Template

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -157,7 +157,7 @@ const LinePlot = ({
             margin: { b: 60, l: 100, r: 10, t: 30 },
             paper_bgcolor: "transparent",
             plot_bgcolor: "transparent",
-            showlegend: !!(legendNameFirst !== "" && legendNameSecond !== ""),
+            showlegend: !!(legendNameFirst && legendNameSecond),
             xaxis: {
               color: theme.palette.text.primary,
               gridcolor: theme.palette.divider,

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -18,8 +18,12 @@ import Plotly from "react-plotly.js";
 const LinePlot = ({
   fullscreenTitle = "",
   title = "",
+  legendName1 = "",
+  legendName2 = "",
   xdata = [],
   ydata = [],
+  xdata2 = [],
+  ydata2 = [],
   xlabel = "",
   ylabel = "",
   showMarkers = true,
@@ -117,17 +121,44 @@ const LinePlot = ({
               line: { color: theme.palette.primary.main, width: 2 },
               marker: { color: theme.palette.primary.dark, size: 7 },
               mode: showMarkers ? "lines+markers" : "lines",
+              name: legendName1 || "",
               type: "scatter",
               x: xdata,
               y: ydata
-            }
+            },
+            ...(xdata2.length > 0 && ydata2.length > 0
+              ? ([
+                  {
+                    line: { color: theme.palette.secondary.main, width: 2 },
+                    marker: { color: theme.palette.secondary.dark, size: 7 },
+                    mode: showMarkers ? "lines+markers" : "lines",
+                    name: legendName2 || "",
+                    type: "scatter",
+                    x: xdata2,
+                    y: ydata2
+                  }
+                ] as Plotly.Data[])
+              : [])
           ]}
           layout={{
             autosize: true,
             font: { family: "Montserrat, sans-serif" },
+            legend: {
+              font: {
+                color: theme.palette.text.primary,
+                size: 12
+              },
+              orientation: "v",
+              x: 0.5,
+              xanchor: "center",
+              y: 1.05,
+              yanchor: "bottom"
+            },
             margin: { b: 60, l: 100, r: 10, t: 30 },
             paper_bgcolor: "transparent",
             plot_bgcolor: "transparent",
+            // only show legend if there are multiple traces
+            showlegend: !!(xdata2.length > 0 && ydata2.length > 0),
             xaxis: {
               color: theme.palette.text.primary,
               gridcolor: theme.palette.divider,

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -157,8 +157,7 @@ const LinePlot = ({
             margin: { b: 60, l: 100, r: 10, t: 30 },
             paper_bgcolor: "transparent",
             plot_bgcolor: "transparent",
-            // only show legend if there are multiple traces
-            showlegend: !!(xdata2.length > 0 && ydata2.length > 0),
+            showlegend: !!(legendName1 !== "" && legendName2 !== ""),
             xaxis: {
               color: theme.palette.text.primary,
               gridcolor: theme.palette.divider,

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -18,12 +18,12 @@ import Plotly from "react-plotly.js";
 const LinePlot = ({
   fullscreenTitle = "",
   title = "",
-  legendName1 = "",
-  legendName2 = "",
+  legendNameFirst = "",
+  legendNameSecond = "",
   xdata = [],
   ydata = [],
-  xdata2 = [],
-  ydata2 = [],
+  xdataSecond = [],
+  ydataSecond = [],
   xlabel = "",
   ylabel = "",
   showMarkers = true,
@@ -121,21 +121,21 @@ const LinePlot = ({
               line: { color: theme.palette.primary.main, width: 2 },
               marker: { color: theme.palette.primary.dark, size: 7 },
               mode: showMarkers ? "lines+markers" : "lines",
-              name: legendName1 || "",
+              name: legendNameFirst || "",
               type: "scatter",
               x: xdata,
               y: ydata
             },
-            ...(xdata2.length > 0 && ydata2.length > 0
+            ...(xdataSecond.length > 0 && ydataSecond.length > 0
               ? ([
                   {
                     line: { color: theme.palette.secondary.main, width: 2 },
                     marker: { color: theme.palette.secondary.dark, size: 7 },
                     mode: showMarkers ? "lines+markers" : "lines",
-                    name: legendName2 || "",
+                    name: legendNameSecond || "",
                     type: "scatter",
-                    x: xdata2,
-                    y: ydata2
+                    x: xdataSecond,
+                    y: ydataSecond
                   }
                 ] as Plotly.Data[])
               : [])
@@ -157,7 +157,7 @@ const LinePlot = ({
             margin: { b: 60, l: 100, r: 10, t: 30 },
             paper_bgcolor: "transparent",
             plot_bgcolor: "transparent",
-            showlegend: !!(legendName1 !== "" && legendName2 !== ""),
+            showlegend: !!(legendNameFirst !== "" && legendNameSecond !== ""),
             xaxis: {
               color: theme.palette.text.primary,
               gridcolor: theme.palette.divider,

--- a/src/LinePlot/LinePlot.types.ts
+++ b/src/LinePlot/LinePlot.types.ts
@@ -21,11 +21,11 @@ export type LinePlotProps = {
   /**
    * Legend name for the first plot.
    */
-  legendName1?: string;
+  legendNameFirst?: string;
   /**
    * Legend name for the second plot.
    */
-  legendName2?: string;
+  legendNameSecond?: string;
   /**
    * Arrays of numbers that represent the X coordinates of the points to be plotted.
    */
@@ -33,7 +33,7 @@ export type LinePlotProps = {
   /**
    * Arrays of numbers that represent the second X coordinates of the points to be plotted.
    */
-  xdata2?: number[];
+  xdataSecond?: number[];
   /**
    * Label for the X axis.
    */
@@ -45,7 +45,7 @@ export type LinePlotProps = {
   /**
    * Arrays of numbers that represent the second Y coordinates of the points to be plotted.
    */
-  ydata2?: number[];
+  ydataSecond?: number[];
   /**
    * Label for the Y axis.
    */

--- a/src/LinePlot/LinePlot.types.ts
+++ b/src/LinePlot/LinePlot.types.ts
@@ -19,9 +19,21 @@ export type LinePlotProps = {
    */
   title?: string;
   /**
+   * Legend name for the first plot.
+   */
+  legendName1?: string;
+  /**
+   * Legend name for the second plot.
+   */
+  legendName2?: string;
+  /**
    * Arrays of numbers that represent the X coordinates of the points to be plotted.
    */
   xdata: number[];
+  /**
+   * Arrays of numbers that represent the second X coordinates of the points to be plotted.
+   */
+  xdata2?: number[];
   /**
    * Label for the X axis.
    */
@@ -30,6 +42,10 @@ export type LinePlotProps = {
    * Arrays of numbers that represent the Y coordinates of the points to be plotted.
    */
   ydata: number[];
+  /**
+   * Arrays of numbers that represent the second Y coordinates of the points to be plotted.
+   */
+  ydata2?: number[];
   /**
    * Label for the Y axis.
    */


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Closes [TD-3529](https://sce.myjetbrains.com/youtrack/issue/TD-3529/Update-LinePlot-to-support-multiple-data-sets)

## Changes
This PR enhances `LinePlot`  by adding support for secondary data, enabling a combined view for multi-line plots.

- Added `ydataSecond` and `ydataSecond` optional props for secondary data set
- If `ydataSecond` and `ydataSecond` are avilable a second line will render with different color as per Figma
- Addded `legendNameFirst` and `legendNameSecond` to display Legend names
- New `Overlay Plots` story added

## UI/UX
Figma: https://www.figma.com/design/s2NuBwBayu8144EGjBCi5d/VIRTO.DATA?node-id=7703-217643&t=OMsPT8a8Q9kRP4BX-0

Storybook
![Screenshot 2025-04-02 221312](https://github.com/user-attachments/assets/9973d344-aaca-497f-9367-8799360a9117)

VIRTO.DATA
![Screenshot 2025-04-02 221346](https://github.com/user-attachments/assets/069b2c5d-ad3b-47c8-9881-a83500e1f14e)
![Screenshot 2025-04-02 215834](https://github.com/user-attachments/assets/3b25e1df-f056-4160-9edf-789bcdb9809c)
![Screenshot 2025-04-02 221359](https://github.com/user-attachments/assets/e47d565d-55bb-48b0-8a7e-e47979cca941)
![Screenshot 2025-04-02 215850](https://github.com/user-attachments/assets/a80d9510-bd64-46b6-a72f-e2cc7b7937a4)

## Testing notes

- Verify default story still works fine
- Verify `Overlay Plots` shows two lines if there are `ydataSecond` and `ydataSecond`, with same colors as Figma
- Verify `Overlay Plots` only shows both legends if `legendNameFirst` and `legendNameSecond` are available

**Note:** Figma is using MUI Plots, it is agreed with @Sowbhagya-ipg to go with current `LinePlot` styles we have, especially you may notice a change in Legends style. Please ignore it, we are following default [Plotly](https://plotly.com/javascript/legend/#legend-names)  settings.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~[ ] I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- [x] I have populated the deploy-preview with relevant test data.
- ~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
