### PR TITLE
TD-3354 Update SurfacePlot for Enhanced Visual Flexibility with Theme-Based Colorscale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.5.2-1",
+  "version": "12.5.2-2",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.5.1",
+  "version": "12.5.2-1",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/SurfacePlot/SurfacePlot.tsx
+++ b/src/SurfacePlot/SurfacePlot.tsx
@@ -21,6 +21,9 @@ const SurfacePlot = ({
   // theme hook
   const theme = useTheme();
 
+  // chooses the color scale based on the theme mode
+  const colorScale = theme.plotlyColorScales;
+
   // state for fullscreen
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -97,6 +100,7 @@ const SurfacePlot = ({
                   weight: 400
                 }
               },
+              colorscale: colorScale,
               type: "surface",
               x: xdata,
               y: ydata,

--- a/src/SurfacePlot/SurfacePlot.tsx
+++ b/src/SurfacePlot/SurfacePlot.tsx
@@ -21,9 +21,6 @@ const SurfacePlot = ({
   // theme hook
   const theme = useTheme();
 
-  // chooses the color scale based on the theme mode
-  const colorScale = theme.plotlyColorScales;
-
   // state for fullscreen
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -100,7 +97,7 @@ const SurfacePlot = ({
                   weight: 400
                 }
               },
-              colorscale: colorScale,
+              colorscale: theme.plotlyColorScales,
               type: "surface",
               x: xdata,
               y: ydata,

--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -21,6 +21,8 @@ import darkScrollbar from "@mui/material/darkScrollbar";
 declare module "@mui/material/styles" {
   // allow configuration using `createTheme`
   // eslint-disable-next-line no-unused-vars
+
+  export type PlotlyColorScale = [number, string];
   interface ThemeOptions {
     layout?: {
       content?: {
@@ -31,6 +33,7 @@ declare module "@mui/material/styles" {
       dark?: ThemeOptions;
       light?: ThemeOptions;
     };
+    plotlyColorScales?: PlotlyColorScale[];
   }
   // eslint-disable-next-line no-unused-vars
   interface Theme {
@@ -43,6 +46,7 @@ declare module "@mui/material/styles" {
       dark?: ThemeOptions;
       light?: ThemeOptions;
     };
+    plotlyColorScales: PlotlyColorScale[];
   }
 }
 
@@ -309,6 +313,11 @@ const mainTheme: ThemeOptions = {
       minHeight: 64
     }
   },
+  plotlyColorScales: [
+    [0, "#3D5A75"],
+    [0.5, "#FFFFFF"],
+    [1, "#FFAF2C"]
+  ],
   typography: {
     allVariants: {
       fontFamily: "Montserrat, Arial, sans-serif"


### PR DESCRIPTION
Closes/Contributes- [TD-3554](https://sce.myjetbrains.com/youtrack/agiles/115-26/current?issue=TD-3554)

## Changes

This PR introduces a centralized color scale configuration for Plotly surface plots via the ThemeProvider.

- Added a new `plotlyColorScales` to the theme object.
- Refactored the `SurfacePlot` component to read the color scale from `theme.plotlyColorScale`



## Dependencies

<!-- Does this branch need to be tested alongside branches from other apps? -->
<!-- Does this branch need to be merged after another Pull Request? -->

## UI/UX
Tagging @Sowbhagya-ipg  to confirm the color scale usage aligns with design expectations.

Before
![image](https://github.com/user-attachments/assets/9cea44b1-dd02-4a43-af21-206cd46f3cfe)
![image](https://github.com/user-attachments/assets/f779978a-2650-41bf-a1b5-81a1990a0fcb)


After
![image](https://github.com/user-attachments/assets/e05c2093-591e-4b4a-900d-304e9fdd76fb)
![image](https://github.com/user-attachments/assets/889d4c66-3072-4b91-889a-8bd3f6b0faf0)


## Testing notes

- Check that the SurfacePlot still renders correctly in Storybook.

- Confirm the color scale reflects the centralized theme config.

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- ~I have populated the deploy-preview with relevant test data.~
- [x] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
