### PR TITLE
TD-3499 Fixed MUI datagrid border color not correct in dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.6.4-0",
+  "version": "12.6.4-1",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipguk/react-ui",
-  "version": "12.6.3",
+  "version": "12.6.4-0",
   "description": "React UI component library for IPG web applications",
   "author": {
     "name": "IPG-Automotive-UK"

--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -92,11 +92,8 @@ const paletteDefaultBackgroundPaperDark = "#182533";
 // palette tooltip color light mode or dark mode
 const paletteTooltipColor = "#3C4F67";
 
-// palette default divider color light mode
-const paletteDefaultDividerColorLight = "#E0E0E0";
-
-// palette default divider color dark mode
-const paletteDefaultDividerColorDark = "#343F4B";
+// datagrid dark mode border color
+const dataGridDarkBorderColor = "#343F4B";
 
 // 0.08 % of the primary light main
 const primaryLightColor08 = alpha(primaryLightMain, 0.08);
@@ -157,7 +154,10 @@ const defaultComponents = {
           borderColor: theme.palette.divider
         },
         "--DataGrid-rowBorderColor": theme.palette.divider,
-        borderColor: theme.palette.divider
+        // If the theme is dark, set the border color to the dataGridDarkBorderColor
+        ...(theme.palette.mode === "dark" && {
+          borderColor: dataGridDarkBorderColor
+        })
       })
     }
   },
@@ -247,7 +247,6 @@ const mainTheme: ThemeOptions = {
           default: paletteDefaultBackgroundDark,
           paper: paletteDefaultBackgroundPaperDark
         },
-        divider: paletteDefaultDividerColorDark,
         primary: {
           dark: primaryDarkDark,
           light: primaryDarkLight,
@@ -305,7 +304,6 @@ const mainTheme: ThemeOptions = {
           default: paletteDefaultBackgroundLight,
           paper: paletteDefaultBackgroundPaperLight
         },
-        divider: paletteDefaultDividerColorLight,
         primary: {
           dark: primaryLightDark,
           light: primaryLightLight,


### PR DESCRIPTION
Closes/Contributes [TD-3499](https://sce.myjetbrains.com/youtrack/issue/TD-3499/MUI-DataGrid-border-colour-not-correct-in-dark-mode)

## Changes

A brief description of what this pull request solves / introduces.

- Fixed the border color issue on MUI DataGrid in dark mode by applying solid color to the border

The MUI DataGrid border color looks different than its row border color even if the color value is same. This is due to the transparency of the border color. So, I have put a solid color value for the border in dark mode which solves the issue.

## Dependencies
N / A

## UI/UX
Before:
![{A632E93D-CF56-4E40-A25E-FC5EE750C25A}](https://github.com/user-attachments/assets/58600947-ded8-41ac-bde0-97f6e1def218)

After:
![{6B656D7A-5192-4BFE-8AAA-6CFB44239CAA}](https://github.com/user-attachments/assets/3fb72141-f248-443e-8e12-a6f13b333397)

## Testing notes
- Run pnpm storybook to launch the Storybook environment
- Switch to the dark mode
- Navigate to General > ThemeProvider > DataGrid and verify the border color and row divider color change, matching to other border colors(e.g. in paper components)

## Author checklist

Before I request a review:

<!-- Strikethrough any items that are not relevant to this PR -->

- [x] I have reviewed my own code-diff.
- [ ] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [ ] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- [x] I have populated the deploy-preview with relevant test data.
- [x] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
