### PR TITLE
VE-397 UI lag when applying scenario filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.5.2-0",
+  "version": "12.5.2-1",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.5.1",
+  "version": "12.5.2-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/LabelSelector/LabelChipGroup/LabelChipGroup.tsx
+++ b/src/LabelSelector/LabelChipGroup/LabelChipGroup.tsx
@@ -11,12 +11,8 @@ import { sortLabelChips } from "./sortLabelChips";
  * The LabelChipGroup component. This component displays a group of LabelChip components in a row. If any of the chips overflow the parent container width, they will be hidden and a popover will be used to show the hidden chips. The chips are sorted by length first, then alphabetically.
  */
 export default function LabelChipGroup({ chips }: LabelChipGroupProps) {
-  // sort the chips, shortest first, then alphabetically
-  const sortedChips = sortLabelChips(chips);
-
-  const cachedSortedChips = React.useMemo(() => {
-    return sortedChips;
-  }, [sortedChips]);
+  // memoize the sorted chips to ensure stable reference across renders and avoid re-sorting unless the input changes, a copy is made before sorting to prevent mutating the original 'chips' prop.
+  const sortedChips = React.useMemo(() => sortLabelChips([...chips]), [chips]);
 
   // store a ref to the parent container so we can check size information and calculate if the chips overflow
   const parentRef = React.useRef<HTMLDivElement>(null);
@@ -26,11 +22,13 @@ export default function LabelChipGroup({ chips }: LabelChipGroupProps) {
 
   // store array of booleans to flag if each chip is overflowing or not
   const [isChipOverflowing, setIsChipOverflowing] = React.useState<boolean[]>(
-    Array(chips.length).fill(false)
+    Array(sortedChips.length).fill(false)
   );
 
   // filter all available chips to find only those that are overflowing so we can show them in the popover
-  const overflowingChips = chips.filter((_, index) => isChipOverflowing[index]);
+  const overflowingChips = sortedChips.filter(
+    (_, index) => isChipOverflowing[index]
+  );
 
   // state to store if the popover is open and the anchor element for the popover
   const [popoverOpen, setPopoverOpen] = React.useState(false);
@@ -88,7 +86,7 @@ export default function LabelChipGroup({ chips }: LabelChipGroupProps) {
         resizeObserver.disconnect();
       };
     }
-  }, [cachedSortedChips, moreItemsRef, parentRef]);
+  }, [sortedChips, moreItemsRef, parentRef]);
 
   // custom onClick event handler for label chips shown in the popper to close the popper on click
   const handleOverflowingChipClick = (
@@ -115,7 +113,7 @@ export default function LabelChipGroup({ chips }: LabelChipGroupProps) {
       spacing={`${chipGap}px`}
       sx={{ overflow: "hidden", width: "100%" }}
     >
-      {chips.map((chip, index) => (
+      {sortedChips.map((chip, index) => (
         <LabelChip key={index} {...chip} visible={false} />
       ))}
       {overflowingChips.length > 0 ? (

--- a/src/LabelSelector/LabelChipGroup/LabelChipGroup.tsx
+++ b/src/LabelSelector/LabelChipGroup/LabelChipGroup.tsx
@@ -11,11 +11,12 @@ import { sortLabelChips } from "./sortLabelChips";
  * The LabelChipGroup component. This component displays a group of LabelChip components in a row. If any of the chips overflow the parent container width, they will be hidden and a popover will be used to show the hidden chips. The chips are sorted by length first, then alphabetically.
  */
 export default function LabelChipGroup({ chips }: LabelChipGroupProps) {
-  // take a copy of the chips prop so we can sort them without mutating the original
-  chips = [...chips];
-
   // sort the chips, shortest first, then alphabetically
-  chips = sortLabelChips(chips);
+  const sortedChips = sortLabelChips(chips);
+
+  const cachedSortedChips = React.useMemo(() => {
+    return sortedChips;
+  }, [sortedChips]);
 
   // store a ref to the parent container so we can check size information and calculate if the chips overflow
   const parentRef = React.useRef<HTMLDivElement>(null);
@@ -87,7 +88,7 @@ export default function LabelChipGroup({ chips }: LabelChipGroupProps) {
         resizeObserver.disconnect();
       };
     }
-  }, [chips, moreItemsRef, parentRef]);
+  }, [cachedSortedChips, moreItemsRef, parentRef]);
 
   // custom onClick event handler for label chips shown in the popper to close the popper on click
   const handleOverflowingChipClick = (


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Closes/Contributes [VE-397](https://sce.myjetbrains.com/youtrack/issue/VE-397/Intermittent-UI-Lag-When-Applying-Scenario-Filters)

This PR improves the `LabelChipGroup` component by preventing unnecessary re-renders due to the `ResizeObserver`.

What’s Changed:
- Used `useMemo` to cache the sorted list (cachedSortedChips).
- Updated `useEffect` to depend on the cached list instead of the raw chips prop.

**Note**: Previously, the chips prop was used directly in the dependency array of the `ResizeObserver` effect. Since chips is usually a new array on each render, this caused the effect to infinite re-renders.
By `memoizing` the sorted array and using it in the dependency array, we ensure stable references, which keeps the `useEffect` from firing more than needed and improves performance.

## Testing notes

<!-- Help the reviewer test your feature with some specific steps, point them towards test data and provide scripts or postman configs etc. -->

Please check this PR([1538](https://github.com/IPG-Automotive-UK/virto/pull/1538)) and follow the instructions under Testing Notes.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [ ] ~I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- [ ] ~I have populated the deploy-preview with relevant test data.~
- [ ] ~I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
