### PR TITLE
TD-3539 Remove legend showing in tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.5.0-1",
+  "version": "12.5.0-2",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -118,6 +118,7 @@ const LinePlot = ({
         <Plotly
           data={[
             {
+              hoverinfo: "x+y",
               line: { color: theme.palette.primary.main, width: 2 },
               marker: { color: theme.palette.primary.dark, size: 7 },
               mode: showMarkers ? "lines+markers" : "lines",
@@ -129,6 +130,7 @@ const LinePlot = ({
             ...(xdataSecond.length > 0 && ydataSecond.length > 0
               ? ([
                   {
+                    hoverinfo: "x+y",
                     line: { color: theme.palette.secondary.main, width: 2 },
                     marker: { color: theme.palette.secondary.dark, size: 7 },
                     mode: showMarkers ? "lines+markers" : "lines",


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Contributes [TD-3529](https://sce.myjetbrains.com/youtrack/issue/TD-3529/Update-LinePlot-to-support-multiple-data-sets)


This PR is to add a fix for a comment recieved [here](https://github.com/IPG-Automotive-UK/virto/pull/1505#issuecomment-2777879613)

## Changes

- Only shows `x` and `y` values on Tooltip

## UI/UX

Before
![Screenshot 2025-04-04 120052](https://github.com/user-attachments/assets/7defc8ce-4498-4c98-9c02-730bb178521e)

After
![Screenshot 2025-04-04 120110](https://github.com/user-attachments/assets/bba9802a-22cd-4a46-9ed5-bb24ffcfe115)

## Testing notes

- Vefify `Legend` not shown with `LinePlot` marker tooltips

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~[ ] I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- [x] I have populated the deploy-preview with relevant test data.
- ~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
