### PR TITLE
TD-3579 - Limit legend characters in LinePlot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.6.2",
+  "version": "12.7.0-1",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -93,6 +93,20 @@ const LinePlot = ({
   // determine whether to show plot title
   const showTitle = title !== "";
 
+  // legend character limit
+  const legendCharLimit = 30;
+
+  // truncate legend names if they exceed 30 characters
+  const truncateLegend = (str: string) => {
+    // trim whitespace and replace multiple spaces with a single space
+    const trimmedLegend = str?.trim().replace(/\s+/g, " ");
+
+    // truncate legend name if it exceeds the character limit
+    return trimmedLegend.length > legendCharLimit
+      ? trimmedLegend.slice(0, legendCharLimit) + "..."
+      : trimmedLegend;
+  };
+
   return (
     <ConditionalDialog
       condition={isFullscreen}
@@ -124,7 +138,7 @@ const LinePlot = ({
               line: { color: theme.palette.primary.main, width: 2 },
               marker: { color: theme.palette.primary.dark, size: 7 },
               mode: showMarkers ? "lines+markers" : "lines",
-              name: legendNameFirst || "",
+              name: truncateLegend(legendNameFirst) || "",
               type: "scatter",
               x: xdata,
               y: ydata
@@ -136,7 +150,7 @@ const LinePlot = ({
                     line: { color: theme.palette.secondary.main, width: 2 },
                     marker: { color: theme.palette.secondary.dark, size: 7 },
                     mode: showMarkers ? "lines+markers" : "lines",
-                    name: legendNameSecond || "",
+                    name: truncateLegend(legendNameSecond) || "",
                     type: "scatter",
                     x: xdataSecond,
                     y: ydataSecond

--- a/src/LinePlot/LinePlot.tsx
+++ b/src/LinePlot/LinePlot.tsx
@@ -138,7 +138,7 @@ const LinePlot = ({
               line: { color: theme.palette.primary.main, width: 2 },
               marker: { color: theme.palette.primary.dark, size: 7 },
               mode: showMarkers ? "lines+markers" : "lines",
-              name: truncateLegend(legendNameFirst) || "",
+              name: legendNameFirst ? truncateLegend(legendNameFirst) : "",
               type: "scatter",
               x: xdata,
               y: ydata
@@ -150,7 +150,9 @@ const LinePlot = ({
                     line: { color: theme.palette.secondary.main, width: 2 },
                     marker: { color: theme.palette.secondary.dark, size: 7 },
                     mode: showMarkers ? "lines+markers" : "lines",
-                    name: truncateLegend(legendNameSecond) || "",
+                    name: legendNameSecond
+                      ? truncateLegend(legendNameSecond)
+                      : "",
                     type: "scatter",
                     x: xdataSecond,
                     y: ydataSecond


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant. This should be a clickable link -->
<!-- Pick relevant action word --->

Closes [TD-3579](https://sce.myjetbrains.com/youtrack/issue/TD-3579/Limit-legend-characters-in-LinePlot)

## Changes

- Added ability to `LinePlot` to truncate legend charactors if it exceeds 30 characters limit 


## UI/UX

![Screenshot 2025-05-01 151817](https://github.com/user-attachments/assets/158e0c60-f566-45e5-ba8e-af4d8b75533e)

Deploy-preview link to test on DATA and FLEET : http://k8s-deploypr-apigatew-2dbcc9a009-177696052.eu-west-2.elb.amazonaws.com/

## Author checklist

- Go to `LinePlot` in deploy preview
- Go to `Overlay Plots` story
- Update `legendNameFirst` and `legendNameSecond` to a very long string and verify it tuncate on UI aftr 30 characters


Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [x] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- ~[ ] I have included appropriate tests.~
- [x] I have checked that the Lint and Test workflows pass on Github.
- [x] I have populated the deploy-preview with relevant test data.
- ~[ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.~
