### PR TITLE
TD-3581- Truncate helpertext and add tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.6.2",
+  "version": "12.7.0-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/Wizard/WizardSteps/WizardStep/WizardStep.stories.tsx
+++ b/src/Wizard/WizardSteps/WizardStep/WizardStep.stories.tsx
@@ -56,3 +56,12 @@ export const WithErrorAndHelperText: Story = {
 
   render: Template
 };
+
+export const WithTooltipAndHelperText: Story = {
+  args: {
+    ...Default.args,
+    helperText: "This is a long helper text that should be truncated"
+  },
+
+  render: Template
+};

--- a/src/Wizard/WizardSteps/WizardStep/WizardStep.stories.tsx
+++ b/src/Wizard/WizardSteps/WizardStep/WizardStep.stories.tsx
@@ -57,7 +57,7 @@ export const WithErrorAndHelperText: Story = {
   render: Template
 };
 
-export const WithTooltipAndHelperText: Story = {
+export const WithHelperTextTooltip: Story = {
   args: {
     ...Default.args,
     helperText: "This is a long helper text that should be truncated"

--- a/src/Wizard/WizardSteps/WizardStep/WizardStep.test.tsx
+++ b/src/Wizard/WizardSteps/WizardStep/WizardStep.test.tsx
@@ -42,4 +42,19 @@ describe("WizardStep", () => {
       longHelperText
     );
   });
+  it("should not show tooltip when helperText is less than 30 characters", async () => {
+    const shortHelperText = "Short helper text.";
+    render(<WizardStep label="Step 1" helperText={shortHelperText} />);
+
+    // Helper text should be in the document
+    expect(screen.getByText(shortHelperText)).toBeInTheDocument();
+
+    const tooltipTrigger = screen.getByText(shortHelperText);
+
+    // Simulate hover
+    await userEvent.hover(tooltipTrigger);
+
+    // Tooltip should not be in the document
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
 });

--- a/src/Wizard/WizardSteps/WizardStep/WizardStep.test.tsx
+++ b/src/Wizard/WizardSteps/WizardStep/WizardStep.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 
 import React from "react";
 import WizardStep from "./WizardStep";
+import userEvent from "@testing-library/user-event";
 
 describe("WizardStep", () => {
   it("should render the label", () => {
@@ -18,5 +19,27 @@ describe("WizardStep", () => {
     );
     expect(screen.getByTestId("ErrorIcon")).toBeInTheDocument();
     expect(screen.getByText("Step 1")).toHaveClass("Mui-error");
+  });
+  it("should show tooltip on hover when helperText exceeds 30 characters", async () => {
+    const longHelperText =
+      "This helper text exceeds the thirty character limit.";
+    render(<WizardStep label="Step 1" helperText={longHelperText} />);
+
+    // Truncated text should be in the document
+    expect(
+      screen.getByText(longHelperText.slice(0, 30) + "...")
+    ).toBeInTheDocument();
+
+    const tooltipTrigger = screen.getByText(
+      longHelperText.slice(0, 30) + "..."
+    );
+
+    // Simulate hover
+    await userEvent.hover(tooltipTrigger);
+
+    // Wait for tooltip content to appear
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      longHelperText
+    );
   });
 });

--- a/src/Wizard/WizardSteps/WizardStep/WizardStep.tsx
+++ b/src/Wizard/WizardSteps/WizardStep/WizardStep.tsx
@@ -40,7 +40,7 @@ function WizardStepLabel({
   helperText,
   error
 }: Pick<WizardStepProps, "label" | "helperText" | "error">) {
-  // get context state
+  // Get context state
   const stepContext = useStepContext();
   let active: boolean, completed: boolean;
   if ("completed" in stepContext && "active" in stepContext) {

--- a/src/Wizard/WizardSteps/WizardStep/WizardStep.tsx
+++ b/src/Wizard/WizardSteps/WizardStep/WizardStep.tsx
@@ -5,6 +5,7 @@ import {
   StepLabel,
   StepLabelProps,
   SvgIcon,
+  Tooltip,
   Typography,
   useStepContext
 } from "@mui/material";
@@ -64,10 +65,27 @@ function WizardStepLabel({
       textColor = "textPrimary";
     }
 
+    // Set helpertext character limit to 30 characters
+    const helperTextMaxLimit = 30;
+    // Trim helper text and replace multiple spaces with a single space
+    const trimmedHelperText = helperText?.trim().replace(/\s+/g, " ");
+
+    // Truncate helper text if it more than 30 characters
+    const truncateHelperText = () => {
+      return trimmedHelperText.length > helperTextMaxLimit
+        ? trimmedHelperText.slice(0, helperTextMaxLimit) + "..."
+        : trimmedHelperText;
+    };
+
     stepLabelProps.optional = (
-      <Typography variant="caption" color={textColor}>
-        {helperText}
-      </Typography>
+      <Tooltip
+        title={helperText}
+        disableHoverListener={trimmedHelperText.length < helperTextMaxLimit}
+      >
+        <Typography variant="caption" color={textColor}>
+          {truncateHelperText()}
+        </Typography>
+      </Tooltip>
     );
   }
 


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Closes [TD-3581](https://sce.myjetbrains.com/youtrack/issue/TD-3581/Limit-step-1-helper-text-characters-in-FLEET)

## Changes

- Added function to truncate helper text if it exceeds 30 characters limit
- Added new story
- Added test to check `Tooltip` is eabled when characters exceeds.

## UI/UX
![Screenshot 2025-04-30 114734](https://github.com/user-attachments/assets/89a53a8f-f832-4687-b23c-53d6cd07972c)


Tested on FLEET
![39](https://github.com/user-attachments/assets/0af1a74d-3952-4031-acff-b2c5319d6725)

## Testing notes

- Check the `WizardStep` component and add a helper text which has morethan 30 characters and make sure this text is trucated and on hover a `Tooltip` with full text shown
- There a new`WithTooltipAndHelperText` story  to test this

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [x] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- [x] I have populated the deploy-preview with relevant test data.
- ~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
