### PR TITLE
TD-3573 Parameter selection vanishes when entering parameter set name

### DIFF
--- a/src/TransferList/TransferList.test.tsx
+++ b/src/TransferList/TransferList.test.tsx
@@ -386,6 +386,7 @@ describe("TransferList", () => {
     expect(unchangedSourceItems.length).toBe(3);
     expect(unchangedTargetItems.length).toBe(0);
 
+    // rerender with selectedItems as ["Apples", "Pears"]
     rerender(
       <TransferList
         items={defaultItemArray}
@@ -417,6 +418,10 @@ describe("TransferList", () => {
       "checked",
       false
     );
+
+    // Check that no transfer occurred, since the selectedItems list is directly controlled
+    // (no re-selection and transfer should happen unless selectedItems is updated)
+    expect(transferFn).toHaveBeenCalledTimes(1); // onChange should only be called once (on initial transfer)
   });
 
   test("select all checkboxes are disabled unless the relevant list has entries", () => {

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -13,7 +13,7 @@ import {
   TransferListItem,
   TransferListProps
 } from "./TransferList.types";
-import React, { useLayoutEffect, useState } from "react";
+import React, { useState } from "react";
 
 import SearchBar from "../SearchBar";
 
@@ -40,13 +40,6 @@ export default function TransferList({
   const [selectedItemKeys, setSelectedItemKeys] = useState<string[]>(
     defaultSelectedItems || []
   );
-
-  /**
-   * useEffect unselects items in the controlled component
-   */
-  useLayoutEffect(() => {
-    setChecked([]);
-  }, [selectedItems]);
 
   /**
    * Get primary label from item

--- a/src/TransferList/TransferList.tsx
+++ b/src/TransferList/TransferList.tsx
@@ -13,7 +13,7 @@ import {
   TransferListItem,
   TransferListProps
 } from "./TransferList.types";
-import React, { useState } from "react";
+import React, { useLayoutEffect, useRef, useState } from "react";
 
 import SearchBar from "../SearchBar";
 
@@ -40,6 +40,32 @@ export default function TransferList({
   const [selectedItemKeys, setSelectedItemKeys] = useState<string[]>(
     defaultSelectedItems || []
   );
+
+  // Keep track of the previous selected items
+  const prevSelectedItemsRef = useRef<string[]>();
+
+  useLayoutEffect(() => {
+    const prev = prevSelectedItemsRef.current;
+
+    // Utility function to convert an array to a Set
+    const toSet = (arr: string[] | undefined) => new Set(arr || []);
+
+    // Convert selectedItems and prev to Sets for easier comparison
+    const currentSet = toSet(selectedItems);
+    const prevSet = toSet(prev);
+
+    // Check if the selected items have changed
+    const hasChanged =
+      currentSet.size !== prevSet.size ||
+      [...currentSet].some(item => !prevSet.has(item));
+
+    if (hasChanged) {
+      setChecked([]);
+    }
+
+    // Update the selected item keys if selectedItems is provided
+    prevSelectedItemsRef.current = selectedItems;
+  }, [selectedItems]);
 
   /**
    * Get primary label from item


### PR DESCRIPTION
Closes/Contributes [TD-3573](https://sce.myjetbrains.com/youtrack/issue/TD-3573/Parameter-Selection-Vanishes-when-Entering-Parameter-Set-Name)

## Changes

The `useLayoutEffect` hook has been removed from the `TransferList` component.

It was unclear why it was originally included, but it caused the selected parameters (checkbox selections) to be cleared whenever the parent component re-rendered due to state changes.

This issue is demonstrated in [TD-3573](https://sce.myjetbrains.com/youtrack/issue/TD-3573/Parameter-Selection-Vanishes-when-Entering-Parameter-Set-Name), where changing the **Name** field or toggling the **Global Parameter Set** option results in the selection within the `TransferList` being reset. The root cause appears to be the `useLayoutEffect`, which was inadvertently clearing the internal checked state on each re-render.

> 🧠 @lukemojo @mattcorner — Is there any specific reason this hook was initially added? If so, I’m happy to revisit the solution.

## Dependencies

N / A

## UI/UX

N / A

## Testing notes

- Go to TransferList component
- Select some items and transfer to the another side of the list.

## Author checklist

Before I request a review:

- [x] I have reviewed my own code-diff.
- [ ] I have tested the changes in Docker / a deploy-preview.
- [x] I have assigned the PR to myself or an appropriate delegate.
- [x] I have added the relevant labels to the PR.
- [ ] I have included appropriate tests.
- [x] I have checked that the Lint and Test workflows pass on Github.
- [ ] I have populated the deploy-preview with relevant test data.
- [ ] I have tagged a UI/UX designer for review if this PR includes UI/UX changes.
